### PR TITLE
 document updates for cayenne modeler based on 4.0.M5 changes

### DIFF
--- a/docs/docbook/cayenne-guide/src/docbkx/setup.xml
+++ b/docs/docbook/cayenne-guide/src/docbkx/setup.xml
@@ -127,7 +127,7 @@
     &lt;plugins>
         &lt;plugin>
             &lt;groupId>org.apache.cayenne.plugins&lt;/groupId>
-            &lt;artifactId>maven-cayenne-modeler-plugin&lt;/artifactId>
+            &lt;artifactId>cayenne-modeler-maven-plugin&lt;/artifactId>
             &lt;version><?eval ${project.version}?>&lt;/version>
         &lt;/plugin>
     &lt;/plugins>


### PR DESCRIPTION
CAY-1980 "maven-cayenne-modeler-plugin" renamed to "cayenne-modeler-maven-plugin"