### PR TITLE
Fix BeanAccessors for Classes with Complex Inheritance

### DIFF
--- a/cayenne-server/src/test/java/org/apache/cayenne/reflect/BeanAccessorTest.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/reflect/BeanAccessorTest.java
@@ -81,4 +81,20 @@ public class BeanAccessorTest {
         assertEquals("Incorrectly set null default", 0, o1.getIntField());
     }
 
+    @Test
+    public void testInheritedCovariantProperty() {
+
+    	BeanAccessor accessor = new BeanAccessor(
+    			TstJavaBeanChild.class,
+    			"related",
+    			null);
+
+    	TstJavaBeanChild o1 = new TstJavaBeanChild();
+
+    	assertNull(o1.getRelated());
+    	accessor.setValue(o1, o1);
+    	assertSame(o1, o1.getRelated());
+    	assertSame(o1, accessor.getValue(o1));
+    }
+
 }

--- a/cayenne-server/src/test/java/org/apache/cayenne/reflect/TstHasRelated.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/reflect/TstHasRelated.java
@@ -1,0 +1,24 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.reflect;
+
+public interface TstHasRelated {
+	Object getRelated();
+}

--- a/cayenne-server/src/test/java/org/apache/cayenne/reflect/TstJavaBeanChild.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/reflect/TstJavaBeanChild.java
@@ -1,0 +1,24 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.reflect;
+
+public class TstJavaBeanChild extends TstJavaBean implements TstHasRelated {
+
+}


### PR DESCRIPTION
In certain cases, simply adding an interface to a class with no other changes can break `PropertyUtils.setProperty`.

For example, consider a HasName interface and a Person entity with a name attribute:
```java
public interface HasName {
    CharSequence getName();
}
```
```java
public class _Person extends CayenneDataObject {
    public void setName(String name) {
        writeProperty(NAME_KEY, name);
    }
    public String getName() {
        return (String) readProperty(NAME_KEY);
    }
}
```
```java
public class Person extends _Person implements HasName {
}
```

My only change from the generated classes is to make `Person` implement `HasName`. Now, when I call `PropertyUtils.setProperty(person, Person.NAME_KEY, newName)`, I get a `PropertyException: Property "name" is not writable`.

What's happening is that the compiler is generating a synthetic, no-arg method in Person.class named "getName" that returns a CharSequence. Since that's the only no-arg method named "getName" in the class, that's the method returned by `Class.getMethod`. (It finds a method in the class and so never checks the super class, per the documentation.) When BeanAccessor looks for the write method, it looks for `setName(CharSequence)` instead of `setName(String)` and comes up empty.

My change is to iterate through the public methods manually and return the read method with the most specific return type, then find a write method that's compatible with it.