### PR TITLE
Add failing test for transient insert and delete of a to-many relation

### DIFF
--- a/cayenne-server/src/test/java/org/apache/cayenne/exp/ExpressionIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/exp/ExpressionIT.java
@@ -23,6 +23,7 @@ import org.apache.cayenne.ObjectContext;
 import org.apache.cayenne.access.DataContext;
 import org.apache.cayenne.configuration.server.ServerRuntime;
 import org.apache.cayenne.di.Inject;
+import org.apache.cayenne.query.ObjectSelect;
 import org.apache.cayenne.query.SelectQuery;
 import org.apache.cayenne.testdo.testmap.Artist;
 import org.apache.cayenne.testdo.testmap.Painting;
@@ -125,4 +126,14 @@ public class ExpressionIT extends ServerCase {
 		assertNull(e4.first(paintingList));
 	}
 
+    @Test
+	public void testLessThanNull() {
+		Artist a1 = context.newObject(Artist.class);
+		a1.setArtistName("Picasso");
+		context.commitChanges();
+		
+		List<Artist> artists = ObjectSelect.query(Artist.class, Artist.ARTIST_NAME.lt((String)null)).select(context);
+		assertTrue("Less than 'NULL' never matches anything", artists.isEmpty());
+    }
+    
 }


### PR DESCRIPTION
This is a test failure I'm seeing with the recent changes for 4.2. This isn't the right place to add this unit test, but it does demonstrate the problem.