### PR TITLE
Allow optionally using a local query cache that is separate

### DIFF
--- a/cayenne-server/src/main/java/org/apache/cayenne/BaseContext.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/BaseContext.java
@@ -98,6 +98,7 @@ public abstract class BaseContext implements ObjectContext {
 	// registry
 	protected transient DataChannel channel;
 	protected transient QueryCache queryCache;
+	protected transient QueryCache localQueryCache;
 	protected transient EntityResolver entityResolver;
 
 	protected boolean validatingObjectsOnCommit = true;
@@ -469,16 +470,40 @@ public abstract class BaseContext implements ObjectContext {
 	@Override
 	public abstract Collection<?> uncommittedObjects();
 
+	/**
+	 * Used for storing cached query results available to all ObjectContexts.
+	 */
 	public QueryCache getQueryCache() {
 		attachToRuntimeIfNeeded();
 		return queryCache;
 	}
 
 	/**
-	 * Sets a QueryCache to be used for storing cached query results.
+	 * Sets a QueryCache to be used for storing cached query results available to all ObjectContexts.
 	 */
 	public void setQueryCache(QueryCache queryCache) {
 		this.queryCache = queryCache;
+	}
+	
+	/**
+	 * Used for storing cached query results available only to this ObjectContext.
+	 * By default the local query cache and the shared query cache will use the same underlying storage.
+	 * 
+	 * @since 4.2
+	 */
+	public QueryCache getLocalQueryCache() {
+		attachToRuntimeIfNeeded();
+		return localQueryCache != null ? localQueryCache : getQueryCache();
+	}
+
+	/**
+	 * Sets a QueryCache to be used for storing cached query results available only to this ObjectContext.
+	 * By default the local query cache and the shared query cache will use the same underlying storage.
+	 * 
+	 * @since 4.2
+	 */
+	public void setLocalQueryCache(QueryCache queryCache) {
+		this.localQueryCache = queryCache;
 	}
 
 	/**

--- a/cayenne-server/src/main/java/org/apache/cayenne/util/ObjectContextQueryAction.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/util/ObjectContextQueryAction.java
@@ -360,7 +360,7 @@ public abstract class ObjectContextQueryAction {
             return !DONE;
         }
 
-        QueryCache queryCache = getQueryCache();
+        QueryCache queryCache = getLocalQueryCache();
         QueryCacheEntryFactory factory = getCacheObjectFactory();
 
         if (cache) {
@@ -384,6 +384,13 @@ public abstract class ObjectContextQueryAction {
      */
     protected QueryCache getQueryCache() {
         return ((BaseContext) actingContext).getQueryCache();
+    }
+    
+    /**
+     * @since 4.2
+     */
+    protected QueryCache getLocalQueryCache() {
+        return ((BaseContext) actingContext).getLocalQueryCache();
     }
 
     /**


### PR DESCRIPTION
Allow optionally using a local query cache that is separate from the shared query cache.

The local query cache can be customized by creating a custom DataContextFactory.

A separate cache can prevent memory leaks from occurring if you used non-expiring cache
groups (like the default cache group perhaps) along with the local cache which wasn't
intuitive if you expected the lifetime of the cache to match the lifetime of the ObjectContext.