### PR TITLE
Added the Orderings class to support chaning of asc() through Ordering

### DIFF
--- a/cayenne-server/src/main/java/org/apache/cayenne/exp/Property.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/exp/Property.java
@@ -18,18 +18,19 @@
  ****************************************************************/
 package org.apache.cayenne.exp;
 
-import org.apache.cayenne.CayenneRuntimeException;
-import org.apache.cayenne.Persistent;
-import org.apache.cayenne.exp.parser.ASTPath;
-import org.apache.cayenne.query.Ordering;
-import org.apache.cayenne.query.PrefetchTreeNode;
-import org.apache.cayenne.query.SortOrder;
-import org.apache.cayenne.reflect.PropertyUtils;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.cayenne.CayenneRuntimeException;
+import org.apache.cayenne.Persistent;
+import org.apache.cayenne.exp.parser.ASTPath;
+import org.apache.cayenne.query.Ordering;
+import org.apache.cayenne.query.Orderings;
+import org.apache.cayenne.query.PrefetchTreeNode;
+import org.apache.cayenne.query.SortOrder;
+import org.apache.cayenne.reflect.PropertyUtils;
 
 /**
  * <p>
@@ -91,7 +92,8 @@ public class Property<E> {
      * @see Property#create(String, Class)
      * @deprecated use factory method Property.create("propertyName", PropertyType.class)
      */
