### PR TITLE
Modeler. Safe encode to XML query descriptors properties.

### DIFF
--- a/cayenne-server/src/main/java/org/apache/cayenne/map/EJBQLQueryDescriptor.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/map/EJBQLQueryDescriptor.java
@@ -69,10 +69,7 @@ public class EJBQLQueryDescriptor extends QueryDescriptor {
         encoder.indent(1);
 
         // print properties
-        for (Map.Entry<String, String> property : properties.entrySet()) {
-            encoder.printProperty(property.getKey(), property.getValue());
-        }
-
+        encodeProperties(encoder);
 
         if (ejbql != null) {
             encoder.print("<ejbql><![CDATA[");

--- a/cayenne-server/src/main/java/org/apache/cayenne/map/ProcedureQueryDescriptor.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/map/ProcedureQueryDescriptor.java
@@ -97,9 +97,7 @@ public class ProcedureQueryDescriptor extends QueryDescriptor {
         encoder.indent(1);
 
         // print properties
-        for (Map.Entry<String, String> property : properties.entrySet()) {
-            encoder.printProperty(property.getKey(), property.getValue());
-        }
+        encodeProperties(encoder);
 
         encoder.indent(-1);
         encoder.println("</query>");

--- a/cayenne-server/src/main/java/org/apache/cayenne/map/QueryDescriptor.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/map/QueryDescriptor.java
@@ -227,11 +227,19 @@ public class QueryDescriptor implements Serializable, ConfigurationNode, XMLSeri
 
         encoder.indent(1);
 
-        for (Map.Entry<String, String> property : properties.entrySet()) {
-            encoder.printProperty(property.getKey(), property.getValue());
-        }
+        encodeProperties(encoder);
 
         encoder.indent(-1);
         encoder.println("</query>");
+    }
+
+    void encodeProperties(XMLEncoder encoder) {
+        for (Map.Entry<String, String> property : properties.entrySet()) {
+            String value = property.getValue();
+            if(value == null || value.isEmpty()) {
+                continue;
+            }
+            encoder.printProperty(property.getKey(), value);
+        }
     }
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/map/SQLTemplateDescriptor.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/map/SQLTemplateDescriptor.java
@@ -138,9 +138,7 @@ public class SQLTemplateDescriptor extends QueryDescriptor {
         encoder.indent(1);
 
         // print properties
-        for (Map.Entry<String, String> property : properties.entrySet()) {
-            encoder.printProperty(property.getKey(), property.getValue());
-        }
+        encodeProperties(encoder);
 
         // encode default SQL
         if (sql != null) {

--- a/cayenne-server/src/main/java/org/apache/cayenne/map/SelectQueryDescriptor.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/map/SelectQueryDescriptor.java
@@ -191,9 +191,7 @@ public class SelectQueryDescriptor extends QueryDescriptor {
         encoder.indent(1);
 
         // print properties
-        for (Map.Entry<String, String> property : properties.entrySet()) {
-            encoder.printProperty(property.getKey(), property.getValue());
-        }
+        encodeProperties(encoder);
 
         // encode qualifier
         if (qualifier != null) {


### PR DESCRIPTION
It was possible to corrupt DataMap xml file with empty Cache Groups setting in query.