### PR TITLE
If the transformer returns PRUNED_NODE, this cast fails...

### DIFF
--- a/cayenne-server/src/main/java/org/apache/cayenne/exp/Expression.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/exp/Expression.java
@@ -620,7 +620,7 @@ public abstract class Expression implements Serializable, XMLSerializable {
 		}
 
 		// all the children are processed, only now transform this copy
-		return (transformer != null) ? (Expression) transformer.apply(copy) : copy;
+		return (transformer != null) ? transformer.apply(copy) : copy;
 	}
 
 	/**


### PR DESCRIPTION
…which isn't correct. This prohibits transformers from proactively pruning nodes.