### PR TITLE
Add new Maven profile postgres-docker

### DIFF
--- a/cayenne-client/pom.xml
+++ b/cayenne-client/pom.xml
@@ -109,6 +109,39 @@
 
     <profiles>
         <profile>
+            <id>postgres-docker</id>
+            <activation>
+                <property>
+                    <name>cayenneTestConnection</name>
+                    <value>postgres-docker</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>start-postgres</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>start</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>stop-postgres</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>code-quality</id>
 
             <activation>

--- a/cayenne-server/pom.xml
+++ b/cayenne-server/pom.xml
@@ -259,6 +259,39 @@
 
     <profiles>
         <profile>
+            <id>postgres-docker</id>
+            <activation>
+                <property>
+                    <name>cayenneTestConnection</name>
+                    <value>postgres-docker</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>start-postgres</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>start</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>stop-postgres</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>code-quality</id>
 
             <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -841,6 +841,11 @@
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>2.4</version>
                 </plugin>
+                <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>0.15.6</version>
+                </plugin>
             </plugins>
 		</pluginManagement>
 
@@ -1345,6 +1350,67 @@
 					<scope>test</scope>
 				</dependency>
 			</dependencies>
+		</profile>
+		<profile>
+			<id>postgres-docker</id>
+			<activation>
+				<property>
+					<name>cayenneTestConnection</name>
+					<value>postgres-docker</value>
+				</property>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>org.postgresql</groupId>
+					<artifactId>postgresql</artifactId>
+					<version>9.4.1209</version>
+					<scope>test</scope>
+				</dependency>
+			</dependencies>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-failsafe-plugin</artifactId>
+						<configuration>
+							<systemPropertyVariables>
+								<!-- Default user, password, and DB name is "postgres", see https://hub.docker.com/_/postgres/ -->
+								<!-- ${db.host} and ${db.port} are dynamically set by docker-maven-plugin below -->
+								<cayenneAdapter>org.apache.cayenne.dba.postgres.PostgresAdapter</cayenneAdapter>
+								<cayenneJdbcUsername>postgres</cayenneJdbcUsername>
+								<cayenneJdbcPassword>postgres</cayenneJdbcPassword>
+								<cayenneJdbcUrl>jdbc:postgresql://${db.host}:${db.port}/postgres</cayenneJdbcUrl>
+								<cayenneJdbcDriver>org.postgresql.Driver</cayenneJdbcDriver>
+							</systemPropertyVariables>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>io.fabric8</groupId>
+						<artifactId>docker-maven-plugin</artifactId>
+						<configuration>
+							<images>
+								<image>
+									<alias>db</alias>
+									<name>postgres:9.5</name>
+									<run>
+										<ports>
+											<port>${db.host}:${db.port}:5432</port>
+										</ports>
+										<wait>
+											<tcp>
+												<ports>
+													<port>5432</port>
+												</ports>
+											</tcp>
+											<time>30000</time>
+										</wait>
+									</run>
+								</image>
+							</images>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
 		</profile>
 		<profile>
 			<id>derby</id>


### PR DESCRIPTION
- Useful to run integration tests without installed Postgres DB
- Activation with `-DcayenneTestConnection=postgres-docker`
- Starts Postgres Docker container before integration test and stops if afterwards
- Sets JDBC connection properties based on dynamic Docker container port allocation
