### PR TITLE
Resolved CAY-1812 - Add Next/Previous Buttons to DbRelationship/ObjRelationship Inspectors

### DIFF
--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/ResolveDbRelationshipDialogNextPrev.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/ResolveDbRelationshipDialogNextPrev.java
@@ -81,7 +81,7 @@ public class ResolveDbRelationshipDialogNextPrev extends CayenneDialog {
     protected JButton prevButton;
     protected JButton nextButton;
     protected JButton saveButton;
-    protected JButton cancelButton;
+    protected JButton closeButton;
     protected int row;
 
     private boolean cancelPressed;
@@ -133,10 +133,10 @@ public class ResolveDbRelationshipDialogNextPrev extends CayenneDialog {
         nextButton = new JButton("Next");
         nextButton.setEnabled(this.editable);
 
-        saveButton = new JButton("Done");
+        saveButton = new JButton("Save");
 
-        cancelButton = new JButton("Cancel");
-        cancelButton.setEnabled(this.editable);
+        closeButton = new JButton("Close");
+        closeButton.setEnabled(this.editable);
 
         table = new AttributeTable();
 
@@ -171,7 +171,7 @@ public class ResolveDbRelationshipDialogNextPrev extends CayenneDialog {
 
         getContentPane().add(builder.getPanel(), BorderLayout.CENTER);
         getContentPane().add(PanelFactory.createButtonPanel(new JButton[] {
-                prevButton, nextButton, saveButton, cancelButton
+                prevButton, nextButton, saveButton, closeButton
         }), BorderLayout.SOUTH);
     }
 
@@ -270,11 +270,10 @@ public class ResolveDbRelationshipDialogNextPrev extends CayenneDialog {
                     save();
                 }
 
-                dispose();
             }
         });
 
