### PR TITLE
CAY-1841 Filters for Left-hand project navigator

### DIFF
--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/ProjectTreeModel.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/ProjectTreeModel.java
@@ -19,14 +19,6 @@
 
 package org.apache.cayenne.modeler;
 
-import java.util.Comparator;
-import java.util.Enumeration;
-import java.util.HashMap;
-
-import javax.swing.tree.DefaultMutableTreeNode;
-import javax.swing.tree.DefaultTreeModel;
-import javax.swing.tree.MutableTreeNode;
-
 import org.apache.cayenne.configuration.DataNodeDescriptor;
 import org.apache.cayenne.map.DataMap;
 import org.apache.cayenne.map.DbEntity;
@@ -35,6 +27,13 @@ import org.apache.cayenne.map.ObjEntity;
 import org.apache.cayenne.map.Procedure;
 import org.apache.cayenne.project.Project;
 import org.apache.cayenne.query.Query;
+
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.MutableTreeNode;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.HashMap;
 
 
 /**
@@ -119,7 +118,7 @@ public class ProjectTreeModel extends DefaultTreeModel {
             insertNodeInto(treeNode, parent, ins);
            }
            catch(NullPointerException e){
-        	   
+
            }
         }
     }
@@ -166,63 +165,52 @@ public class ProjectTreeModel extends DefaultTreeModel {
 
         return currentNode;
     }
-    
-    
+
+
     public void setFiltered(HashMap<String,Boolean> filterMap) {
-    	
     	filter.setFilterMap(filterMap);
-        Object[] path = {root};
-        int[] childIndices  = new int[root.getChildCount()];      
-        Object[] children  = new Object[root.getChildCount()];
-       
-        for (int i = 0; i < root.getChildCount(); i++) {
-        	childIndices[i] = i;
-        	children[i] = root.getChildAt(i);
-        }
-        
-        fireTreeStructureChanged(this,path,childIndices, children);	
     }
-    
-    
+
+
       public int getChildCount(Object parent) {
     	  int realCount = super.getChildCount(parent), filterCount =0;
-        
+
     	  for (int i=0; i<realCount; i++) {
     		  DefaultMutableTreeNode dmtn = (DefaultMutableTreeNode)super.getChild(parent,i);
-    		  if (filter.pass(dmtn)) { 
+    		  if (filter.pass(dmtn)) {
     			  filterCount++;
     		  }
     	  }
     	  return filterCount;
       }
-      
+
       public Object getChild(Object parent, int index) {
     	  int cnt=-1;
     	  for (int i=0; i<super.getChildCount(parent); i++) {
     		  Object child = super.getChild(parent,i);
-    		  if (filter.pass(child)) { 
+    		  if (filter.pass(child)) {
     			  cnt++;
     		  }
-    		  if (cnt==index) { 
+    		  if (cnt==index) {
     			  return child;
     		  }
     	  }
     	  return null;
       }
-      
+
       class Filter {
     	  private HashMap<String, Boolean> filterMap;
     	  boolean pass=true;
-		
+
     	  public void setFilterMap(HashMap<String, Boolean> filterMap) {
     		  this.filterMap=filterMap;
     		  pass=false;
     	  }
-    	  
-    	  public boolean pass(Object obj) { 
+
+    	  public boolean pass(Object obj) {
     		 Object root = ((DefaultMutableTreeNode) obj).getUserObject();
     		 Object firstLeaf = ((DefaultMutableTreeNode) obj).getFirstLeaf().getUserObject();
-    		 
+
     		 return ((pass) ||
     				 (root instanceof DataMap) ||
     				 (root instanceof DataNodeDescriptor) ||
@@ -232,9 +220,9 @@ public class ProjectTreeModel extends DefaultTreeModel {
     				 (firstLeaf instanceof Query      && filterMap.get("query"))      ||
     				 (firstLeaf instanceof Procedure  && filterMap.get("procedure")));
     	  }
-    	  
-    	  public boolean isFiltered() { 
-    		  return pass; 
+
+    	  public boolean isFiltered() {
+    		  return pass;
     	  }
-    	}   
+    	}
 }

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/datadomain/FilterDialog.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/datadomain/FilterDialog.java
@@ -149,7 +149,7 @@ public class FilterDialog extends JPopupMenu {
 				all.setEnabled(false);
 
                 filterController.getTreeModel().setFiltered(filterController.getFilterMap());
-                filterController.treeExpOrCollPath("expand");
+                filterController.getTree().updateUI();
             }
 		});
 	}
@@ -189,8 +189,8 @@ public class FilterDialog extends JPopupMenu {
 		public void actionPerformed(ActionEvent e) {
 			filterController.getFilterMap().put(key, ((JCheckBoxMenuItem)e.getSource()).isSelected());
 			filterController.getTreeModel().setFiltered(filterController.getFilterMap());
-			filterController.treeExpOrCollPath("expand");
-			checkAllStates();
+            filterController.getTree().updateUI();
+            checkAllStates();
 		}
 	}
 	

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/EditorView.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/EditorView.java
@@ -19,20 +19,6 @@
 
 package org.apache.cayenne.modeler.editor;
 
-import java.awt.BorderLayout;
-import java.awt.CardLayout;
-import java.awt.Component;
-import java.awt.Container;
-import java.awt.Dimension;
-
-import javax.swing.Action;
-import javax.swing.Box;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JSplitPane;
-import javax.swing.JTabbedPane;
-import javax.swing.JToolBar;
-
 import org.apache.cayenne.modeler.Application;
 import org.apache.cayenne.modeler.ProjectController;
 import org.apache.cayenne.modeler.ProjectTreeView;
@@ -67,6 +53,21 @@ import org.apache.cayenne.query.SQLTemplate;
 import org.apache.cayenne.query.SelectQuery;
 import org.apache.commons.logging.LogFactory;
 
+import javax.swing.Action;
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
+import javax.swing.JTabbedPane;
+import java.awt.BorderLayout;
+import java.awt.CardLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+
 /**
  * Main display area split into the project navigation tree on the left and selected
  * object editor on the right.
@@ -91,6 +92,7 @@ public class EditorView extends JPanel implements ObjEntityDisplayListener,
 
     protected ProjectController eventController;
     protected JSplitPane splitPane;
+    protected JPanel leftPanel;
     protected Container detailPanel;
     protected CardLayout detailLayout;
     private ProjectTreeView treePanel;
@@ -177,30 +179,30 @@ public class EditorView extends JPanel implements ObjEntityDisplayListener,
 	private void initView() {
 
         // init widgets
-        treePanel = new ProjectTreeView(eventController);            
-        JToolBar bar = new JToolBar();
-        
-        bar.setPreferredSize(new Dimension(100,30));
-        
-        bar.add(Box.createHorizontalGlue());
-        bar.add(getAction(CollapseTreeAction.class).buildButton());
-        bar.add(getAction(FilterAction.class).buildButton());
+        JButton collapseButton = getAction(CollapseTreeAction.class).buildButton();
+        collapseButton.setPreferredSize(new Dimension(35, 30));
+        JButton filterButton = getAction(FilterAction.class).buildButton();
+        filterButton.setPreferredSize(new Dimension(35, 30));
         actionManager.getAction(CollapseTreeAction.class).setAlwaysOn(true);
         actionManager.getAction(FilterAction.class).setAlwaysOn(true);
-        
-        JPanel treeNavigatePanel = new JPanel();      
-        treeNavigatePanel.setMinimumSize(new Dimension(50,200));
+
+        JPanel barPanel = new JPanel(true);
+        barPanel.setMinimumSize(new Dimension(75, 33));
+        barPanel.setLayout(new FlowLayout(FlowLayout.TRAILING, 1, 0));
+        barPanel.add(collapseButton);
+        barPanel.add(filterButton);
+        barPanel.setBorder(BorderFactory.createLineBorder(Color.gray));
+
+        treePanel = new ProjectTreeView(eventController);
+        treePanel.setMinimumSize(new Dimension(75, 180));
+        JPanel treeNavigatePanel = new JPanel();
+        treeNavigatePanel.setMinimumSize(new Dimension(75, 220));
         treeNavigatePanel.setLayout(new BorderLayout());
-        treeNavigatePanel.add(bar, BorderLayout.NORTH);       
         treeNavigatePanel.add(treePanel, BorderLayout.CENTER);
 
-        
-        
-        treePanel.setMinimumSize(new Dimension(50, 180));
-                 
         this.detailPanel = new JPanel();
         this.splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, true);
-
+        this.leftPanel = new JPanel(new BorderLayout());
         // assemble...
 
         this.detailLayout = new CardLayout();
@@ -247,7 +249,9 @@ public class EditorView extends JPanel implements ObjEntityDisplayListener,
         dbDetailView = new DbEntityTabbedView(eventController);
         detailPanel.add(dbDetailView, DB_VIEW);
 
-        splitPane.setLeftComponent(new JScrollPane(treeNavigatePanel));
+        leftPanel.add(barPanel, BorderLayout.NORTH);
+        leftPanel.add(new JScrollPane(treeNavigatePanel), BorderLayout.CENTER);
+        splitPane.setLeftComponent(leftPanel);
         splitPane.setRightComponent(detailPanel);
 
         setLayout(new BorderLayout());


### PR DESCRIPTION
This commit includes next fixes:
*Horizontal scroll (due to the long entity names) should not include the toolbar.
*When a tree is collapsed, and we check one of the previously excluded options, currently the tree is made to expand. I think it should stay collapsed.
