### PR TITLE
Cayenne-crypto: support for mapping non-String and non-binary types

### DIFF
--- a/cayenne-crypto/src/main/java/org/apache/cayenne/crypto/transformer/value/DefaultValueTransformerFactory.java
+++ b/cayenne-crypto/src/main/java/org/apache/cayenne/crypto/transformer/value/DefaultValueTransformerFactory.java
@@ -144,6 +144,12 @@ public class DefaultValueTransformerFactory implements ValueTransformerFactory {
         map.put("byte[]", BytesToBytesConverter.INSTANCE);
         map.put(String.class.getName(), Utf8StringConverter.INSTANCE);
 
+        map.put(Double.class.getName(), DoubleConverter.INSTANCE);
+        map.put(Double.TYPE.getName(), DoubleConverter.INSTANCE);
+
+        map.put(Float.class.getName(), FloatConverter.INSTANCE);
+        map.put(Float.TYPE.getName(), FloatConverter.INSTANCE);
+
         map.put(Long.class.getName(), LongConverter.INSTANCE);
         map.put(Long.TYPE.getName(), LongConverter.INSTANCE);
 

--- a/cayenne-crypto/src/main/java/org/apache/cayenne/crypto/transformer/value/DoubleConverter.java
+++ b/cayenne-crypto/src/main/java/org/apache/cayenne/crypto/transformer/value/DoubleConverter.java
@@ -1,0 +1,35 @@
+package org.apache.cayenne.crypto.transformer.value;
+
+/**
+ * Converts between double and byte[]
+ *
+ * @since 4.0
+ */
+public class DoubleConverter implements BytesConverter<Double> {
+
+    public static final BytesConverter<Double> INSTANCE = new DoubleConverter();
+    private static final int BYTES = 8;
+
+    static double getDouble(byte[] bytes) {
+
+        if (bytes.length > BYTES) {
+            throw new IllegalArgumentException("byte[] is too large for a single double value: " + bytes.length);
+        }
+
+        return Double.longBitsToDouble(LongConverter.getLong(bytes));
+    }
+
+    static byte[] getBytes(Double d) {
+        return LongConverter.getBytes(Double.doubleToLongBits(d));
+    }
+
+    @Override
+    public Double fromBytes(byte[] bytes) {
+        return getDouble(bytes);
+    }
+
+    @Override
+    public byte[] toBytes(Double value) {
+        return getBytes(value);
+    }
+}

--- a/cayenne-crypto/src/main/java/org/apache/cayenne/crypto/transformer/value/FloatConverter.java
+++ b/cayenne-crypto/src/main/java/org/apache/cayenne/crypto/transformer/value/FloatConverter.java
@@ -1,0 +1,35 @@
+package org.apache.cayenne.crypto.transformer.value;
+
+/**
+ * Converts between float and byte[]
+ *
+ * @since 4.0
+ */
+public class FloatConverter implements BytesConverter<Float> {
+
+    public static final BytesConverter<Float> INSTANCE = new FloatConverter();
+    private static final int BYTES = 4;
+
+    static float getFloat(byte[] bytes) {
+
+        if (bytes.length > BYTES) {
+            throw new IllegalArgumentException("byte[] is too large for a single float value: " + bytes.length);
+        }
+
+        return Float.intBitsToFloat(IntegerConverter.getInt(bytes));
+    }
+
+    static byte[] getBytes(float f) {
+        return IntegerConverter.getBytes(Float.floatToRawIntBits(f));
+    }
+
+    @Override
+    public Float fromBytes(byte[] bytes) {
+        return getFloat(bytes);
+    }
+
+    @Override
+    public byte[] toBytes(Float value) {
+        return getBytes(value);
+    }
+}

--- a/cayenne-crypto/src/main/java/org/apache/cayenne/crypto/transformer/value/IntegerConverter.java
+++ b/cayenne-crypto/src/main/java/org/apache/cayenne/crypto/transformer/value/IntegerConverter.java
@@ -42,7 +42,7 @@ public class IntegerConverter implements BytesConverter<Integer> {
 
     static byte[] getBytes(int k) {
 
-        if (k <= Short.MAX_VALUE) {
+        if (k >= Short.MIN_VALUE && k <= Short.MAX_VALUE) {
             return ShortConverter.getBytes((short) k);
         }
 

--- a/cayenne-crypto/src/main/java/org/apache/cayenne/crypto/transformer/value/LongConverter.java
+++ b/cayenne-crypto/src/main/java/org/apache/cayenne/crypto/transformer/value/LongConverter.java
@@ -49,7 +49,7 @@ public class LongConverter implements BytesConverter<Long> {
 
     static byte[] getBytes(long k) {
 
-        if (k <= Integer.MAX_VALUE) {
+        if (k >= Integer.MIN_VALUE && k <= Integer.MAX_VALUE) {
             return IntegerConverter.getBytes((int) k);
         }
 

--- a/cayenne-crypto/src/main/java/org/apache/cayenne/crypto/transformer/value/ShortConverter.java
+++ b/cayenne-crypto/src/main/java/org/apache/cayenne/crypto/transformer/value/ShortConverter.java
@@ -41,7 +41,7 @@ public class ShortConverter implements BytesConverter<Short> {
 
     static byte[] getBytes(short k) {
 
-        if (k <= Byte.MAX_VALUE) {
+        if (k >= Byte.MIN_VALUE && k <= Byte.MAX_VALUE) {
             return ByteConverter.getBytes((byte) k);
         }
 

--- a/cayenne-crypto/src/test/java/org/apache/cayenne/crypto/transformer/value/DoubleConverterTest.java
+++ b/cayenne-crypto/src/test/java/org/apache/cayenne/crypto/transformer/value/DoubleConverterTest.java
@@ -1,0 +1,43 @@
+package org.apache.cayenne.crypto.transformer.value;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DoubleConverterTest {
+
+    @Test
+    public void testConverter() {
+        Double originalValue = 36.6d;
+        DoubleConverter converter = new DoubleConverter();
+        assertEquals(originalValue, converter.fromBytes(converter.toBytes(originalValue)));
+    }
+
+    @Test
+    public void testConverter_Negative() {
+        Double originalValue = -36.6d;
+        DoubleConverter converter = new DoubleConverter();
+        assertEquals(originalValue, converter.fromBytes(converter.toBytes(originalValue)));
+    }
+
+    @Test
+    public void testConverter_MaxValue() {
+        Double originalValue = Double.MAX_VALUE;
+        DoubleConverter converter = new DoubleConverter();
+        assertEquals(originalValue, converter.fromBytes(converter.toBytes(originalValue)));
+    }
+
+    @Test
+    public void testConverter_MinValue() {
+        Double originalValue = Double.MIN_VALUE;
+        DoubleConverter converter = new DoubleConverter();
+        assertEquals(originalValue, converter.fromBytes(converter.toBytes(originalValue)));
+    }
+
+    @Test
+    public void testConverter_Zero() {
+        Double originalValue = 0d;
+        DoubleConverter converter = new DoubleConverter();
+        assertEquals(originalValue, converter.fromBytes(converter.toBytes(originalValue)));
+    }
+}

--- a/cayenne-crypto/src/test/java/org/apache/cayenne/crypto/transformer/value/FloatConverterTest.java
+++ b/cayenne-crypto/src/test/java/org/apache/cayenne/crypto/transformer/value/FloatConverterTest.java
@@ -1,0 +1,43 @@
+package org.apache.cayenne.crypto.transformer.value;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class FloatConverterTest {
+
+    @Test
+    public void testConverter() {
+        Float originalValue = 36.6f;
+        FloatConverter converter = new FloatConverter();
+        assertEquals(originalValue, converter.fromBytes(converter.toBytes(originalValue)));
+    }
+
+    @Test
+    public void testConverter_Negative() {
+        Float originalValue = -36.6f;
+        FloatConverter converter = new FloatConverter();
+        assertEquals(originalValue, converter.fromBytes(converter.toBytes(originalValue)));
+    }
+
+    @Test
+    public void testConverter_MaxValue() {
+        Float originalValue = Float.MAX_VALUE;
+        FloatConverter converter = new FloatConverter();
+        assertEquals(originalValue, converter.fromBytes(converter.toBytes(originalValue)));
+    }
+
+    @Test
+    public void testConverter_MinValue() {
+        Float originalValue = Float.MIN_VALUE;
+        FloatConverter converter = new FloatConverter();
+        assertEquals(originalValue, converter.fromBytes(converter.toBytes(originalValue)));
+    }
+
+    @Test
+    public void testConverter_Zero() {
+        Float originalValue = 0f;
+        FloatConverter converter = new FloatConverter();
+        assertEquals(originalValue, converter.fromBytes(converter.toBytes(originalValue)));
+    }
+}


### PR DESCRIPTION
Includes float and double converters + fix for numeric overflow in short, integer and long converters