### PR TITLE
CAY-2016 cdbimport: Rename table with toMany relationship causes migration error

### DIFF
--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/DbMerger.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/DbMerger.java
@@ -33,7 +33,6 @@ import org.apache.cayenne.map.DetectedDbEntity;
 import java.sql.Types;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -112,18 +111,8 @@ public class DbMerger {
 
         List<MergerToken> tokens = createMergeTokens(filter(dataMap, filters), dbImport.getDbEntities());
 
-        // sort. use a custom Comparator since only toDb tokens are comparable
-        // by now
-        Collections.sort(tokens, new Comparator<MergerToken>() {
-
-            public int compare(MergerToken o1, MergerToken o2) {
-                if (o1 instanceof AbstractToDbToken && o2 instanceof AbstractToDbToken) {
-
-                    return ((AbstractToDbToken) o1).compareTo(o2);
-                }
-                return 0;
-            }
-        });
+        // sort
+        Collections.sort(tokens, new TokenComparator());
 
         return tokens;
     }

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/TokenComparator.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/TokenComparator.java
@@ -1,0 +1,46 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.dbsync.merge;
+
+import java.util.Comparator;
+
+/**
+ * Simple sort of merge tokens.
+ * Just move all relationships creation tokens to the end of the list.
+ */
+public class TokenComparator implements Comparator<MergerToken> {
+
+    @Override
+    public int compare(MergerToken o1, MergerToken o2) {
+        if (o1 instanceof AbstractToDbToken && o2 instanceof AbstractToDbToken) {
+            return ((AbstractToDbToken) o1).compareTo(o2);
+        }
+
+        if (o1 instanceof AddRelationshipToModel && o2 instanceof AddRelationshipToModel) {
+            return 0;
+        }
+
+        if (!(o1 instanceof AddRelationshipToModel || o2 instanceof AddRelationshipToModel)) {
+            return o1.getClass().getSimpleName().compareTo(o2.getClass().getSimpleName());
+        }
+
+        return o1 instanceof AddRelationshipToModel ? 1 : -1;
+    }
+}

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/MergeCase.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/MergeCase.java
@@ -101,9 +101,13 @@ public abstract class MergeCase extends DbSyncCase {
     }
 
     protected List<MergerToken> createMergeTokens() {
+        return createMergeTokens("ARTIST|GALLERY|PAINTING|NEW_TABLE2?");
+    }
+
+    protected List<MergerToken> createMergeTokens(String tableFilterInclude) {
 
         FiltersConfig filters = FiltersConfig.create(null, null,
-                TableFilter.include("ARTIST|GALLERY|PAINTING|NEW_TABLE2?"), PatternFilter.INCLUDE_NOTHING);
+                TableFilter.include(tableFilterInclude), PatternFilter.INCLUDE_NOTHING);
 
         DbLoaderConfiguration loaderConfiguration = new DbLoaderConfiguration();
         loaderConfiguration.setFiltersConfig(filters);

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/TokenComparatorTest.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/TokenComparatorTest.java
@@ -1,0 +1,101 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.dbsync.merge;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TokenComparatorTest {
+
+    TokenComparator comparator;
+
+    @Before
+    public void setUp() {
+        comparator = new TokenComparator();
+    }
+
+    private List<String> toClassesNames(List<MergerToken> sort) {
+        List<String> res = new ArrayList<String>(sort.size());
+        for (MergerToken mergerToken : sort) {
+            res.add(mergerToken.getClass().getSimpleName());
+        }
+        return res;
+    }
+
+    @Test
+    public void testToModelTokensCompare() throws Exception {
+        List<MergerToken> tokens = Arrays.<MergerToken>asList(
+                new DropColumnToModel(null, null),
+                new DropRelationshipToModel(null, null),
+                new DropTableToModel(null),
+                new AddColumnToDb(null, null),
+                new AddRelationshipToModel(null, null),
+                new AddColumnToModel(null, null),
+                new CreateTableToModel(null));
+        Collections.sort(tokens, comparator);
+
+        List<String> actual = toClassesNames(tokens);
+        List<String> expected = Arrays.asList(
+                "AddColumnToDb",
+                "AddColumnToModel",
+                "CreateTableToModel",
+                "DropColumnToModel",
+                "DropRelationshipToModel",
+                "DropTableToModel",
+                "AddRelationshipToModel"
+        );
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testToDbTokensCompare() throws Exception {
+        List<MergerToken> tokens = Arrays.<MergerToken>asList(
+                new DropColumnToDb(null, null),
+                new DropRelationshipToDb(null, null),
+                new DropTableToDb(null),
+                new AddColumnToModel(null, null),
+                new AddRelationshipToDb(null, null),
+                new AddColumnToDb(null, null),
+                new CreateTableToDb(null));
+        Collections.sort(tokens, comparator);
+
+        List<String> actual = toClassesNames(tokens);
+        List<String> expected = Arrays.asList(
+                "AddColumnToModel",
+                "DropRelationshipToDb",
+                "DropColumnToDb",
+                "DropTableToDb",
+                "AddColumnToDb",
+                "AddRelationshipToDb",
+                "CreateTableToDb"
+        );
+
+        assertEquals(expected, actual);
+    }
+
+}

--- a/cayenne-tools/src/main/java/org/apache/cayenne/tools/dbimport/DefaultDbImportAction.java
+++ b/cayenne-tools/src/main/java/org/apache/cayenne/tools/dbimport/DefaultDbImportAction.java
@@ -25,12 +25,12 @@ import org.apache.cayenne.configuration.server.DbAdapterFactory;
 import org.apache.cayenne.dba.DbAdapter;
 import org.apache.cayenne.dbsync.filter.NameFilter;
 import org.apache.cayenne.dbsync.merge.AbstractToModelToken;
-import org.apache.cayenne.dbsync.merge.AddRelationshipToDb;
 import org.apache.cayenne.dbsync.merge.DbMerger;
 import org.apache.cayenne.dbsync.merge.MergerContext;
 import org.apache.cayenne.dbsync.merge.MergerToken;
 import org.apache.cayenne.dbsync.merge.ModelMergeDelegate;
 import org.apache.cayenne.dbsync.merge.ProxyModelMergeDelegate;
+import org.apache.cayenne.dbsync.merge.TokenComparator;
 import org.apache.cayenne.dbsync.merge.factory.MergerTokenFactory;
 import org.apache.cayenne.dbsync.merge.factory.MergerTokenFactoryProvider;
 import org.apache.cayenne.dbsync.naming.ObjectNameGenerator;
@@ -64,7 +64,6 @@ import java.io.IOException;
 import java.sql.Connection;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -98,21 +97,7 @@ public class DefaultDbImportAction implements DbImportAction {
     }
 
     protected static List<MergerToken> sort(List<MergerToken> reverse) {
-        Collections.sort(reverse, new Comparator<MergerToken>() {
-            @Override
-            public int compare(MergerToken o1, MergerToken o2) {
-                if (o1 instanceof AddRelationshipToDb && o2 instanceof AddRelationshipToDb) {
-                    return 0;
-                }
-
-                if (!(o1 instanceof AddRelationshipToDb || o2 instanceof AddRelationshipToDb)) {
-                    return o1.getClass().getSimpleName().compareTo(o2.getClass().getSimpleName());
-                }
-
-                return o1 instanceof AddRelationshipToDb ? 1 : -1;
-            }
-        });
-
+        Collections.sort(reverse, new TokenComparator());
         return reverse;
     }
 

--- a/cayenne-tools/src/test/java/org/apache/cayenne/tools/dbimport/DefaultDbImportActionTest.java
+++ b/cayenne-tools/src/test/java/org/apache/cayenne/tools/dbimport/DefaultDbImportActionTest.java
@@ -25,8 +25,8 @@ import org.apache.cayenne.configuration.server.DbAdapterFactory;
 import org.apache.cayenne.dba.DbAdapter;
 import org.apache.cayenne.dbsync.DbSyncModule;
 import org.apache.cayenne.dbsync.filter.NamePatternMatcher;
-import org.apache.cayenne.dbsync.merge.AddColumnToDb;
-import org.apache.cayenne.dbsync.merge.AddRelationshipToDb;
+import org.apache.cayenne.dbsync.merge.AddColumnToModel;
+import org.apache.cayenne.dbsync.merge.AddRelationshipToModel;
 import org.apache.cayenne.dbsync.merge.CreateTableToDb;
 import org.apache.cayenne.dbsync.merge.CreateTableToModel;
 import org.apache.cayenne.dbsync.merge.DefaultModelMergeDelegate;
@@ -330,12 +330,12 @@ public class DefaultDbImportActionTest {
     @Test
     public void testMergeTokensSorting() {
         LinkedList<MergerToken> tokens = new LinkedList<MergerToken>();
-        tokens.add(new AddColumnToDb(null, null));
-        tokens.add(new AddRelationshipToDb(null, null));
+        tokens.add(new AddColumnToModel(null, null));
+        tokens.add(new AddRelationshipToModel(null, null));
         tokens.add(new CreateTableToDb(null));
         tokens.add(new CreateTableToModel(null));
 
-        assertEquals(asList("AddColumnToDb", "CreateTableToDb", "CreateTableToModel", "AddRelationshipToDb"),
+        assertEquals(asList("AddColumnToModel", "CreateTableToDb", "CreateTableToModel", "AddRelationshipToModel"),
                 toClasses(DefaultDbImportAction.sort(tokens)));
     }
 

--- a/docs/doc/src/main/resources/RELEASE-NOTES.txt
+++ b/docs/doc/src/main/resources/RELEASE-NOTES.txt
@@ -45,6 +45,7 @@ CAY-2136 Allow Ordering.orderedList(…) methods to accept a Collection rather t
 
 Bug Fixes:
 
+CAY-2016 cdbimport: Rename table with toMany relationship causes migration error
 CAY-2064 Issue with BeanAccessor for classes with complex inheritance
 CAY-2066 Fixes for inner enums handling in ExtendedTypeMap
 CAY-2067 Cayenne 4.0 connection pool is occasionally running out of connections

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/db/MergerTokenSelectorController.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/db/MergerTokenSelectorController.java
@@ -20,6 +20,7 @@ package org.apache.cayenne.modeler.dialog.db;
 
 import org.apache.cayenne.dbsync.merge.MergeDirection;
 import org.apache.cayenne.dbsync.merge.MergerToken;
+import org.apache.cayenne.dbsync.merge.TokenComparator;
 import org.apache.cayenne.dbsync.merge.factory.MergerTokenFactory;
 import org.apache.cayenne.modeler.Application;
 import org.apache.cayenne.modeler.util.CayenneController;
@@ -231,6 +232,7 @@ public class MergerTokenSelectorController extends CayenneController {
             }
         }
 
+        Collections.sort(selectableTokensList, new TokenComparator());
         AbstractTableModel model = (AbstractTableModel) view.getTokens().getModel();
         model.fireTableDataChanged();
     }


### PR DESCRIPTION
Real problem here is sorting order of MergeTokens.
In this fix:
 - Improved sort on DbImportAction
 - Added sorting to DB migration

Whole sorting need to be reviewed and possibly rewritten.