### PR TITLE
CAY-2385 CAY-2386 Fixing visualization issues after an undo action for a deleted DbRelationship or DbAttribute

### DIFF
--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/action/DbEntityCounterpartAction.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/action/DbEntityCounterpartAction.java
@@ -26,11 +26,9 @@ import javax.swing.tree.TreePath;
 
 import org.apache.cayenne.configuration.DataChannelDescriptor;
 import org.apache.cayenne.map.DbEntity;
-import org.apache.cayenne.map.Entity;
 import org.apache.cayenne.map.ObjEntity;
 import org.apache.cayenne.modeler.Application;
 import org.apache.cayenne.modeler.ProjectController;
-import org.apache.cayenne.modeler.ProjectTreeModel;
 import org.apache.cayenne.modeler.event.EntityDisplayEvent;
 import org.apache.cayenne.modeler.util.CayenneAction;
 
@@ -85,34 +83,5 @@ public class DbEntityCounterpartAction extends CayenneAction {
         getProjectController().fireObjEntityDisplayEvent(event);
     }
     
-    /**
-     * Builds a tree path for a given entity. Urgent for later selection.
-     * 
-     * @param entity to build path for
-     * @return tree path
-     */
-    public static TreePath buildTreePath(Entity entity) {
-        DataChannelDescriptor domain = (DataChannelDescriptor) Application
-                .getInstance()
-                .getProject()
-                .getRootNode();
-        
-        Object[] path = new Object[] {domain, entity.getDataMap(), entity};
-
-        Object[] mutableTreeNodes = new Object[path.length];
-        mutableTreeNodes[0] = ((ProjectTreeModel) editor().getProjectTreeView().getModel())
-                .getRootNode();
-
-        Object[] helper;
-        for (int i = 1; i < path.length; i++) {
-            helper = new Object[i];
-            for (int j = 0; j < i;) {
-                helper[j] = path[++j];
-            }
-            mutableTreeNodes[i] = ((ProjectTreeModel) editor()
-                    .getProjectTreeView()
-                    .getModel()).getNodeForObjectPath(helper);
-        }
-        return new TreePath(mutableTreeNodes);
-    }
+    
 }

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/action/DbEntityCounterpartAction.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/action/DbEntityCounterpartAction.java
@@ -29,10 +29,8 @@ import org.apache.cayenne.map.DbEntity;
 import org.apache.cayenne.map.Entity;
 import org.apache.cayenne.map.ObjEntity;
 import org.apache.cayenne.modeler.Application;
-import org.apache.cayenne.modeler.CayenneModelerFrame;
 import org.apache.cayenne.modeler.ProjectController;
 import org.apache.cayenne.modeler.ProjectTreeModel;
-import org.apache.cayenne.modeler.editor.EditorView;
 import org.apache.cayenne.modeler.event.EntityDisplayEvent;
 import org.apache.cayenne.modeler.util.CayenneAction;
 
@@ -85,13 +83,6 @@ public class DbEntityCounterpartAction extends CayenneAction {
                 entity.getDataMap(),
                 (DataChannelDescriptor) getProjectController().getProject().getRootNode());
         getProjectController().fireObjEntityDisplayEvent(event);
