### PR TITLE
CAY-2384  Modeler: Visualization issue after an undo action for a deleted ObjRelationship

### DIFF
--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/undo/RemoveRelationshipUndoableEdit.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/undo/RemoveRelationshipUndoableEdit.java
@@ -26,6 +26,7 @@ import org.apache.cayenne.map.DbRelationship;
 import org.apache.cayenne.map.ObjEntity;
 import org.apache.cayenne.map.ObjRelationship;
 import org.apache.cayenne.modeler.action.CreateRelationshipAction;
+import org.apache.cayenne.modeler.action.DbEntityCounterpartAction;
 import org.apache.cayenne.modeler.action.RemoveRelationshipAction;
 
 public class RemoveRelationshipUndoableEdit extends CayenneUndoableEdit {
@@ -78,11 +79,17 @@ public class RemoveRelationshipUndoableEdit extends CayenneUndoableEdit {
             for (ObjRelationship r : rels) {
                 action.createObjRelationship(objEntity, r);
             }
+            focusObjEntity(objEntity);
         }
         else {
             for (DbRelationship dr : dbRels) {
                 action.createDbRelationship(dbEntity, dr);
             }
         }
+    }
+    
+    private void focusObjEntity(ObjEntity objEntity){
+        actionManager.getAction(DbEntityCounterpartAction.class)
+                .viewCounterpartEntity(objEntity);
     }
 }


### PR DESCRIPTION
Added method `focusObjEntity(ObjEntity objEntity)` in `RemoveRelationshipUndoableEdit` class, that is called during `undo()` action in order to fix CAY-2384