### PR TITLE
Cayenne 4.2.M1 testing

### DIFF
--- a/cayenne-ant/src/main/java/org/apache/cayenne/tools/CayenneGeneratorTask.java
+++ b/cayenne-ant/src/main/java/org/apache/cayenne/tools/CayenneGeneratorTask.java
@@ -27,6 +27,7 @@ import org.apache.cayenne.dbsync.reverse.configuration.ToolsModule;
 import org.apache.cayenne.di.Injector;
 import org.apache.cayenne.gen.ArtifactsGenerationMode;
 import org.apache.cayenne.gen.CgenConfiguration;
+import org.apache.cayenne.gen.CgenModule;
 import org.apache.cayenne.gen.ClassGenerationAction;
 import org.apache.cayenne.gen.ClassGenerationActionFactory;
 import org.apache.cayenne.gen.ClientClassGenerationAction;
@@ -104,6 +105,7 @@ public class CayenneGeneratorTask extends CayenneTask {
         validateAttributes();
 
         injector = new ToolsInjectorBuilder()
+                .addModule(new CgenModule())
                 .addModule(new ToolsModule(LoggerFactory.getLogger(CayenneGeneratorTask.class)))
                 .create();
 

--- a/cayenne-joda/src/test/java/org/apache/cayenne/joda/JodaModuleIT.java
+++ b/cayenne-joda/src/test/java/org/apache/cayenne/joda/JodaModuleIT.java
@@ -61,6 +61,11 @@ public class JodaModuleIT {
         assertNotNull(timestamp);
         assertEquals(DateTime.class, timestamp.getClass());
         assertEquals(dateTime, timestamp);
+        
+        testRead = ObjectSelect.query(DateTimeTestEntity.class)
+        	.where(DateTimeTestEntity.TIMESTAMP.between(dateTime, dateTime))
+        	.selectOne(context);
+        assertNotNull(testRead);
     }
 
     @Test

--- a/cayenne-joda/src/test/java/org/apache/cayenne/joda/db/auto/_DateTimeTestEntity.java
+++ b/cayenne-joda/src/test/java/org/apache/cayenne/joda/db/auto/_DateTimeTestEntity.java
@@ -6,6 +6,7 @@ import java.io.ObjectOutputStream;
 
 import org.apache.cayenne.BaseDataObject;
 import org.apache.cayenne.exp.property.BaseProperty;
+import org.apache.cayenne.exp.property.DateProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
 import org.joda.time.DateTime;
 
@@ -21,7 +22,7 @@ public abstract class _DateTimeTestEntity extends BaseDataObject {
 
     public static final String ID_PK_COLUMN = "ID";
 
-    public static final BaseProperty<DateTime> TIMESTAMP = PropertyFactory.createBase("timestamp", DateTime.class);
+    public static final DateProperty<DateTime> TIMESTAMP = PropertyFactory.createDate("timestamp", DateTime.class);
 
     protected DateTime timestamp;
 


### PR DESCRIPTION
I'm trying out 4.2.M1 snapshot in order to provide testing feedback. 

These changes aren't really meant to be applied directly, but to provide feedback into the issues I'm having.

1) Joda time support is lacking in the class generation templates. I understand this is deprecated now, but since it hasn't been removed yet it should still work. Thinking ahead to the future there will need to a way for third parties to integrate Joda support into cayenne without having to create a hard fork. This doesn't appear to currently be possible - at least I don't know how to provide an additional Module to cgen via ant that could provide PropertyDescriptorCreator changes.

2) I need to have a method like PropertyUtils.propertyTypeDefinition exposed so I can utilize it in my templates. The refactoring to move logic into PropertyUtils makes the templates clean and simple, but users need access to smaller pieces as well. 

3) Using "between" expressions on Joda time DateProperty instances fails. This is a bug that still needs to be fixed. I don't know where to start on this one.

4) Ant's cgen task was completely broken. I doubt this is the correct fix, but it does get it running again.