-        cancelButton.addActionListener(new ActionListener() {
+        closeButton.addActionListener(new ActionListener() {
 
             public void actionPerformed(ActionEvent e) {
                 cancelPressed = true;

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/ResolveDbRelationshipDialogNextPrev.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/ResolveDbRelationshipDialogNextPrev.java
@@ -285,11 +285,11 @@ public class ResolveDbRelationshipDialogNextPrev extends CayenneDialog {
 
             public void actionPerformed(ActionEvent e) {
             	if((row+1)<tableInit.getRowCount()){
-	            	setVisible(false);
-	            	table.select(row+1);
-	            	ResolveDbRelationshipDialogNextPrev dialog = new ResolveDbRelationshipDialogNextPrev(tableInit,row+1);
-	                dialog.setVisible(true);
-	                dialog.dispose();
+            		row = row+1;
+	            	table.select(row);
+	            	relationship = ((DbRelationshipTableModel)tableInit.getModel()).getRelationship(row);
+	            	undo = new RelationshipUndoableEdit(relationship);
+	            	initWithModel(relationship);
             	}
             	else{
             		JOptionPane.showMessageDialog(nextButton.getParent(), "This is the last relationship.");
@@ -301,11 +301,11 @@ public class ResolveDbRelationshipDialogNextPrev extends CayenneDialog {
 
             public void actionPerformed(ActionEvent e) {
             	if((row-1)>=0){
-            		setVisible(false);
-	            	table.select(row-1);
-	            	ResolveDbRelationshipDialogNextPrev dialog = new ResolveDbRelationshipDialogNextPrev(tableInit,row-1);
-	                dialog.setVisible(true);
-	                dialog.dispose();
+            		row = row-1;
+	            	table.select(row);
+            		relationship = ((DbRelationshipTableModel)tableInit.getModel()).getRelationship(row);
+            		undo = new RelationshipUndoableEdit(relationship);
+	            	initWithModel(relationship);
             	}
             	else{
             		JOptionPane.showMessageDialog(nextButton.getParent(), "This is the first relationship.");

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/ResolveDbRelationshipDialogNextPrev.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/ResolveDbRelationshipDialogNextPrev.java
@@ -1,0 +1,493 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.modeler.dialog;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextField;
+import javax.swing.ListSelectionModel;
+import javax.swing.table.TableColumn;
+
+import org.apache.cayenne.CayenneRuntimeException;
+import org.apache.cayenne.map.DbEntity;
+import org.apache.cayenne.map.DbJoin;
+import org.apache.cayenne.map.DbRelationship;
+import org.apache.cayenne.map.Entity;
+import org.apache.cayenne.map.Relationship;
+import org.apache.cayenne.map.event.MapEvent;
+import org.apache.cayenne.map.event.RelationshipEvent;
+import org.apache.cayenne.map.naming.DefaultUniqueNameGenerator;
+import org.apache.cayenne.map.naming.NameCheckers;
+import org.apache.cayenne.modeler.Application;
+import org.apache.cayenne.modeler.editor.dbentity.DbRelationshipTableModel;
+import org.apache.cayenne.modeler.pref.TableColumnPreferences;
+import org.apache.cayenne.modeler.undo.RelationshipUndoableEdit;
+import org.apache.cayenne.modeler.util.CayenneDialog;
+import org.apache.cayenne.modeler.util.CayenneTable;
+import org.apache.cayenne.modeler.util.ModelerUtil;
+import org.apache.cayenne.modeler.util.PanelFactory;
+import org.apache.cayenne.modeler.util.combo.AutoCompletion;
+import org.apache.cayenne.util.Util;
+
+import com.jgoodies.forms.builder.PanelBuilder;
+import com.jgoodies.forms.layout.CellConstraints;
+import com.jgoodies.forms.layout.FormLayout;
+
+/**
+ * Editor of DbRelationship joins.
+ */
+public class ResolveDbRelationshipDialogNextPrev extends CayenneDialog {
+
+    protected DbRelationship relationship;
+    protected DbRelationship reverseRelationship;
+
+    protected JTextField name;
+    protected JTextField reverseName;
+    protected CayenneTable table;
+    protected CayenneTable tableInit;
+    protected TableColumnPreferences tablePreferences;
+    protected JButton addButton;
+    protected JButton removeButton;
+    protected JButton prevButton;
+    protected JButton nextButton;
+    protected JButton saveButton;
+    protected JButton cancelButton;
+    protected int row;
+
+    private boolean cancelPressed;
+
+    private RelationshipUndoableEdit undo;
+
+    private boolean editable = true;
+
+    public ResolveDbRelationshipDialogNextPrev(CayenneTable table, int row) {
+        this(table, row, true);
+    }
+
+    public ResolveDbRelationshipDialogNextPrev(CayenneTable table, int row, boolean editable) {
+        super(Application.getFrame(), "", true);
+        this.editable = editable;
+        this.row = row;
+        this.tableInit = table;
+        this.relationship = ((DbRelationshipTableModel)tableInit.getModel()).getRelationship(row);
+      
+        initView();
+        initController();
+        initWithModel(relationship);
+
+        this.undo = new RelationshipUndoableEdit(relationship);
+
+        this.pack();
+        this.centerWindow();
+
+    }
+
+    /**
+     * Creates graphical components.
+     */
+    private void initView() {
+
+        // create widgets
+        name = new JTextField(25);
+        reverseName = new JTextField(25);
+
+        addButton = new JButton("Add");
+        addButton.setEnabled(this.editable);
+
+        removeButton = new JButton("Remove");
+        removeButton.setEnabled(this.editable);
+        
+        prevButton = new JButton("Previous");
+        prevButton.setEnabled(this.editable);
+        
+        nextButton = new JButton("Next");
+        nextButton.setEnabled(this.editable);
+
+        saveButton = new JButton("Done");
+
+        cancelButton = new JButton("Cancel");
+        cancelButton.setEnabled(this.editable);
+
+        table = new AttributeTable();
+
+        table.getSelectionModel().setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        tablePreferences = new TableColumnPreferences(getClass(), "dbentity/dbjoinTable");
+
+        // assemble
+        getContentPane().setLayout(new BorderLayout());
+
+        CellConstraints cc = new CellConstraints();
+        PanelBuilder builder = new PanelBuilder(
+                new FormLayout(
+                        "right:max(50dlu;pref), 3dlu, fill:min(150dlu;pref), 3dlu, fill:min(50dlu;pref)",
+                        "p, 3dlu, p, 3dlu, p, 9dlu, p, 3dlu, top:14dlu, 3dlu, top:p:grow"));
+        builder.setDefaultDialogBorder();
+
+        builder.addSeparator("DbRelationship Information", cc.xywh(1, 1, 5, 1));
+        builder.addLabel("Relationship:", cc.xy(1, 3));
+        builder.add(name, cc.xywh(3, 3, 1, 1));
+        builder.addLabel("Reverse Relationship", cc.xy(1, 5));
+        builder.add(reverseName, cc.xywh(3, 5, 1, 1));
+
+        builder.addSeparator("Joins", cc.xywh(1, 7, 5, 1));
+        builder.add(new JScrollPane(table), cc.xywh(1, 9, 3, 3, "fill, fill"));
+
+        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.LEADING));
+
+        buttons.add(addButton);
+        buttons.add(removeButton);
+        
+        builder.add(buttons, cc.xywh(5, 9, 1, 3));
+
+        getContentPane().add(builder.getPanel(), BorderLayout.CENTER);
+        getContentPane().add(PanelFactory.createButtonPanel(new JButton[] {
+                prevButton, nextButton, saveButton, cancelButton
+        }), BorderLayout.SOUTH);
+    }
+
+    private void initWithModel(DbRelationship aRelationship) {
+        // sanity check
+        if (aRelationship.getSourceEntity() == null) {
+            throw new CayenneRuntimeException("Null source entity: " + aRelationship);
+        }
+
+        if (aRelationship.getTargetEntity() == null) {
+            throw new CayenneRuntimeException("Null target entity: " + aRelationship);
+        }
+
+        if (aRelationship.getSourceEntity().getDataMap() == null) {
+            throw new CayenneRuntimeException("Null DataMap: "
+                    + aRelationship.getSourceEntity());
+        }
+
+        // Once assigned, can reference relationship directly. Would it be
+        // OK to assign relationship at the very top of this method?
+        relationship = aRelationship;
+        reverseRelationship = relationship.getReverseRelationship();
+
+        // init UI components
+        setTitle("DbRelationship Info: "
+                + relationship.getSourceEntity().getName()
+                + " to "
+                + relationship.getTargetEntityName());
+
+        table.setModel(new DbJoinTableModel(relationship, getMediator(), this, true));
+        TableColumn sourceColumn = table.getColumnModel().getColumn(
+                DbJoinTableModel.SOURCE);
+        JComboBox comboBox = Application.getWidgetFactory().createComboBox(
+                ModelerUtil.getDbAttributeNames(getMediator(), (DbEntity) relationship
+                        .getSourceEntity()),
+                true);
+
+        AutoCompletion.enable(comboBox);
+        sourceColumn.setCellEditor(Application.getWidgetFactory().createCellEditor(
+                comboBox));
+
+        TableColumn targetColumn = table.getColumnModel().getColumn(
+                DbJoinTableModel.TARGET);
+        comboBox = Application.getWidgetFactory().createComboBox(
+                ModelerUtil.getDbAttributeNames(getMediator(), (DbEntity) relationship
+                        .getTargetEntity()),
+                true);
+        AutoCompletion.enable(comboBox);
+
+        targetColumn.setCellEditor(Application.getWidgetFactory().createCellEditor(
+                comboBox));
+
+        if (reverseRelationship != null) {
+            reverseName.setText(reverseRelationship.getName());
+        }
+
+        name.setText(relationship.getName());
+        tablePreferences.bind(table, null, null, null, DbJoinTableModel.SOURCE, true);
+    }
+
+    private void initController() {
+        addButton.addActionListener(new ActionListener() {
+
+            public void actionPerformed(ActionEvent e) {
+                DbJoinTableModel model = (DbJoinTableModel) table.getModel();
+
+                DbJoin join = new DbJoin(relationship);
+                model.addRow(join);
+
+                undo.addDbJoinAddUndo(join);
+
+                table.select(model.getRowCount() - 1);
+            }
+        });
+
+        removeButton.addActionListener(new ActionListener() {
+
+            public void actionPerformed(ActionEvent e) {
+                DbJoinTableModel model = (DbJoinTableModel) table.getModel();
+                stopEditing();
+                int row = table.getSelectedRow();
+
+                DbJoin join = model.getJoin(row);
+                undo.addDbJoinRemoveUndo(join);
+
+                model.removeRow(join);
+            }
+        });
+
+        saveButton.addActionListener(new ActionListener() {
+
+            public void actionPerformed(ActionEvent e) {
+                cancelPressed = false;
+
+                if (editable) {
+                    save();
+                }
+
+                dispose();
+            }
+        });
+
+        cancelButton.addActionListener(new ActionListener() {
+
+            public void actionPerformed(ActionEvent e) {
+                cancelPressed = true;
+                setVisible(false);
+            }
+        });
+        
+        nextButton.addActionListener(new ActionListener() {
+
+            public void actionPerformed(ActionEvent e) {
+            	if((row+1)<tableInit.getRowCount()){
+	            	setVisible(false);
+	            	table.select(row+1);
+	            	ResolveDbRelationshipDialogNextPrev dialog = new ResolveDbRelationshipDialogNextPrev(tableInit,row+1);
+	                dialog.setVisible(true);
+	                dialog.dispose();
+            	}
+            	else{
+            		JOptionPane.showMessageDialog(nextButton.getParent(), "This is the last relationship.");
+            	}
+            }
+        });
+        
+        prevButton.addActionListener(new ActionListener() {
+
+            public void actionPerformed(ActionEvent e) {
+            	if((row-1)>=0){
+            		setVisible(false);
+	            	table.select(row-1);
+	            	ResolveDbRelationshipDialogNextPrev dialog = new ResolveDbRelationshipDialogNextPrev(tableInit,row-1);
+	                dialog.setVisible(true);
+	                dialog.dispose();
+            	}
+            	else{
+            		JOptionPane.showMessageDialog(nextButton.getParent(), "This is the first relationship.");
+            	}
+            }
+        });
+    }
+
+    public boolean isCancelPressed() {
+        return cancelPressed;
+    }
+
+    private void stopEditing() {
+        // Stop whatever editing may be taking place
+        int col_index = table.getEditingColumn();
+        if (col_index >= 0) {
+            TableColumn col = table.getColumnModel().getColumn(col_index);
+            col.getCellEditor().stopCellEditing();
+        }
+    }
+
+    private void save() {
+        stopEditing();
+
+        // extract names...
+        String sourceEntityName = name.getText();
+        if (sourceEntityName.length() == 0) {
+            sourceEntityName = null;
+        }
+
+        if (sourceEntityName == null) {
+            sourceEntityName = DefaultUniqueNameGenerator.generate(NameCheckers.dbRelationship, relationship.getSourceEntity());
+        }
+
+        if (!validateName(relationship.getSourceEntity(), relationship, sourceEntityName)) {
+            return;
+        }
+
+        String targetEntityName = reverseName.getText().trim();
+        if (targetEntityName.length() == 0) {
+            targetEntityName = null;
+        }
+
+        if (targetEntityName == null) {
+            targetEntityName = DefaultUniqueNameGenerator.generate(NameCheckers.dbRelationship, relationship.getTargetEntity());
+        }
+
+        // check if reverse name is valid
+        DbJoinTableModel model = (DbJoinTableModel) table.getModel();
+        boolean updatingReverse = model.getObjectList().size() > 0;
+
+        if (updatingReverse
+                && !validateName(
+                        relationship.getTargetEntity(),
+                        reverseRelationship,
+                        targetEntityName)) {
+            return;
+        }
+
+        // handle name update
+        if (!Util.nullSafeEquals(sourceEntityName, relationship.getName())) {
+            String oldName = relationship.getName();
+            
+            relationship.setName(sourceEntityName);
+
+            undo.addNameUndo(relationship, oldName, sourceEntityName);
+
+            getMediator().fireDbRelationshipEvent(
+                    new RelationshipEvent(this, relationship, relationship
+                            .getSourceEntity(), oldName));
+        }
+
+        model.commit();
+
+        // check "to dep pk" setting,
+        // maybe this is no longer valid
+        if (relationship.isToDependentPK() && !relationship.isValidForDepPk()) {
+            relationship.setToDependentPK(false);
+        }
+
+        // If new reverse DbRelationship was created, add it to the target
+        // Don't create reverse with no joins - makes no sense...
+        if (updatingReverse) {
+
+            // If didn't find anything, create reverseDbRel
+            if (reverseRelationship == null) {
+                reverseRelationship = new DbRelationship(targetEntityName);
+                reverseRelationship.setSourceEntity(relationship.getTargetEntity());
+                reverseRelationship.setTargetEntityName(relationship.getSourceEntity());
+                reverseRelationship.setToMany(!relationship.isToMany());
+                relationship.getTargetEntity().addRelationship(reverseRelationship);
+
+                // fire only if the relationship is to the same entity...
+                // this is needed to update entity view...
+                if (relationship.getSourceEntity() == relationship.getTargetEntity()) {
+                    getMediator().fireDbRelationshipEvent(
+                            new RelationshipEvent(
+                                    this,
+                                    reverseRelationship,
+                                    reverseRelationship.getSourceEntity(),
+                                    MapEvent.ADD));
+                }
+            }
+            else if (!Util
+                    .nullSafeEquals(targetEntityName, reverseRelationship.getName())) {
+
+                String oldName = reverseRelationship.getName();
+                
+                reverseRelationship.setName(targetEntityName);
+
+                undo.addNameUndo(reverseRelationship, oldName, targetEntityName);
+
+                getMediator().fireDbRelationshipEvent(
+                        new RelationshipEvent(
+                                this,
+                                reverseRelationship,
+                                reverseRelationship.getSourceEntity(),
+                                oldName));
+            }
+
+            Collection reverseJoins = getReverseJoins();
+            reverseRelationship.setJoins(reverseJoins);
+
+            // check if joins map to a primary key of this entity
+            if (!relationship.isToDependentPK() && reverseRelationship.isValidForDepPk()) {
+                reverseRelationship.setToDependentPK(true);
+            }
+        }
+
+        Application.getInstance().getUndoManager().addEdit(undo);
+
+        getMediator()
+                .fireDbRelationshipEvent(
+                        new RelationshipEvent(this, relationship, relationship
+                                .getSourceEntity()));
+    }
+
+    private boolean validateName(Entity entity, Relationship aRelationship, String newName) {
+        Relationship existing = entity.getRelationship(newName);
+        if (existing != null && (aRelationship == null || aRelationship != existing)) {
+            JOptionPane.showMessageDialog(
+                    this,
+                    "There is an existing relationship named \""
+                            + newName
+                            + "\". Select a different name.");
+            return false;
+        }
+
+        return true;
+    }
+
+    private Collection getReverseJoins() {
+        Collection<DbJoin> joins = relationship.getJoins();
+
+        if ((joins == null) || (joins.size() == 0)) {
+            return Collections.EMPTY_LIST;
+        }
+
+        List reverseJoins = new ArrayList(joins.size());
+
+        // Loop through the list of attribute pairs, create reverse pairs
+        // and put them to the reverse list.
+        for (DbJoin pair : joins) {
+            DbJoin reverseJoin = pair.createReverseJoin();
+
+            // since reverse relationship is not yet initialized,
+            // reverse join will not have it set automatically
+            reverseJoin.setRelationship(reverseRelationship);
+            reverseJoins.add(reverseJoin);
+        }
+
+        return reverseJoins;
+    }
+
+    final class AttributeTable extends CayenneTable {
+
+        final Dimension preferredSize = new Dimension(203, 100);
+
+        @Override
+        public Dimension getPreferredScrollableViewportSize() {
+            return preferredSize;
+        }
+    }
+}

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/objentity/ObjRelationshipInfo.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/objentity/ObjRelationshipInfo.java
@@ -201,6 +201,54 @@ public class ObjRelationshipInfo extends CayenneController implements TreeSelect
             }
         });
     }
+    
+    private void updateVariables(ObjRelationship relationship, int row){
+    	this.relationship = relationship;
+    	this.row = row;
+    	ObjEntity target = getObjectTarget();
+        getPathBrowser().addTreeSelectionListener(this);
+        setObjectTarget(target);
+        view.sourceEntityLabel.setText(relationship.getSourceEntity().getName());
+        this.relationshipName = relationship.getName();
+        view.relationshipName.setText(relationshipName);
+        this.mapKey = relationship.getMapKey();
+        this.targetCollection = relationship.getCollectionType();
+        if (targetCollection == null) {
+            targetCollection = ObjRelationship.DEFAULT_COLLECTION_TYPE;
+        }
+
+        this.objectTarget = (ObjEntity) relationship.getTargetEntity();
+        if (objectTarget != null) {
+            updateTargetCombo(objectTarget.getDbEntity());
+        }
+
+        // validate -
+        // current limitation is that an ObjRelationship must have source
+        // and target entities present, with DbEntities chosen.
+        validateCanMap();
+
+        this.targetCollections = new ArrayList<String>(4);
+        targetCollections.add(COLLECTION_TYPE_COLLECTION);
+        targetCollections.add(ObjRelationship.DEFAULT_COLLECTION_TYPE);
+        targetCollections.add(COLLECTION_TYPE_MAP);
+        targetCollections.add(COLLECTION_TYPE_SET);
+
+        for (String s : targetCollections) {
+            view.collectionTypeCombo.addItem(s);
+        }
+
+        this.mapKeys = new ArrayList<String>();
+        initMapKeys();
+
+        // setup path
+        dbRelationships = new ArrayList<DbRelationship>(relationship.getDbRelationships());
+        selectPath();
+        updateCollectionChoosers();
+
+        // add dummy last relationship if we are not connected
+        connectEnds();
+        initFromModel();
+    }
 
     void initFromModel() {
 
@@ -236,9 +284,8 @@ public class ObjRelationshipInfo extends CayenneController implements TreeSelect
 
     void takeNextRelationship(){
     	if((row+1)<table.getRowCount()){
-    		view.dispose();
         	table.select(row+1);
-        	new ObjRelationshipInfo(mediator, table, row+1).startupAction();
+        	updateVariables(((ObjRelationshipTableModel)table.getModel()).getRelationship(row+1),row+1);
     	}
     	else{
     		JOptionPane.showMessageDialog(view, "This is the last relationship.");
@@ -248,9 +295,8 @@ public class ObjRelationshipInfo extends CayenneController implements TreeSelect
     
     void takePrevRelationship(){
     	if((row-1)>=0){
-    		view.dispose();
         	table.select(row-1);
-        	new ObjRelationshipInfo(mediator, table, row-1).startupAction();
+        	updateVariables(((ObjRelationshipTableModel)table.getModel()).getRelationship(row-1),row-1);
     	}
     	else{
     		JOptionPane.showMessageDialog(view, "This is the first relationship.");

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/objentity/ObjRelationshipInfoView.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/objentity/ObjRelationshipInfoView.java
@@ -54,6 +54,8 @@ public class ObjRelationshipInfoView extends JDialog{
 
     protected JButton saveButton;
     protected JButton cancelButton;
+    protected JButton nextButton;
+    protected JButton prevButton;
     protected JButton newRelButton;
     protected JButton selectPathButton;
     
@@ -70,8 +72,10 @@ public class ObjRelationshipInfoView extends JDialog{
         
         this.widgetFactory = new DefaultWidgetFactory();
         
-        this.cancelButton = new JButton("Cancel");
-        this.saveButton = new JButton("Done");
+        this.cancelButton = new JButton("Close");
+        this.saveButton = new JButton("Save");
+        this.prevButton = new JButton("Previous");
+        this.nextButton = new JButton("Next");
         this.newRelButton = new JButton("New DbRelationship");
         this.selectPathButton = new JButton("Select Path");
         this.relationshipName= new JTextField(25);
@@ -133,7 +137,7 @@ public class ObjRelationshipInfoView extends JDialog{
 
         add(builder.getPanel(), BorderLayout.CENTER);
         add(PanelFactory.createButtonPanel(new JButton[] {
-                saveButton, cancelButton
+                prevButton, nextButton, saveButton, cancelButton
             }), BorderLayout.SOUTH);        
     }
 
@@ -145,6 +149,16 @@ public class ObjRelationshipInfoView extends JDialog{
     public JButton getCancelButton()
     {
         return cancelButton;
+    }
+    
+    public JButton getPrevButton()
+    {
+        return prevButton;
+    }
+    
+    public JButton getNextButton()
+    {
+        return nextButton;
     }
     
     public JButton getNewRelButton()

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/ObjEntityRelationshipPanel.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/ObjEntityRelationshipPanel.java
@@ -153,7 +153,7 @@ public class ObjEntityRelationshipPanel extends JPanel implements ObjEntityDispl
 
                 ObjRelationshipTableModel model = (ObjRelationshipTableModel) table
                         .getModel();
-                new ObjRelationshipInfo(mediator, model.getRelationship(row)).startupAction();
+                new ObjRelationshipInfo(mediator, table, row).startupAction();
 
                 /**
                  * This is required for a table to be updated properly

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/dbentity/DbEntityRelationshipPanel.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/dbentity/DbEntityRelationshipPanel.java
@@ -34,6 +34,7 @@ import org.apache.cayenne.modeler.action.CutAttributeRelationshipAction;
 import org.apache.cayenne.modeler.action.PasteAction;
 import org.apache.cayenne.modeler.action.RemoveAttributeRelationshipAction;
 import org.apache.cayenne.modeler.dialog.ResolveDbRelationshipDialog;
+import org.apache.cayenne.modeler.dialog.ResolveDbRelationshipDialogNextPrev;
 import org.apache.cayenne.modeler.event.DbEntityDisplayListener;
 import org.apache.cayenne.modeler.event.EntityDisplayEvent;
 import org.apache.cayenne.modeler.event.TablePopupHandler;
@@ -139,10 +140,7 @@ public class DbEntityRelationshipPanel extends JPanel implements DbEntityDisplay
                     return;
                 }
 
-                // Get DbRelationship
-                DbRelationshipTableModel model = (DbRelationshipTableModel) table.getModel();
-                DbRelationship rel = model.getRelationship(row);
-                ResolveDbRelationshipDialog dialog = new ResolveDbRelationshipDialog(rel);
+                ResolveDbRelationshipDialogNextPrev dialog = new ResolveDbRelationshipDialogNextPrev(table, row);
                 dialog.setVisible(true);
                 dialog.dispose();
             }


### PR DESCRIPTION
Proper buttons were added in Inspectors, and other buttons near them changed their names and function a bit to make this dialog comfortable to use. Done button was changed into Save button, which only applies changes, but doesn't close the dialog. Cancel button was changed to Close button, which does the same thing, but the meaning of using it is a little diffrent.