-    }
-    
-    public static EditorView editor() {
-        return ((CayenneModelerFrame) Application
-                .getInstance()
-                .getFrameController()
-                .getView()).getView();
     }
     
     /**

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/action/ObjEntityCounterpartAction.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/action/ObjEntityCounterpartAction.java
@@ -25,7 +25,6 @@ import org.apache.cayenne.configuration.DataChannelDescriptor;
 import org.apache.cayenne.map.DbEntity;
 import org.apache.cayenne.map.Entity;
 import org.apache.cayenne.modeler.Application;
-import org.apache.cayenne.modeler.ProjectTreeModel;
 import org.apache.cayenne.modeler.event.EntityDisplayEvent;
 
 public class ObjEntityCounterpartAction extends BaseViewEntityAction {
@@ -59,34 +58,4 @@ public class ObjEntityCounterpartAction extends BaseViewEntityAction {
         getProjectController().fireDbEntityDisplayEvent(event);
     }
 
-    /**
-     * Builds a tree path for a given entity. Urgent for later selection.
-     *
-     * @param entity to build path for
-     * @return tree path
-     */
-    public static TreePath buildTreePath(Entity entity) {
-        DataChannelDescriptor domain = (DataChannelDescriptor) Application
-                .getInstance()
-                .getProject()
-                .getRootNode();
-
-        Object[] path = new Object[] {domain, entity.getDataMap(), entity};
-
-        Object[] mutableTreeNodes = new Object[path.length];
-        mutableTreeNodes[0] = ((ProjectTreeModel) editor().getProjectTreeView().getModel())
-                .getRootNode();
-
-        Object[] helper;
-        for (int i = 1; i < path.length; i++) {
-            helper = new Object[i];
-            for (int j = 0; j < i;) {
-                helper[j] = path[++j];
-            }
-            mutableTreeNodes[i] = ((ProjectTreeModel) editor()
-                    .getProjectTreeView()
-                    .getModel()).getNodeForObjectPath(helper);
-        }
-        return new TreePath(mutableTreeNodes);
-    }
 }

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/action/ObjEntityCounterpartAction.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/action/ObjEntityCounterpartAction.java
@@ -25,9 +25,7 @@ import org.apache.cayenne.configuration.DataChannelDescriptor;
 import org.apache.cayenne.map.DbEntity;
 import org.apache.cayenne.map.Entity;
 import org.apache.cayenne.modeler.Application;
-import org.apache.cayenne.modeler.CayenneModelerFrame;
 import org.apache.cayenne.modeler.ProjectTreeModel;
