### PR TITLE
draft for a toManyTarget setter

### DIFF
--- a/cayenne-server/src/main/java/org/apache/cayenne/CayenneDataObject.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/CayenneDataObject.java
@@ -289,8 +289,9 @@ public class CayenneDataObject extends PersistentObject implements DataObject, V
      *            another object.
      * @param setReverse
      *            update reverse relationships
-     * @return non null <code>List&lt;? extends DataObject&gt;</code> whose
-     *            relationships were removed
+     * @return <code>List&lt;? extends DataObject&gt;</code> of unrelated
+     *            DataObjects. If no relationship was removed an empty List is
+     *            returned.
      * @throws NullPointerException
      *             if passed <code>Collection</code> is null. To clear all
      *             relationships use an empty <code>Collection</code>

--- a/cayenne-server/src/main/java/org/apache/cayenne/CayenneDataObject.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/CayenneDataObject.java
@@ -284,7 +284,7 @@ public class CayenneDataObject extends PersistentObject implements DataObject, V
      *            <code>DataObject</code> objects of this
      *            <code>Collection</code> are set to the object. No changes will
      *            be made to the the
-     *            <code>List&lt;? extends DataObject&gt;</code>, a copy is used.
+     *            <code>Collection</code>, a copy is used.
      *            It is safe to pass a persisted <code>Collection</code> of
      *            another object.
      * @param setReverse

--- a/cayenne-tools/src/main/resources/templates/v1_2/superclass.vm
+++ b/cayenne-tools/src/main/resources/templates/v1_2/superclass.vm
@@ -36,6 +36,7 @@ ${importUtils.setPackage($superPackageName)}##
 ${importUtils.addReservedType("${superPackageName}.${superClassName}")}##
 ${importUtils.addType("${basePackageName}.${baseClassName}")}##
 ${importUtils.addType('org.apache.cayenne.exp.Property')}##
+${importUtils.addType('java.util.Collection')}##
 #foreach( $attr in ${object.DeclaredAttributes} )
 $importUtils.addType(${attr.Type})##
 #end
@@ -125,6 +126,12 @@ public abstract class ${superClassName} extends ${baseClassName} {
     }
     public void removeFrom${stringUtils.capitalized($rel.Name)}($importUtils.formatJavaType(${rel.TargetEntity.ClassName}) obj) {
         removeToManyTarget("${rel.Name}", obj, true);
+    }
+    public void setTo${stringUtils.capitalized($rel.Name)}(Collection<$importUtils.formatJavaType(${rel.TargetEntity.ClassName})> obj) {
+        setToManyTarget("${rel.Name}", obj, true, false);
+    }
+    public void setTo${stringUtils.capitalized($rel.Name)}(Collection<$importUtils.formatJavaType(${rel.TargetEntity.ClassName})> obj, boolean delete) {
+        setToManyTarget("${rel.Name}", obj, true, delete);
     }
 #end
     @SuppressWarnings("unchecked")

--- a/cayenne-tools/src/main/resources/templates/v1_2/superclass.vm
+++ b/cayenne-tools/src/main/resources/templates/v1_2/superclass.vm
@@ -127,12 +127,6 @@ public abstract class ${superClassName} extends ${baseClassName} {
     public void removeFrom${stringUtils.capitalized($rel.Name)}($importUtils.formatJavaType(${rel.TargetEntity.ClassName}) obj) {
         removeToManyTarget("${rel.Name}", obj, true);
     }
-    public void setTo${stringUtils.capitalized($rel.Name)}(Collection<$importUtils.formatJavaType(${rel.TargetEntity.ClassName})> obj) {
-        setToManyTarget("${rel.Name}", obj, true, false);
-    }
-    public void setTo${stringUtils.capitalized($rel.Name)}(Collection<$importUtils.formatJavaType(${rel.TargetEntity.ClassName})> obj, boolean delete) {
-        setToManyTarget("${rel.Name}", obj, true, delete);
-    }
 #end
     @SuppressWarnings("unchecked")
 #if ( ${rel.CollectionType} == "java.util.Map")


### PR DESCRIPTION
Sadly I didn't get any feedback this time at [developer mailinglist](http://mail-archives.apache.org/mod_mbox/cayenne-dev/201412.mbox/%3C549F3BB6.4050708%40gmail.com%3E). But this shouldn't contain bug anyway.

This pull request serves a setter method for toManyTargets, which is located in the `CayenneDataObject` (thank Davids advice). Others and me desire such a functionality in the out-of-the-box class gernation, look at [user mailinglist](http://mail-archives.apache.org/mod_mbox/cayenne-user/201412.mbox/%3C548BDF97.1040104%40gmail.com%3E).

In difference to `addToManyTarget` and `removeFromManyTarget` this method takes a input `Collection<? extends DataObject>` and an optional `boolean` delete parameter (default is false) for deletion
of DataObjects, which relationships were removed.

The method documentation should be more comprehensible, what the method does and what not.

The `superclass.vm` generates two setter methods per toMany relationship where the relationName is part of the method name. The delete ommited method sets the deletion parameter to false and calls the other method.

I don't know, if it is a the best idea to serve a deletion parameter to prevent for orphaned DataObjects. Maybe there is a better solution.
I didn't implement yet any test classes. This has still to be done.

It would be happy if you would include my code into your project!
Thanks Johannes
