### PR TITLE
Added failing test for prefetched relationships not preserving pendin…

### DIFF
--- a/cayenne-server/src/test/java/org/apache/cayenne/access/JointPrefetchIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/access/JointPrefetchIT.java
@@ -29,6 +29,7 @@ import org.apache.cayenne.di.Inject;
 import org.apache.cayenne.exp.Expression;
 import org.apache.cayenne.map.ObjAttribute;
 import org.apache.cayenne.map.ObjEntity;
+import org.apache.cayenne.query.ObjectSelect;
 import org.apache.cayenne.query.SQLSelect;
 import org.apache.cayenne.query.SQLTemplate;
 import org.apache.cayenne.query.SelectQuery;
@@ -448,5 +449,41 @@ public class JointPrefetchIT extends ServerCase {
             assertNotNull(g1);
             assertEquals("G1", g1.readProperty("galleryName"));
         });
+    }
+    
+    @Test
+    public void testJointPrefetchPreservesPendingToOneArcDiff() throws Exception {
+        createJointPrefetchDataSet();
+
+    	Artist artist = ObjectSelect.query(Artist.class)
+        		.where(Artist.ARTIST_NAME.eq("artist1"))
+        		.selectFirst(context);
+    	
+    	Painting painting = ObjectSelect.query(Painting.class)
+    		.where(Painting.PAINTING_TITLE.eq("P_artist21"))
+    		.selectFirst(context);
+        
+    	// create pending arc diff
+    	painting.setToArtist(artist); 
+    	
+    	// refresh the painting (should preserve pending arc diff)
+    	ObjectSelect.query(Painting.class)
+			.where(Painting.PAINTING_TITLE.eq("P_artist21"))
+			.selectFirst(context);
+    	assertEquals(artist, painting.getToArtist());
+
+    	// refresh the artist (should preserve pending arc diff)
+    	ObjectSelect.query(Artist.class)
+			.where(Artist.ARTIST_NAME.eq("artist1"))
+			.selectFirst(context);
+    	assertEquals(artist, painting.getToArtist());
+
+    	// refresh them both together (should preserve pending arc diff)
+    	ObjectSelect.query(Painting.class)
+    		.where(Painting.PAINTING_TITLE.eq("P_artist21"))
+    		.prefetch(Painting.TO_ARTIST.joint())
+    		.selectFirst(context);
+
+    	assertEquals(artist, painting.getToArtist());
     }
 }


### PR DESCRIPTION
Added failing test for prefetched relationships not preserving pending changes (arc diffs)

The last assert (only) fails, when the prefetch is included in the query.

