### PR TITLE
CAY-2153 Modeler. Exception in save action after reverse engineering some complex DB schema

### DIFF
--- a/cayenne-server/src/main/java/org/apache/cayenne/map/ObjAttribute.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/map/ObjAttribute.java
@@ -114,8 +114,8 @@ public class ObjAttribute extends Attribute implements ConfigurationNode {
         }
 
         // If this obj attribute is mapped to db attribute
-        if (getDbAttribute() != null
-                || (((ObjEntity) getEntity()).isAbstract() && !Util.isEmptyString(getDbAttributePath()))) {
+        if (/*getDbAttribute() != null
+                || (((ObjEntity) getEntity()).isAbstract() && */!Util.isEmptyString(getDbAttributePath())) {
             encoder.print(" db-attribute-path=\"");
             encoder.print(Util.encodeXmlAttribute(getDbAttributePath()));
             encoder.print('\"');

--- a/docs/doc/src/main/resources/RELEASE-NOTES.txt
+++ b/docs/doc/src/main/resources/RELEASE-NOTES.txt
@@ -69,6 +69,7 @@ CAY-2131 Modeler NullPointerException in reverse engineering when importing diff
 CAY-2138 NVARCHAR, LONGNVARCHAR and NCLOB types are missing from Firebird types.xml
 CAY-2143 NPE in BaseSchemaUpdateStrategy
 CAY-2144 cdbimport always fails for databases which don't support catalogs
+CAY-2153 Modeler Exception in save action after reverse engineering some complex DB schema
 
 ----------------------------------
 Release: 4.0.M3

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/db/DbLoaderHelper.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/db/DbLoaderHelper.java
@@ -49,6 +49,7 @@ import org.apache.cayenne.modeler.ProjectController;
 import org.apache.cayenne.modeler.dialog.DbImportProjectSaver;
 import org.apache.cayenne.modeler.pref.DBConnectionInfo;
 import org.apache.cayenne.modeler.util.LongRunningTask;
+import org.apache.cayenne.modeler.util.ProjectUtil;
 import org.apache.cayenne.tools.configuration.ToolsModule;
 import org.apache.cayenne.tools.dbimport.DbImportAction;
 import org.apache.cayenne.tools.dbimport.DbImportConfiguration;
@@ -373,6 +374,7 @@ public class DbLoaderHelper {
             } catch (Exception e) {
                 processException(e, "Error importing database schema.");
             }
+            ProjectUtil.cleanObjMappings(dataMap);
         }
 
         protected DbImportAction createAction(DataMap targetDataMap) {

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/wrapper/ObjAttributeWrapper.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/wrapper/ObjAttributeWrapper.java
@@ -20,6 +20,7 @@ package org.apache.cayenne.modeler.editor.wrapper;
 
 import java.util.List;
 
+import org.apache.cayenne.exp.ExpressionException;
 import org.apache.cayenne.map.DbAttribute;
 import org.apache.cayenne.map.Entity;
 import org.apache.cayenne.map.ObjAttribute;
@@ -139,7 +140,11 @@ public class ObjAttributeWrapper implements Wrapper<ObjAttribute> {
     }
 
     public DbAttribute getDbAttribute() {
-        return objAttribute.getDbAttribute();
+        try {
+            return objAttribute.getDbAttribute();
+        } catch (ExpressionException e) {
+            return null;
+        }
     }
 
     public boolean isInherited() {


### PR DESCRIPTION
After reverse engineering is done all data map is checked for invalid references from Obj to Db attributes
Additionally some defensive code added to bypass invalid db path state in ObjAttribute:
- correct check for this state in ObjAttribute validator
- returning null in ObjAttributeWrapper in modeler
- unconditional saving of db attribute path to XML (this one is questionable though)