### PR TITLE
Enable docker profiles on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Since 4GB not enough for build, we use 'sudo' environment with 7.5GB RAM
 # Downside: It's starts a little bit slower
 # How to fix: Change build setting or fix code.

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@
 # How to fix: Change build setting or fix code.
 # https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments
 sudo: required
+
+services:
+  - docker
+
 language: java
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Since 4GB not enought for build, we use 'sudo' environment with 7.5GB RAM
+# Since 4GB not enough for build, we use 'sudo' environment with 7.5GB RAM
 # Downside: It's starts a little bit slower
 # How to fix: Change build setting or fix code.
 # https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments
@@ -15,9 +15,9 @@ jdk:
   - oraclejdk7
 
 script:
-  - mvn verify -q -DcayenneTestConnection=$DB_PROFILE
+  - mvn verify -q -DcayenneTestConnection=$DB_PROFILE -DcayenneLogLevel=ERROR
 
-# prevent Travis from uneeded "mvn install" run
+# prevent Travis from unneeded "mvn install" run
 install: /bin/true
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ env:
   - DB_PROFILE=hsql
   - DB_PROFILE=h2
   - DB_PROFILE=derby
+  - DB_PROFILE=mysql-docker
+  - DB_PROFILE=postgres-docker
 
 jdk:
   - oraclejdk8

--- a/cayenne-server/src/test/resources/simplelogger.properties
+++ b/cayenne-server/src/test/resources/simplelogger.properties
@@ -1,7 +1,0 @@
-# SLF4J's SimpleLogger configuration file
-# Simple implementation of Logger that sends all enabled log messages, for all defined loggers, to System.err.
-
-# Default logging detail level for all instances of SimpleLogger.
-# Must be one of ("trace", "debug", "info", "warn", or "error").
-# If not specified, defaults to "info".
-org.slf4j.simpleLogger.defaultLogLevel=error

--- a/pom.xml
+++ b/pom.xml
@@ -890,12 +890,18 @@
 							<name>cayenneJdbcDriver</name>
 							<value>${cayenneJdbcDriver}</value>
 						</property>
+                        <org.slf4j.simpleLogger.defaultLogLevel>${cayenneLogLevel}</org.slf4j.simpleLogger.defaultLogLevel>
 					</systemPropertyVariables>
 				</configuration>
 			</plugin>
 			<plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <org.slf4j.simpleLogger.defaultLogLevel>${cayenneLogLevel}</org.slf4j.simpleLogger.defaultLogLevel>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
 			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1428,7 +1428,7 @@
 			<activation>
 				<property>
 					<name>cayenneTestConnection</name>
-					<value>postgresdocker</value>
+					<value>postgres-docker</value>
 				</property>
 			</activation>
 			<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1352,7 +1352,7 @@
 								<cayenneAdapter>org.apache.cayenne.dba.mysql.MySQLAdapter</cayenneAdapter>
 								<cayenneJdbcUsername>root</cayenneJdbcUsername>
 								<cayenneJdbcPassword></cayenneJdbcPassword>
-								<cayenneJdbcUrl>jdbc:mysql://${db.host}:${db.port}/cayenne</cayenneJdbcUrl>
+								<cayenneJdbcUrl>jdbc:mysql://${db.host}:${db.port}/cayenne?useUnicode=true&amp;characterEncoding=UTF-8&amp;generateSimpleParameterMetadata=true</cayenneJdbcUrl>
 								<cayenneJdbcDriver>com.mysql.jdbc.Driver</cayenneJdbcDriver>
 							</systemPropertyVariables>
 						</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1424,7 +1424,7 @@
 			</dependencies>
 		</profile>
 		<profile>
-			<id>postgresdocker</id>
+			<id>postgres-docker</id>
 			<activation>
 				<property>
 					<name>cayenneTestConnection</name>


### PR DESCRIPTION
Since travis supports docker inside build, we can enable docker profiles.

Also i renamed `postgresdocker` to `postgres-docker` for consistency with `mysql-docker`