### PR TITLE
Cgen - Avoid class loader issues causing missing classes

### DIFF
--- a/cayenne-cgen/src/main/java/org/apache/cayenne/gen/PropertyUtils.java
+++ b/cayenne-cgen/src/main/java/org/apache/cayenne/gen/PropertyUtils.java
@@ -362,17 +362,28 @@ public class PropertyUtils {
     }
 
     private PropertyDescriptor getPropertyDescriptor(String attrType) {
+    	Class<?> type = null;
         try {
-            Class<?> type = adhocObjectFactory.getJavaClass(attrType);
-            for(PropertyDescriptorCreator creator : propertyList) {
-                Optional<PropertyDescriptor> optionalPropertyDescriptor = creator.apply(type);
-                if(optionalPropertyDescriptor.isPresent()) {
-                    return optionalPropertyDescriptor.get();
-                }
-            }
-        } catch (DIRuntimeException ex) {
-            return PropertyDescriptor.defaultDescriptor();
+            type = adhocObjectFactory.getJavaClass(attrType);
+        } catch (DIRuntimeException ex) {}
+        
+        if (type == null) {
+        	try {
+				type = Class.forName(attrType); // retry with default class loader
+			} catch (ClassNotFoundException ex) {
+				System.out.println("WARN: Class not found: " + attrType);
+			}
         }
+        
+        if (type != null) {
+	        for(PropertyDescriptorCreator creator : propertyList) {
+	            Optional<PropertyDescriptor> optionalPropertyDescriptor = creator.apply(type);
+	            if(optionalPropertyDescriptor.isPresent()) {
+	                return optionalPropertyDescriptor.get();
+	            }
+	        }
+        }
+        
         return PropertyDescriptor.defaultDescriptor();
     }
 }

--- a/cayenne-cgen/src/main/java/org/apache/cayenne/gen/PropertyUtils.java
+++ b/cayenne-cgen/src/main/java/org/apache/cayenne/gen/PropertyUtils.java
@@ -365,13 +365,16 @@ public class PropertyUtils {
     	Class<?> type = null;
         try {
             type = adhocObjectFactory.getJavaClass(attrType);
-        } catch (DIRuntimeException ex) {}
+        } catch (DIRuntimeException ex) {
+			System.out.println("WARN: Class not found by adhoc factory: " + attrType);
+        }
         
         if (type == null) {
         	try {
+        		System.out.println("Default classloader: " + getClass().getClassLoader());
 				type = Class.forName(attrType); // retry with default class loader
 			} catch (ClassNotFoundException ex) {
-				System.out.println("WARN: Class not found: " + attrType);
+				System.out.println("WARN: Class not found by default classloader: " + attrType);
 			}
         }
         

--- a/cayenne-di/src/main/java/org/apache/cayenne/di/spi/DefaultAdhocObjectFactory.java
+++ b/cayenne-di/src/main/java/org/apache/cayenne/di/spi/DefaultAdhocObjectFactory.java
@@ -18,6 +18,9 @@
  ****************************************************************/
 package org.apache.cayenne.di.spi;
 
+import java.net.URLClassLoader;
+import java.util.Arrays;
+
 import org.apache.cayenne.di.AdhocObjectFactory;
 import org.apache.cayenne.di.ClassLoaderManager;
 import org.apache.cayenne.di.DIRuntimeException;
@@ -86,7 +89,13 @@ public class DefaultAdhocObjectFactory implements AdhocObjectFactory {
         }
 
         ClassLoader classLoader = classLoaderManager.getClassLoader(className.replace('.', '/'));
-
+        if (classLoader instanceof URLClassLoader) {
+        	System.out.println("Classloader for " + className + ": " + classLoader + "[" + 
+        			Arrays.toString(((URLClassLoader)classLoader).getURLs()) + "]");
+        } else {
+        	System.out.println("Classloader for " + className + ": " + classLoader);
+        }
+        
         // use custom logic on failure only, assuming primitives and arrays are
         // not that common
         try {


### PR DESCRIPTION
Cgen - Avoid class loader issues causing missing classes; don't swallow missing class errors completely

It took me almost a full day to find where an exception was being swallowed which would have indicated the problem here. Whatever class loader is being used by Cgen (AdhocObjectFactory) is not picking up classes that are available in the default class loader - namely all the Joda classes, like org.joda.time.LocalDateTime.

This change will make it fallback to using the default class loader if a class is not found, and will log a single line WARNing if the class isn't found by either class loader.