### PR TITLE
Fix issue with Frontbase PK generation

### DIFF
--- a/framework/cayenne-jdk1.5-unpublished/src/main/java/org/apache/cayenne/dba/JdbcPkGenerator.java
+++ b/framework/cayenne-jdk1.5-unpublished/src/main/java/org/apache/cayenne/dba/JdbcPkGenerator.java
@@ -246,7 +246,7 @@ public class JdbcPkGenerator implements PkGenerator {
         if (pkGenerator != null && pkGenerator.getKeyCacheSize() != null)
             cacheSize = pkGenerator.getKeyCacheSize().intValue();
         else
-            cacheSize = pkCacheSize;
+            cacheSize = getPkCacheSize();
 
         long value;
 


### PR DESCRIPTION
Hi all, I noticed an issue with Frontbase primary key generation, the fix is really simple. There is a method getPkCacheSize() that is supposed to be overriden by subclasses, but we was calling the default value instead of method.