### PR TITLE
CAY-2476 Modeller: Fixed wrong bihaviour of code generation dialog

### DIFF
--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/codegen/CustomModeController.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/codegen/CustomModeController.java
@@ -175,19 +175,20 @@ public class CustomModeController extends GeneratorController {
 	public Collection<ClassGenerationAction> createGenerator() {
 
 		Collection<ClassGenerationAction> generators = super.createGenerator();
+		boolean selected = view.getPairs().isSelected();
 
 		String superKey = Objects.requireNonNull(view.getSuperclassTemplate().getSelectedItem()).toString();
-		String superTemplate = templateManager.getTemplatePath(superKey);
+		String superTemplate = selected ? templateManager.getTemplatePath(superKey) : ClassGenerationAction.SINGLE_CLASS_TEMPLATE;
 
 		String subKey = Objects.requireNonNull(view.getSubclassTemplate().getSelectedItem()).toString();
-		String subTemplate = templateManager.getTemplatePath(subKey);
+		String subTemplate = selected ? templateManager.getTemplatePath(subKey) : null;
 
 		for (ClassGenerationAction generator : generators) {
 			generator.setSuperTemplate(superTemplate);
 			generator.setTemplate(subTemplate);
 			generator.setOverwrite(view.getOverwrite().isSelected());
 			generator.setUsePkgPath(view.getUsePackagePath().isSelected());
-			generator.setMakePairs(view.getPairs().isSelected());
+			generator.setMakePairs(selected);
 			generator.setCreatePropertyNames(view.getCreatePropertyNames().isSelected());
 
 			if (!Util.isEmptyString(view.getOutputPattern().getText())) {

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/codegen/CustomModePanel.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/codegen/CustomModePanel.java
@@ -54,9 +54,11 @@ public class CustomModePanel extends GeneratorControllerPanel {
         this.manageTemplatesLink = new ActionLink("Customize Templates...");
         manageTemplatesLink.setFont(manageTemplatesLink.getFont().deriveFont(10f));
 
+        updateClassTemplatesSelection();
         pairs.addChangeListener(e -> {
-            superclassTemplate.setEnabled(pairs.isSelected());
-            overwrite.setEnabled(!pairs.isSelected());
+            boolean selected = pairs.isSelected();
+            updateClassTemplatesSelection();
+            overwrite.setEnabled(!selected);
         });
 
         // assemble
@@ -129,5 +131,10 @@ public class CustomModePanel extends GeneratorControllerPanel {
 
     public JCheckBox getCreatePropertyNames() {
         return createPropertyNames;
+    }
+
+    private void updateClassTemplatesSelection() {
+        superclassTemplate.setEnabled(pairs.isSelected());
+        subclassTemplate.setEnabled(pairs.isSelected());
     }
 }

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/codegen/CustomModePanel.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/codegen/CustomModePanel.java
@@ -54,13 +54,6 @@ public class CustomModePanel extends GeneratorControllerPanel {
         this.manageTemplatesLink = new ActionLink("Customize Templates...");
         manageTemplatesLink.setFont(manageTemplatesLink.getFont().deriveFont(10f));
 
-        updateClassTemplatesSelection();
-        pairs.addChangeListener(e -> {
-            boolean selected = pairs.isSelected();
-            updateClassTemplatesSelection();
-            overwrite.setEnabled(!selected);
-        });
-
         // assemble
         FormLayout layout = new FormLayout(
                 "right:77dlu, 1dlu, fill:100:grow, 1dlu, left:80dlu, 1dlu", "");
@@ -133,8 +126,4 @@ public class CustomModePanel extends GeneratorControllerPanel {
         return createPropertyNames;
     }
 
-    private void updateClassTemplatesSelection() {
-        superclassTemplate.setEnabled(pairs.isSelected());
-        subclassTemplate.setEnabled(pairs.isSelected());
-    }
 }


### PR DESCRIPTION
Added update state of Superclass and Subclass Templates dropdowns on dialog open. Added disabling Subclass Template dropdown and added using singleclass.vm template when 'Make Pairs' checkbox is nod checked.