-    public Property(final String name) {
+    @Deprecated
+	public Property(final String name) {
         this(name, null);
     }
 
@@ -525,11 +527,9 @@ public class Property<E> {
     /**
      * @return Ascending sort orderings on this property.
      */
-    public List<Ordering> ascs() {
-        List<Ordering> result = new ArrayList<>(1);
-        result.add(asc());
-        return result;
-    }
+	public Orderings ascs() {
+		return new Orderings(asc());
+	}
 
     /**
      * @return Ascending case insensitive sort orderings on this property.
@@ -541,11 +541,9 @@ public class Property<E> {
     /**
      * @return Ascending case insensitive sort orderings on this property.
      */
-    public List<Ordering> ascInsensitives() {
-        List<Ordering> result = new ArrayList<>(1);
-        result.add(ascInsensitive());
-        return result;
-    }
+	public Orderings ascInsensitives() {
+		return new Orderings(ascInsensitive());
+	}
 
     /**
      * @return Descending sort orderings on this property.
@@ -557,10 +555,8 @@ public class Property<E> {
     /**
      * @return Descending sort orderings on this property.
      */
-    public List<Ordering> descs() {
-        List<Ordering> result = new ArrayList<>(1);
-        result.add(desc());
-        return result;
+    public Orderings descs() {
+        return new Orderings(desc());
     }
 
     /**
@@ -573,10 +569,8 @@ public class Property<E> {
     /**
      * @return Descending case insensitive sort orderings on this property.
      */
-    public List<Ordering> descInsensitives() {
-        List<Ordering> result = new ArrayList<>(1);
-        result.add(descInsensitive());
-        return result;
+    public Orderings descInsensitives() {
+        return new Orderings(descInsensitive());
     }
 
     /**

--- a/cayenne-server/src/main/java/org/apache/cayenne/query/Ordering.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/query/Ordering.java
@@ -19,6 +19,15 @@
 
 package org.apache.cayenne.query;
 
+import java.io.PrintWriter;
+import java.io.Serializable;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
 import org.apache.cayenne.configuration.ConfigurationNodeVisitor;
 import org.apache.cayenne.configuration.EmptyConfigurationNodeVisitor;
 import org.apache.cayenne.exp.Expression;
@@ -30,15 +39,6 @@ import org.apache.cayenne.util.Util;
 import org.apache.cayenne.util.XMLEncoder;
 import org.apache.cayenne.util.XMLSerializable;
 import org.apache.commons.collections.ComparatorUtils;
-
-import java.io.PrintWriter;
-import java.io.Serializable;
-import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
 
 /**
  * Defines object sorting criteria, used either for in-memory sorting of object
@@ -460,4 +460,40 @@ public class Ordering implements Comparator<Object>, Serializable, XMLSerializab
 	public SortOrder getSortOrder() {
 		return sortOrder;
 	}
+	
+	
+	 /**
+	  * Returns Orderings with this Ordering followed by the provided
+	  * next Ordering.
+	  * 
+	  * @param nextOrdering the next Ordering to chain to this
+	  * @return a new Orderings with both Ordering
+	  */
+	 public Orderings then(Ordering nextOrdering) {
+	 	return new Orderings(this, nextOrdering);
+	 }
+
+	 /**
+	  * Returns Orderings with this Ordering followed by the provided
+	  * list of next Orderings.
+	  * 
+	  * @param nextOrderings the next Orderings to chain to this
+	  * @return an array of sort orderings
+	  */
+	 public Orderings then(Orderings nextOrderings) {
+	 	Orderings newOrderings = new Orderings(this);
+	 	
+	 	return newOrderings.then(nextOrderings);
+	 }
+	 
+	 /**
+	  * @see Orderings#then(Orderings)
+	  * @param nextOrderings
+	  * @return
+	  */
+	 public Orderings then(List<Ordering> nextOrderings) {
+	 	Orderings newOrderings = new Orderings(this);
+	 	
+	 	return newOrderings.then(nextOrderings);
+	 }
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/query/Orderings.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/query/Orderings.java
@@ -1,0 +1,95 @@
+package org.apache.cayenne.query;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+/**
+  * <p>Orderings is provided so that you can chain Ordering together and then use 
+  * the result to pass into methods that require List&lt;Ordering&gt;</p>
+  * <p>Example:</p>
+  * <pre>Person.COMPANY_NAME.asc().then(Person.FIRST_NAME.desc)</pre>
+  * 
+  * @since 4.0
+  */
+public class Orderings extends ArrayList<Ordering> {
+	 
+	public Orderings() {
+	 	super();
+	 }
+	 
+	 public Orderings(int initialCapacity) {
+	 	super(initialCapacity);
+	 }
+
+	 public Orderings(Collection<? extends Ordering> c) {
+	 	super(c);
+	 }
+
+	 public Orderings(Ordering ordering) {
+	 	super(Arrays.asList(ordering));
+	 }
+
+	 public Orderings(Ordering... orderings) {
+	 	super(Arrays.asList(orderings));
+	 }
+
+	 /**
+	 * Adds the given sort ordering to the end of this list and
+	 * returns "this" so it can be chained again.
+	 * 
+	 * @param nextOrdering the sort ordering to add
+	 * @return this (with nextOrdering appended)
+	 */
+	 public Orderings then(Ordering nextOrdering) {
+	 	add(nextOrdering);
+	 	
+	 	return this;
+	 }
+
+	 /**
+	 * Adds the given sort orderings to the end of this list and returns
+	 * "this" so it can be chained again.
+	 * 
+	 * @param nextOrderings the sort ordering to add
+	 * @return this (with nextOrderings appended)
+	 */
+	 public Orderings then(Orderings nextOrderings) {
+	 	addAll(nextOrderings);
+	 	
+	 	return this;
+	 }
+	 
+	 /**
+	 * @see Orderings#then(Orderings)
+	 * @param nextOrderings
+	 * @return
+	 */
+	 public Orderings then(List<Ordering> nextOrderings) {
+	 	addAll(nextOrderings);
+	 	
+	 	return this;
+	 }
+	 
+	 /**
+	 * Returns an list sorted with these Orderings.
+	 * 
+	 * @param <T> the type of the list
+	 * @param list the list to sort
+	 * @return a sorted copy of the list
+	 */
+	 public <T> List<T> orderedList(List<T> list) {
+	 	return Ordering.orderedList(list, this);
+	 }
+
+	 /**
+	 * Sorts the given array with these Orderings.
+	 * 
+	 * @param <T> the type of the list
+	 * @param list the list to sort
+	 */
+	 public <T> void orderList(List<T> list) {
+	 	Ordering.orderList(list, this);
+	 }
+}


### PR DESCRIPTION
I have added this class as a convenience to chain Ordering calls and then passing them into APIs that support List\<Ordering>.  Here's an example:

Person.COMPANY_NAME.asc().then(Person.LAST_NAME.desc()).then(Person.FIRST_NAME.asc())

I understand the the newer select API doesn't really need this, but there are still plenty of APIs that use List\<Ordering> and this newer format supports the code being simpler and easier to read.