### PR TITLE
CAY-2148 Failure upgrading from 3.1 to M4

### DIFF
--- a/cayenne-project/src/main/java/org/apache/cayenne/project/upgrade/v8/UpgradeHandler_V8.java
+++ b/cayenne-project/src/main/java/org/apache/cayenne/project/upgrade/v8/UpgradeHandler_V8.java
@@ -113,6 +113,9 @@ public class UpgradeHandler_V8 extends BaseUpgradeHandler {
                 for (int j = 0; j < queryNodes.getLength(); j++) {
                     Element queryElement = (Element) queryNodes.item(j);
                     String factory = queryElement.getAttribute("factory");
+                    if(factory == null || factory.isEmpty()) {
+                        continue;
+                    }
 
                     String queryType;
 

--- a/cayenne-server/src/main/java/org/apache/cayenne/map/MapLoader.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/map/MapLoader.java
@@ -1029,8 +1029,12 @@ public class MapLoader extends DefaultHandler {
 		this.queryBuilder = new QueryDescriptorLoader();
 
 		String type = attributes.getValue("", "type");
-
-		queryBuilder.setQueryType(type);
+		// Legacy format support (v7 and older)
+		if(type == null) {
+			queryBuilder.setLegacyFactory(attributes.getValue("", "factory"));
+		} else {
+			queryBuilder.setQueryType(type);
+		}
 
 		String rootType = attributes.getValue("", "root");
 		String rootName = attributes.getValue("", "root-name");

--- a/cayenne-server/src/main/java/org/apache/cayenne/map/QueryDescriptorLoader.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/map/QueryDescriptorLoader.java
@@ -19,6 +19,7 @@
 package org.apache.cayenne.map;
 
 import org.apache.cayenne.CayenneRuntimeException;
+import org.apache.cayenne.ConfigurationException;
 import org.apache.cayenne.exp.Expression;
 import org.apache.cayenne.query.*;
 
@@ -87,6 +88,31 @@ public class QueryDescriptorLoader {
 
     void setName(String name) {
         this.name = name;
+    }
+
+    /**
+     * It's better be handled by project upgrade handler and actually it is.
+     * But upgrade logic is faulty when project is several versions away
+     * and can't be changed without complete upgrade system rewrite
+     * @param factory old style query factory class
+     */
+    void setLegacyFactory(String factory) {
+        switch (factory) {
+            case "org.apache.cayenne.map.SelectQueryBuilder":
+                queryType = QueryDescriptor.SELECT_QUERY;
+                break;
+            case "org.apache.cayenne.map.SQLTemplateBuilder":
+                queryType = QueryDescriptor.SQL_TEMPLATE;
+                break;
+            case "org.apache.cayenne.map.EjbqlBuilder":
+                queryType = QueryDescriptor.EJBQL_QUERY;
+                break;
+            case "org.apache.cayenne.map.ProcedureQueryBuilder":
+                queryType = QueryDescriptor.PROCEDURE_QUERY;
+                break;
+            default:
+                throw new ConfigurationException("Unknown query factory: " + factory);
+        }
     }
 
     void setQueryType(String queryType) {

--- a/docs/doc/src/main/resources/RELEASE-NOTES.txt
+++ b/docs/doc/src/main/resources/RELEASE-NOTES.txt
@@ -69,6 +69,7 @@ CAY-2131 Modeler NullPointerException in reverse engineering when importing diff
 CAY-2138 NVARCHAR, LONGNVARCHAR and NCLOB types are missing from Firebird types.xml
 CAY-2143 NPE in BaseSchemaUpdateStrategy
 CAY-2144 cdbimport always fails for databases which don't support catalogs
+CAY-2148 Failure upgrading from 3.1 to M4
 
 ----------------------------------
 Release: 4.0.M3


### PR DESCRIPTION
Fix notes: this is a hot-fix for exact problem converting queries from v6 directly to v9 format.
Actually whole upgrade system should be redesigned, see some thoughts at https://issues.apache.org/jira/browse/CAY-2152