### PR TITLE
QueryCache improvements for local caching

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,7 +9,7 @@ https://issues.apache.org/jira/browse/CAY
 
 ----------------------------------
 Release: 4.1.M2
-Date:
+Date: 
 ----------------------------------
 Changes/New Features:
 

--- a/cayenne-rop-server/src/main/java/org/apache/cayenne/CayenneContextQueryAction.java
+++ b/cayenne-rop-server/src/main/java/org/apache/cayenne/CayenneContextQueryAction.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.apache.cayenne.cache.QueryCacheEntryFactory;
 import org.apache.cayenne.map.EntityResolver;
 import org.apache.cayenne.query.Query;
+import org.apache.cayenne.query.QueryMetadata;
 import org.apache.cayenne.query.RefreshQuery;
 import org.apache.cayenne.reflect.AttributeProperty;
 import org.apache.cayenne.reflect.ClassDescriptor;
@@ -108,10 +109,9 @@ class CayenneContextQueryAction extends ObjectContextQueryAction {
             if (refreshQuery.getQuery() != null) {
                 Query cachedQuery = refreshQuery.getQuery();
 
-                String cacheKey = cachedQuery
-                        .getMetaData(context.getEntityResolver())
-                        .getCacheKey();
-                context.getQueryCache().remove(cacheKey);
+                QueryMetadata metadata = cachedQuery
+                        .getMetaData(context.getEntityResolver());
+                context.getQueryCache().remove(metadata);
 
                 this.response = context.performGenericQuery(cachedQuery);
 

--- a/cayenne-server/src/main/java/org/apache/cayenne/BaseContext.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/BaseContext.java
@@ -48,6 +48,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -120,6 +121,14 @@ public abstract class BaseContext implements ObjectContext {
 		graphAction = new ObjectContextGraphAction(this);
 	}
 
+	@Override
+	protected void finalize() throws Throwable {
+		if (queryCache != null) {
+			queryCache.clearLocalCache(Optional.empty());
+		}
+		super.finalize();
+	}
+	
 	/**
 	 * Checks whether this context is attached to Cayenne runtime stack and if
 	 * not, attempts to attach itself to the runtime using Injector returned
@@ -469,6 +478,7 @@ public abstract class BaseContext implements ObjectContext {
 	@Override
 	public abstract Collection<?> uncommittedObjects();
 
+	@Override
 	public QueryCache getQueryCache() {
 		attachToRuntimeIfNeeded();
 		return queryCache;

--- a/cayenne-server/src/main/java/org/apache/cayenne/ObjectContext.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/ObjectContext.java
@@ -19,6 +19,7 @@
 
 package org.apache.cayenne;
 
+import org.apache.cayenne.cache.QueryCache;
 import org.apache.cayenne.graph.GraphManager;
 import org.apache.cayenne.map.EntityResolver;
 import org.apache.cayenne.query.Query;
@@ -261,6 +262,8 @@ public interface ObjectContext extends DataChannel, Serializable {
      */
     DataChannel getChannel();
 
+    QueryCache getQueryCache();
+    
     /**
      * Returns <code>true</code> if there are any modified, deleted or new
      * objects registered with this ObjectContext, <code>false</code> otherwise.

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/DataContextQueryAction.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/DataContextQueryAction.java
@@ -31,6 +31,7 @@ import org.apache.cayenne.map.DbEntity;
 import org.apache.cayenne.query.EntityResultSegment;
 import org.apache.cayenne.query.ObjectIdQuery;
 import org.apache.cayenne.query.Query;
+import org.apache.cayenne.query.QueryMetadata;
 import org.apache.cayenne.query.RefreshQuery;
 import org.apache.cayenne.util.ListResponse;
 import org.apache.cayenne.util.ObjectContextQueryAction;
@@ -176,9 +177,8 @@ class DataContextQueryAction extends ObjectContextQueryAction {
             Query cachedQuery = refreshQuery.getQuery();
             if (cachedQuery != null) {
 
-                String cacheKey = cachedQuery
-                        .getMetaData(context.getEntityResolver())
-                        .getCacheKey();
+                QueryMetadata cacheKey = cachedQuery
+                        .getMetaData(context.getEntityResolver());
                 context.getQueryCache().remove(cacheKey);
 
                 this.response = context.performGenericQuery(cachedQuery);

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/DataDomainQueryAction.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/DataDomainQueryAction.java
@@ -344,7 +344,7 @@ class DataDomainQueryAction implements QueryRouter, OperationObserver {
             if (refreshQuery.getQuery() != null) {
                 Query cachedQuery = refreshQuery.getQuery();
 
-                String cacheKey = cachedQuery.getMetaData(context.getEntityResolver()).getCacheKey();
+                QueryMetadata cacheKey = cachedQuery.getMetaData(context.getEntityResolver());
                 context.getQueryCache().remove(cacheKey);
 
                 this.response = domain.onQuery(context, cachedQuery);

--- a/cayenne-server/src/main/java/org/apache/cayenne/cache/NestedQueryCache.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/cache/NestedQueryCache.java
@@ -18,10 +18,11 @@
  ****************************************************************/
 package org.apache.cayenne.cache;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.apache.cayenne.query.QueryMetadata;
 import org.apache.cayenne.query.QueryMetadataProxy;
-
-import java.util.List;
 
 /**
  * A {@link QueryCache} wrapper that introduces a key namespace on top of a
@@ -97,8 +98,8 @@ public class NestedQueryCache implements QueryCache {
      * Removes an entry for key in the current namespace.
      */
     @Override
-    public void remove(String key) {
-        delegate.remove(qualifiedKey(key));
+    public void remove(QueryMetadata metadata) {
+        delegate.remove(qualifiedMetadata(metadata));
     }
 
     /**
@@ -126,4 +127,16 @@ public class NestedQueryCache implements QueryCache {
             }
         };
     }
+
+	@Override
+	public void clearLocalCache(Optional<String> namespace) {
+		// ignore passed in namespace
+		delegate.clearLocalCache(Optional.of(this.namespace));
+	}
+
+	@Override
+	public List<String> debugListCacheKeys() {
+		return delegate.debugListCacheKeys();
+	}
+
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/cache/QueryCache.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/cache/QueryCache.java
@@ -55,9 +55,19 @@ public interface QueryCache {
     void put(QueryMetadata metadata, List results);
 	
     /**
+     * Removes a single entry from cache.<br>
+     * @deprecated since 4.1 - use {@link #remove(QueryMetadata)} instead.
+     */
+    @Deprecated
+    void remove(String key);
+
+    /**
      * Removes a single query result from the cache that matches the given metadata.
      * The metadata can be obtained like so: 
-     * <pre>query.getMetaData(context.getEntityResolver())</pre>
+     * <p>
+     * <code>query.getMetaData(objectContext.getEntityResolver())</code>
+     * 
+     * @since 4.1
      */
     void remove(QueryMetadata metadata);
 
@@ -89,10 +99,8 @@ public interface QueryCache {
     
     /**
      * Clears all entries in the LOCAL cache.
-     * @param namespace this parameter is for internal use only - client should always pass Optional.empty()
+     * @param namespace this parameter is for internal use only - clients should always pass Optional.empty()
      */
 	void clearLocalCache(Optional<String> namespace);
-	
-	List<String> debugListCacheKeys();
 
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/cache/QueryCache.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/cache/QueryCache.java
@@ -21,6 +21,7 @@ package org.apache.cayenne.cache;
 import org.apache.cayenne.query.QueryMetadata;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Defines API of a cache that stores query results.
@@ -29,6 +30,7 @@ import java.util.List;
  */
 public interface QueryCache {
 
+	
     /**
      * Returns a cached query result for the given QueryMetadata or null if the result is
      * not cached or is expired.
@@ -51,11 +53,13 @@ public interface QueryCache {
 
     @SuppressWarnings("rawtypes")
     void put(QueryMetadata metadata, List results);
-
+	
     /**
-     * Removes a single entry from cache.
+     * Removes a single query result from the cache that matches the given metadata.
+     * The metadata can be obtained like so: 
+     * <pre>query.getMetaData(context.getEntityResolver())</pre>
      */
-    void remove(String key);
+    void remove(QueryMetadata metadata);
 
     /**
      * Removes a group of entries identified by group key. Note that depending on
@@ -65,7 +69,7 @@ public interface QueryCache {
      * will not change after calling this method.
      */
     void removeGroup(String groupKey);
-
+    
     /**
      * Removes a group of entries identified by group key.
      * Can be used if cache provider supports strictly typed caches.
@@ -82,4 +86,13 @@ public interface QueryCache {
      */
     @Deprecated
     void clear();
+    
+    /**
+     * Clears all entries in the LOCAL cache.
+     * @param namespace this parameter is for internal use only - client should always pass Optional.empty()
+     */
+	void clearLocalCache(Optional<String> namespace);
+	
+	List<String> debugListCacheKeys();
+
 }

--- a/cayenne-server/src/test/java/org/apache/cayenne/cache/MockQueryCache.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/cache/MockQueryCache.java
@@ -42,6 +42,9 @@ public class MockQueryCache implements QueryCache {
     public void put(QueryMetadata metadata, List results) {
     }
 
+    public void remove(String key) {
+    }
+    
     public void remove(QueryMetadata metadata) {
     }
 
@@ -55,14 +58,9 @@ public class MockQueryCache implements QueryCache {
     public int size() {
         return 0;
     }
-    
-	@Override
-	public void clearLocalCache(Optional<String> namespace) {
-	}
 
-	@Override
-	public List<String> debugListCacheKeys() {
-		return Collections.emptyList();
-	}
+    @Override
+    public void clearLocalCache(Optional<String> namespace) {
+    }
 
 }

--- a/cayenne-server/src/test/java/org/apache/cayenne/cache/MockQueryCache.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/cache/MockQueryCache.java
@@ -18,8 +18,12 @@
  ****************************************************************/
 package org.apache.cayenne.cache;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
+import org.apache.cayenne.query.QueryCacheStrategy;
 import org.apache.cayenne.query.QueryMetadata;
 
 public class MockQueryCache implements QueryCache {
@@ -38,7 +42,7 @@ public class MockQueryCache implements QueryCache {
     public void put(QueryMetadata metadata, List results) {
     }
 
-    public void remove(String key) {
+    public void remove(QueryMetadata metadata) {
     }
 
     public void removeGroup(String groupKey) {
@@ -51,4 +55,14 @@ public class MockQueryCache implements QueryCache {
     public int size() {
         return 0;
     }
+    
+	@Override
+	public void clearLocalCache(Optional<String> namespace) {
+	}
+
+	@Override
+	public List<String> debugListCacheKeys() {
+		return Collections.emptyList();
+	}
+
 }

--- a/cayenne-web/src/main/java/org/apache/cayenne/configuration/web/StatelessContextRequestHandler.java
+++ b/cayenne-web/src/main/java/org/apache/cayenne/configuration/web/StatelessContextRequestHandler.java
@@ -18,6 +18,8 @@
  ****************************************************************/
 package org.apache.cayenne.configuration.web;
 
+import java.util.Optional;
+
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 
@@ -67,6 +69,10 @@ public class StatelessContextRequestHandler implements RequestHandler {
 
     public void requestEnd(ServletRequest request, ServletResponse response) {
         CayenneRuntime.bindThreadInjector(null);
+        ObjectContext context = BaseContext.getThreadObjectContext();
+        if (context != null) {
+        	((BaseContext)context).getQueryCache().clearLocalCache(Optional.empty());
+        }
         BaseContext.bindThreadObjectContext(null);
     }
 


### PR DESCRIPTION
Added getQueryCache to the ObjectContext interface since this is already implemented by BaseContext anyway and makes accessing the cache much easier.

Revised signature for QueryCache.remove(String) to be remove(QueryMetadata) to increase understandability. It was never clear how to use this method before.

Added QueryCache.clearLocalCache method. This is now called automatically at the end of the request-response loop in StatelessContextRequestHandler and by BaseContext.finalize. This will prevent memory leaking from locally cached data in cases where the cache is not configured to expire entries based on time.

Added QueryCache.debugListCacheKeys method to list all keys (prefixed by cache group) in the cache for debugging purposes.