-import org.apache.cayenne.modeler.editor.EditorView;
 import org.apache.cayenne.modeler.event.EntityDisplayEvent;
 
 public class ObjEntityCounterpartAction extends BaseViewEntityAction {
@@ -59,13 +57,6 @@ public class ObjEntityCounterpartAction extends BaseViewEntityAction {
                 entity.getDataMap(),
                 (DataChannelDescriptor) getProjectController().getProject().getRootNode());
         getProjectController().fireDbEntityDisplayEvent(event);
-    }
-
-    public static EditorView editor() {
-        return ((CayenneModelerFrame) Application
-                .getInstance()
-                .getFrameController()
-                .getView()).getView();
     }
 
     /**

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/undo/CayenneUndoableEdit.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/undo/CayenneUndoableEdit.java
@@ -20,9 +20,13 @@ package org.apache.cayenne.modeler.undo;
 
 import javax.swing.undo.AbstractUndoableEdit;
 
+import org.apache.cayenne.map.DbEntity;
+import org.apache.cayenne.map.ObjEntity;
 import org.apache.cayenne.modeler.Application;
 import org.apache.cayenne.modeler.ProjectController;
 import org.apache.cayenne.modeler.action.ActionManager;
+import org.apache.cayenne.modeler.action.DbEntityCounterpartAction;
+import org.apache.cayenne.modeler.action.ObjEntityCounterpartAction;
 
 public abstract class CayenneUndoableEdit extends AbstractUndoableEdit {
     
@@ -42,5 +46,13 @@ public abstract class CayenneUndoableEdit extends AbstractUndoableEdit {
     @Override
     public boolean canUndo() {
         return true;
+    }
+    
+    protected void focusObjEntity(ObjEntity objEntity){
+        actionManager.getAction(DbEntityCounterpartAction.class).viewCounterpartEntity(objEntity);
+    }
+
+    protected void focusDBEntity(DbEntity dbEntity){
+        actionManager.getAction(ObjEntityCounterpartAction.class).viewCounterpartObject(dbEntity);
     }
 }

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/undo/RemoveAttributeUndoableEdit.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/undo/RemoveAttributeUndoableEdit.java
@@ -30,8 +30,6 @@ import org.apache.cayenne.map.EmbeddableAttribute;
 import org.apache.cayenne.map.ObjAttribute;
 import org.apache.cayenne.map.ObjEntity;
 import org.apache.cayenne.modeler.action.CreateAttributeAction;
-import org.apache.cayenne.modeler.action.DbEntityCounterpartAction;
-import org.apache.cayenne.modeler.action.ObjEntityCounterpartAction;
 import org.apache.cayenne.modeler.action.RemoveAttributeAction;
 import org.apache.cayenne.modeler.event.EmbeddableDisplayEvent;
 import org.apache.cayenne.modeler.event.EntityDisplayEvent;
@@ -132,14 +130,6 @@ public class RemoveAttributeUndoableEdit extends CayenneUndoableEdit {
             }
         }
 
-    }
-
-    private void focusObjEntity(ObjEntity objEntity){
-        actionManager.getAction(DbEntityCounterpartAction.class).viewCounterpartEntity(objEntity);
-    }
-
-    private void focusDBEntity(DbEntity dbEntity){
-        actionManager.getAction(ObjEntityCounterpartAction.class).viewCounterpartObject(dbEntity);
     }
 
     @Override

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/undo/RemoveAttributeUndoableEdit.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/undo/RemoveAttributeUndoableEdit.java
@@ -31,6 +31,7 @@ import org.apache.cayenne.map.ObjAttribute;
 import org.apache.cayenne.map.ObjEntity;
 import org.apache.cayenne.modeler.action.CreateAttributeAction;
 import org.apache.cayenne.modeler.action.DbEntityCounterpartAction;
+import org.apache.cayenne.modeler.action.ObjEntityCounterpartAction;
 import org.apache.cayenne.modeler.action.RemoveAttributeAction;
 import org.apache.cayenne.modeler.event.EmbeddableDisplayEvent;
 import org.apache.cayenne.modeler.event.EntityDisplayEvent;
@@ -122,6 +123,7 @@ public class RemoveAttributeUndoableEdit extends CayenneUndoableEdit {
             for (DbAttribute attr : dbAttributes) {
                 action.createDbAttribute(dataMap, dbEntity, attr);
             }
+            focusDBEntity(dbEntity);
         }
 
         if (embeddable != null) {
@@ -133,8 +135,11 @@ public class RemoveAttributeUndoableEdit extends CayenneUndoableEdit {
     }
 
     private void focusObjEntity(ObjEntity objEntity){
-        actionManager.getAction(DbEntityCounterpartAction.class)
-                .viewCounterpartEntity(objEntity);
+        actionManager.getAction(DbEntityCounterpartAction.class).viewCounterpartEntity(objEntity);
+    }
+
+    private void focusDBEntity(DbEntity dbEntity){
+        actionManager.getAction(ObjEntityCounterpartAction.class).viewCounterpartObject(dbEntity);
     }
 
     @Override

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/undo/RemoveRelationshipUndoableEdit.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/undo/RemoveRelationshipUndoableEdit.java
@@ -26,8 +26,6 @@ import org.apache.cayenne.map.DbRelationship;
 import org.apache.cayenne.map.ObjEntity;
 import org.apache.cayenne.map.ObjRelationship;
 import org.apache.cayenne.modeler.action.CreateRelationshipAction;
-import org.apache.cayenne.modeler.action.DbEntityCounterpartAction;
-import org.apache.cayenne.modeler.action.ObjEntityCounterpartAction;
 import org.apache.cayenne.modeler.action.RemoveRelationshipAction;
 
 public class RemoveRelationshipUndoableEdit extends CayenneUndoableEdit {
@@ -88,13 +86,5 @@ public class RemoveRelationshipUndoableEdit extends CayenneUndoableEdit {
             }
             focusDBEntity(dbEntity);
         }
-    }
-
-    private void focusObjEntity(ObjEntity objEntity){
-        actionManager.getAction(DbEntityCounterpartAction.class).viewCounterpartEntity(objEntity);
-    }
-
-    private void focusDBEntity(DbEntity dbEntity){
-        actionManager.getAction(ObjEntityCounterpartAction.class).viewCounterpartObject(dbEntity);
     }
 }

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/undo/RemoveRelationshipUndoableEdit.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/undo/RemoveRelationshipUndoableEdit.java
@@ -27,6 +27,7 @@ import org.apache.cayenne.map.ObjEntity;
 import org.apache.cayenne.map.ObjRelationship;
 import org.apache.cayenne.modeler.action.CreateRelationshipAction;
 import org.apache.cayenne.modeler.action.DbEntityCounterpartAction;
+import org.apache.cayenne.modeler.action.ObjEntityCounterpartAction;
 import org.apache.cayenne.modeler.action.RemoveRelationshipAction;
 
 public class RemoveRelationshipUndoableEdit extends CayenneUndoableEdit {
@@ -85,11 +86,15 @@ public class RemoveRelationshipUndoableEdit extends CayenneUndoableEdit {
             for (DbRelationship dr : dbRels) {
                 action.createDbRelationship(dbEntity, dr);
             }
+            focusDBEntity(dbEntity);
         }
     }
-    
+
     private void focusObjEntity(ObjEntity objEntity){
-        actionManager.getAction(DbEntityCounterpartAction.class)
-                .viewCounterpartEntity(objEntity);
+        actionManager.getAction(DbEntityCounterpartAction.class).viewCounterpartEntity(objEntity);
+    }
+
+    private void focusDBEntity(DbEntity dbEntity){
+        actionManager.getAction(ObjEntityCounterpartAction.class).viewCounterpartObject(dbEntity);
     }
 }

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/util/CayenneAction.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/util/CayenneAction.java
@@ -31,11 +31,15 @@ import javax.swing.JButton;
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JMenuItem;
 import javax.swing.KeyStroke;
+import javax.swing.tree.TreePath;
 
 import org.apache.cayenne.configuration.ConfigurationNode;
+import org.apache.cayenne.configuration.DataChannelDescriptor;
+import org.apache.cayenne.map.Entity;
 import org.apache.cayenne.modeler.Application;
 import org.apache.cayenne.modeler.CayenneModelerFrame;
 import org.apache.cayenne.modeler.ProjectController;
+import org.apache.cayenne.modeler.ProjectTreeModel;
 import org.apache.cayenne.modeler.dialog.ErrorDebugDialog;
 import org.apache.cayenne.modeler.editor.EditorView;
 import org.apache.cayenne.project.Project;
@@ -330,5 +334,36 @@ public abstract class CayenneAction extends AbstractAction {
                 .getInstance()
                 .getFrameController()
                 .getView()).getView();
+    }
+    
+    /**
+     * Builds a tree path for a given entity. Urgent for later selection.
+     * 
+     * @param entity to build path for
+     * @return tree path
+     */
+    protected static TreePath buildTreePath(Entity entity) {
+        DataChannelDescriptor domain = (DataChannelDescriptor) Application
+                .getInstance()
+                .getProject()
+                .getRootNode();
+        
+        Object[] path = new Object[] {domain, entity.getDataMap(), entity};
+
+        Object[] mutableTreeNodes = new Object[path.length];
+        mutableTreeNodes[0] = ((ProjectTreeModel) editor().getProjectTreeView().getModel())
+                .getRootNode();
+
+        Object[] helper;
+        for (int i = 1; i < path.length; i++) {
+            helper = new Object[i];
+            for (int j = 0; j < i;) {
+                helper[j] = path[++j];
+            }
+            mutableTreeNodes[i] = ((ProjectTreeModel) editor()
+                    .getProjectTreeView()
+                    .getModel()).getNodeForObjectPath(helper);
+        }
+        return new TreePath(mutableTreeNodes);
     }
 }

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/util/CayenneAction.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/util/CayenneAction.java
@@ -34,8 +34,10 @@ import javax.swing.KeyStroke;
 
 import org.apache.cayenne.configuration.ConfigurationNode;
 import org.apache.cayenne.modeler.Application;
+import org.apache.cayenne.modeler.CayenneModelerFrame;
 import org.apache.cayenne.modeler.ProjectController;
 import org.apache.cayenne.modeler.dialog.ErrorDebugDialog;
+import org.apache.cayenne.modeler.editor.EditorView;
 import org.apache.cayenne.project.Project;
 import org.apache.cayenne.swing.components.image.FilteredIconFactory;
 import org.apache.cayenne.util.Util;
@@ -321,5 +323,12 @@ public abstract class CayenneAction extends AbstractAction {
                 super.setToolTipText(text);
             }
         }
+    }
+    
+    protected static EditorView editor() {
+        return ((CayenneModelerFrame) Application
+                .getInstance()
+                .getFrameController()
+                .getView()).getView();
     }
 }


### PR DESCRIPTION
Includes solution for both bugs [CAY-2385](https://issues.apache.org/jira/browse/CAY-2385) and [CAY-2386](https://issues.apache.org/jira/browse/CAY-2386), as well as the required refactoring derived from the solutions for [CY-2379](https://issues.apache.org/jira/browse/CAY-2379) and [CAY-2383](https://issues.apache.org/jira/browse/CAY-2383)

No bugs detected for `Embeddable` undo actions.