### PR TITLE
CAY-2604 Specialization of property API for PK

### DIFF
--- a/cayenne-cgen/src/main/java/org/apache/cayenne/gen/PropertyUtils.java
+++ b/cayenne-cgen/src/main/java/org/apache/cayenne/gen/PropertyUtils.java
@@ -32,11 +32,13 @@ import org.apache.cayenne.dba.TypesMapping;
 import org.apache.cayenne.di.AdhocObjectFactory;
 import org.apache.cayenne.di.DIRuntimeException;
 import org.apache.cayenne.exp.ExpressionFactory;
+import org.apache.cayenne.exp.property.BaseIdProperty;
 import org.apache.cayenne.exp.property.BaseProperty;
 import org.apache.cayenne.exp.property.DateProperty;
 import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.ListProperty;
 import org.apache.cayenne.exp.property.MapProperty;
+import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.NumericProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
 import org.apache.cayenne.exp.property.SetProperty;
@@ -69,6 +71,8 @@ public class PropertyUtils {
         FACTORY_METHODS.put(ListProperty.class.getName(), "createList");
         FACTORY_METHODS.put(SetProperty.class.getName(), "createSet");
         FACTORY_METHODS.put(MapProperty.class.getName(), "createMap");
+        FACTORY_METHODS.put(NumericIdProperty.class.getName(), "createNumericId");
+        FACTORY_METHODS.put(BaseIdProperty.class.getName(), "createBaseId");
     }
 
     private static final List<Class<?>> JAVA_DATE_TYPES = Arrays.asList(
@@ -112,14 +116,13 @@ public class PropertyUtils {
             if(!entityUtils.declaresDbAttribute(attribute)) {
                 String javaBySqlType = TypesMapping.getJavaBySqlType(attribute.getType());
                 importUtils.addType(javaBySqlType);
-                importUtils.addType(getPropertyTypeForType(javaBySqlType));
+                importUtils.addType(getPkPropertyTypeForType(javaBySqlType));
                 needToCreatePK = true;
             }
         }
 
         if(needToCreatePK) {
             importUtils.addType(PropertyFactory.class.getName());
-            importUtils.addType(ExpressionFactory.class.getName());
         }
     }
 
@@ -163,20 +166,21 @@ public class PropertyUtils {
         }
     }
 
-    public String propertyDefinition(DbAttribute attribute) throws ClassNotFoundException {
+    public String propertyDefinition(ObjEntity entity, DbAttribute attribute) throws ClassNotFoundException {
         StringUtils utils = StringUtils.getInstance();
 
         String attributeType = TypesMapping.getJavaBySqlType(attribute.getType());
-        String propertyType = getPropertyTypeForType(TypesMapping.getJavaBySqlType(attribute.getType()));
+        String propertyType = getPkPropertyTypeForType(TypesMapping.getJavaBySqlType(attribute.getType()));
         String propertyFactoryMethod = factoryMethodForPropertyType(propertyType);
         attributeType = importUtils.formatJavaType(attributeType, false);
 
-        return String.format("public static final %s<%s> %s = PropertyFactory.%s(ExpressionFactory.dbPathExp(\"%s\"), %s.class);",
+        return String.format("public static final %s<%s> %s = PropertyFactory.%s(\"%s\", \"%s\", %s.class);",
                 importUtils.formatJavaType(propertyType),
                 attributeType,
                 utils.capitalizedAsConstant(attribute.getName()) + PK_PROPERTY_SUFFIX,
                 propertyFactoryMethod,
                 attribute.getName(),
+                entity.getName(),
                 attributeType
         );
     }
@@ -331,25 +335,12 @@ public class PropertyUtils {
         return FACTORY_METHODS.get(propertyType);
     }
 
-    private String getPropertyTypeForType(String attributeType) throws ClassNotFoundException {
-        if(TypesMapping.JAVA_BYTES.equals(attributeType)) {
-            return BaseProperty.class.getName();
-        }
-
+    private String getPkPropertyTypeForType(String attributeType) throws ClassNotFoundException {
         Class<?> javaClass = Class.forName(attributeType);
         if (Number.class.isAssignableFrom(javaClass)) {
-            return NumericProperty.class.getName();
+            return NumericIdProperty.class.getName();
         }
-
-        if (CharSequence.class.isAssignableFrom(javaClass)) {
-            return StringProperty.class.getName();
-        }
-
-        if (JAVA_DATE_TYPES.contains(javaClass)) {
-            return DateProperty.class.getName();
-        }
-
-        return BaseProperty.class.getName();
+        return BaseIdProperty.class.getName();
     }
 
     private String getPropertyTypeForJavaClass(ObjRelationship relationship) {

--- a/cayenne-cgen/src/main/resources/templates/v4_1/singleclass.vm
+++ b/cayenne-cgen/src/main/resources/templates/v4_1/singleclass.vm
@@ -73,7 +73,7 @@ public#if("true" == "${object.isAbstract()}") abstract#end class ${subClassName}
     #foreach( $idAttr in ${object.DbEntity.PrimaryKeys} )
         #if( $createPKProperties && !${entityUtils.declaresDbAttribute($idAttr)})
             #set ( $type = "$importUtils.dbAttributeToJavaType($idAttr)")
-    $propertyUtils.propertyDefinition($idAttr)
+    $propertyUtils.propertyDefinition($object, $idAttr)
         #else
     public static final String ${stringUtils.capitalizedAsConstant($idAttr.Name)}_PK_COLUMN = "${idAttr.Name}";
         #end

--- a/cayenne-cgen/src/main/resources/templates/v4_1/superclass.vm
+++ b/cayenne-cgen/src/main/resources/templates/v4_1/superclass.vm
@@ -81,7 +81,7 @@ public abstract class ${superClassName} extends ${baseClassName} {
     #foreach( $idAttr in ${object.DbEntity.PrimaryKeys} )
         #if( $createPKProperties && !${entityUtils.declaresDbAttribute($idAttr)})
             #set ( $type = "$importUtils.dbAttributeToJavaType($idAttr)")
-    $propertyUtils.propertyDefinition($idAttr)
+    $propertyUtils.propertyDefinition($object, $idAttr)
         #end
     public static final String ${stringUtils.capitalizedAsConstant($idAttr.Name)}_PK_COLUMN = "${idAttr.Name}";
     #end

--- a/cayenne-server/src/main/java/org/apache/cayenne/BaseDataObject.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/BaseDataObject.java
@@ -199,6 +199,14 @@ public abstract class BaseDataObject extends PersistentObject implements DataObj
     }
 
     Object readSimpleProperty(String property) {
+        // Special ID property
+        if(property.startsWith(Cayenne.PROPERTY_ID)) {
+            if(property.equals(Cayenne.PROPERTY_ID)) {
+                return Cayenne.pkForObject(this);
+            } else {
+                return getObjectId().getIdSnapshot().get(property.substring(Cayenne.PROPERTY_ID.length() + 1));
+            }
+        }
 
         // side effect - resolves HOLLOW object
         Object object = readProperty(property);
@@ -373,7 +381,7 @@ public abstract class BaseDataObject extends PersistentObject implements DataObj
             return;
         }
 
-        getObjectContext().propertyChanged(this, relationshipName, oldTarget, value);
+        objectContext.propertyChanged(this, relationshipName, oldTarget, value);
 
         if (setReverse) {
             // unset old reverse relationship

--- a/cayenne-server/src/main/java/org/apache/cayenne/Cayenne.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/Cayenne.java
@@ -55,6 +55,8 @@ public class Cayenne {
      */
     final static String PROPERTY_COLLECTION_SIZE = "@size";
 
+    public final static String PROPERTY_ID = "@id";
+
     /**
      * Returns mapped ObjEntity for object. If an object is transient or is not
      * mapped returns null.
@@ -140,7 +142,15 @@ public class Cayenne {
         if (o == null) {
             return null;
         } else if (o instanceof DataObject) {
-            return ((DataObject) o).readNestedProperty(path);
+            DataObject dataObject = (DataObject) o;
+            if(path.startsWith(PROPERTY_ID)) {
+                if(path.equals(PROPERTY_ID)) {
+                    return Cayenne.pkForObject(dataObject);
+                } else {
+                    return extractObjectId(dataObject).get(path.substring(PROPERTY_ID.length() + 1));
+                }
+            }
+            return dataObject.readNestedProperty(path);
         } else if (o instanceof Collection<?>) {
 
             // This allows people to put @size at the end of a property

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/translator/select/DbPathProcessor.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/translator/select/DbPathProcessor.java
@@ -19,6 +19,7 @@
 
 package org.apache.cayenne.access.translator.select;
 
+import org.apache.cayenne.Cayenne;
 import org.apache.cayenne.map.DbAttribute;
 import org.apache.cayenne.map.DbEntity;
 import org.apache.cayenne.map.DbJoin;
@@ -61,6 +62,15 @@ class DbPathProcessor extends PathProcessor<DbEntity> {
         }
 
         throw new IllegalStateException("Unable to resolve path: " + currentDbPath.toString() + "." + next);
+    }
+
+    @Override
+    protected void processId(String id) {
+        if(id.equals(Cayenne.PROPERTY_ID)) {
+            attributes.addAll(entity.getPrimaryKeys());
+        } else {
+            attributes.add(entity.getAttribute(id.substring(Cayenne.PROPERTY_ID.length() + 1)));
+        }
     }
 
     @Override

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/translator/select/ObjPathProcessor.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/translator/select/ObjPathProcessor.java
@@ -19,6 +19,8 @@
 
 package org.apache.cayenne.access.translator.select;
 
+import org.apache.cayenne.Cayenne;
+import org.apache.cayenne.map.DbAttribute;
 import org.apache.cayenne.map.DbRelationship;
 import org.apache.cayenne.map.EmbeddedAttribute;
 import org.apache.cayenne.map.JoinType;
@@ -61,6 +63,20 @@ class ObjPathProcessor extends PathProcessor<ObjEntity> {
 
         throw new IllegalStateException("Unable to resolve path: " + currentDbPath.toString()
                 + " (unknown '" + next + "' component)");
+    }
+
+    @Override
+    protected void processId(String id) {
+        if(id.equals(Cayenne.PROPERTY_ID)) {
+            for (DbAttribute attribute : entity.getDbEntity().getPrimaryKeys()) {
+                attributes.add(attribute);
+                attributePaths.add(currentDbPath.toString());
+            }
+        } else {
+            DbAttribute attribute = entity.getDbEntity().getAttribute(id.substring(Cayenne.PROPERTY_ID.length() + 1));
+            attributes.add(attribute);
+            attributePaths.add(currentDbPath.toString());
+        }
     }
 
     @Override

--- a/cayenne-server/src/main/java/org/apache/cayenne/exp/property/BaseIdProperty.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/exp/property/BaseIdProperty.java
@@ -1,0 +1,57 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.exp.property;
+
+import java.util.Objects;
+
+/**
+ * @since 4.2
+ */
+public class BaseIdProperty<E> extends BaseProperty<E> implements IdProperty<E> {
+
+    private final String entityName;
+
+    private final String attributeName;
+
+    /**
+     * Constructs a new property with the given name and expression
+     *
+     * @param attribute  PK attribute name (optional, can be omitted for single PK entity)
+     * @param path       cayenne path (optional, can be omitted for  ID of the root)
+     * @param entityName name of the entity (mandatory)
+     * @param type       of the property (mandatory)
+     * @see PropertyFactory#createBaseId(String, Class)
+     */
+    protected BaseIdProperty(String attribute, String path, String entityName, Class<? super E> type) {
+        super(IdProperty.getName(attribute, path), null, type);
+        this.entityName = Objects.requireNonNull(entityName);
+        this.attributeName = attribute;
+    }
+
+    @Override
+    public String getEntityName() {
+        return entityName;
+    }
+
+    @Override
+    public String getAttributeName() {
+        return attributeName;
+    }
+}

--- a/cayenne-server/src/main/java/org/apache/cayenne/exp/property/IdProperty.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/exp/property/IdProperty.java
@@ -1,0 +1,63 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.exp.property;
+
+import java.util.Map;
+
+import org.apache.cayenne.Cayenne;
+import org.apache.cayenne.CayenneRuntimeException;
+import org.apache.cayenne.ObjectId;
+import org.apache.cayenne.exp.Expression;
+import org.apache.cayenne.exp.ExpressionFactory;
+
+/**
+ * @since 4.2
+ */
+public interface IdProperty<E> extends Property<E> {
+
+    default Expression eq(ObjectId value) {
+        if(!getEntityName().equals(value.getEntityName())) {
+            throw new CayenneRuntimeException("Can match IdProperty only with ObjectId for same entity");
+        }
+        Map<String, Object> idSnapshot = value.getIdSnapshot();
+        Object pkValue;
+        if(getAttributeName() == null) {
+            if (idSnapshot.size() > 1) {
+                throw new CayenneRuntimeException("Can't match IdProperty with compound PK");
+            }
+            pkValue = idSnapshot.values().iterator().next();
+        } else {
+            pkValue = idSnapshot.get(getAttributeName());
+            if(pkValue == null && !idSnapshot.containsKey(getAttributeName())) {
+                throw new CayenneRuntimeException("No PK attribute %s for ObjectId %s", getAttributeName(), value);
+            }
+        }
+        return ExpressionFactory.matchExp(getExpression(), pkValue);
+    }
+
+    String getEntityName();
+
+    String getAttributeName();
+
+    static String getName(String attribute, String path) {
+        String name = attribute == null ? Cayenne.PROPERTY_ID : Cayenne.PROPERTY_ID + ':' + attribute;
+        return path == null ? name : path + '.' + name;
+    }
+}

--- a/cayenne-server/src/main/java/org/apache/cayenne/exp/property/NumericIdProperty.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/exp/property/NumericIdProperty.java
@@ -1,0 +1,57 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.exp.property;
+
+import java.util.Objects;
+
+/**
+ * @since 4.2
+ */
+public class NumericIdProperty<E extends Number> extends NumericProperty<E> implements IdProperty<E> {
+
+    private final String entityName;
+
+    private final String attributeName;
+
+    /**
+     * Constructs a new property with the given name and expression
+     *
+     * @param attribute  PK attribute name (optional, can be omitted for single PK entity)
+     * @param path       cayenne path (optional, can be omitted for  ID of the root)
+     * @param entityName name of the entity (mandatory)
+     * @param type       of the property (mandatory)
+     * @see PropertyFactory#createNumericId(String, Class)
+     */
+    protected NumericIdProperty(String attribute, String path, String entityName, Class<E> type) {
+        super(IdProperty.getName(attribute, path), null, type);
+        this.entityName = Objects.requireNonNull(entityName);
+        this.attributeName = attribute;
+    }
+
+    @Override
+    public String getEntityName() {
+        return entityName;
+    }
+
+    @Override
+    public String getAttributeName() {
+        return attributeName;
+    }
+}

--- a/cayenne-server/src/main/java/org/apache/cayenne/exp/property/PropertyFactory.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/exp/property/PropertyFactory.java
@@ -372,4 +372,28 @@ public class PropertyFactory {
     public static <K, V extends Persistent> MapProperty<K, V> createMap(String name, Class<K> keyType, Class<V> entityType) {
         return createMap(name, null, keyType, entityType);
     }
+
+    public static <T> BaseIdProperty<T> createBaseId(String entityName, Class<T> propertyType) {
+        return createBaseId(null, null, entityName, propertyType);
+    }
+
+    public static <T> BaseIdProperty<T> createBaseId(String attribute, String entityName, Class<T> propertyType) {
+        return createBaseId(attribute, null, entityName, propertyType);
+    }
+
+    public static <T> BaseIdProperty<T> createBaseId(String attribute, String path, String entityName, Class<T> propertyType) {
+        return new BaseIdProperty<>(attribute, path, entityName, propertyType);
+    }
+
+    public static <T extends Number> NumericIdProperty<T> createNumericId(String entityName, Class<T> propertyType) {
+        return createNumericId(null, null, entityName, propertyType);
+    }
+
+    public static <T extends Number> NumericIdProperty<T> createNumericId(String attribute, String entityName, Class<T> propertyType) {
+        return createNumericId(attribute, null, entityName, propertyType);
+    }
+
+    public static <T extends Number> NumericIdProperty<T> createNumericId(String attribute, String path, String entityName, Class<T> propertyType) {
+        return new NumericIdProperty<>(attribute, path, entityName, propertyType);
+    }
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/exp/property/RelationshipProperty.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/exp/property/RelationshipProperty.java
@@ -58,6 +58,10 @@ public interface RelationshipProperty<E> extends Property<E> {
                 property.getType());
     }
 
+    default <T> BaseIdProperty<T> dot(BaseIdProperty<T> property) {
+        return PropertyFactory.createBaseId(property.getAttributeName(), getName(), property.getEntityName(), property.getType());
+    }
+
     /**
      * Constructs a new property path by appending the argument to the existing property separated by a dot.
      *
@@ -69,6 +73,10 @@ public interface RelationshipProperty<E> extends Property<E> {
         return PropertyFactory.createNumeric(path,
                 PropertyUtils.buildExp(path, getExpression().getPathAliases()),
                 property.getType());
+    }
+
+    default <T extends Number> NumericIdProperty<T> dot(NumericIdProperty<T> property) {
+        return PropertyFactory.createNumericId(property.getAttributeName(), getName(), property.getEntityName(), property.getType());
     }
 
     /**

--- a/cayenne-server/src/test/java/org/apache/cayenne/CayenneDataObjectIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/CayenneDataObjectIT.java
@@ -176,4 +176,17 @@ public class CayenneDataObjectIT extends ServerCase {
 		result.add(a); // list should be mutable
 		assertTrue(!result.isEmpty());
 	}
+
+	@Test
+	public void testReadIdProperty() {
+		Artist a = context.newObject(Artist.class);
+		Painting p = context.newObject(Painting.class);
+		p.setToArtist(a);
+
+		p.setObjectId(ObjectId.of("Painting", "PAINTING_ID", 321));
+		a.setObjectId(ObjectId.of("Artist", "ARTIST_ID", 123));
+
+		Object id2 = p.readNestedProperty("toArtist.@id");
+		assertEquals(123, id2);
+	}
 }

--- a/cayenne-server/src/test/java/org/apache/cayenne/exp/property/IdPropertyIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/exp/property/IdPropertyIT.java
@@ -1,0 +1,201 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.exp.property;
+
+import java.util.List;
+
+import org.apache.cayenne.Cayenne;
+import org.apache.cayenne.ObjectId;
+import org.apache.cayenne.access.DataContext;
+import org.apache.cayenne.di.Inject;
+import org.apache.cayenne.exp.ExpressionFactory;
+import org.apache.cayenne.query.ObjectSelect;
+import org.apache.cayenne.test.jdbc.DBHelper;
+import org.apache.cayenne.test.jdbc.TableHelper;
+import org.apache.cayenne.testdo.testmap.Artist;
+import org.apache.cayenne.testdo.testmap.Painting;
+import org.apache.cayenne.unit.di.server.CayenneProjects;
+import org.apache.cayenne.unit.di.server.ServerCase;
+import org.apache.cayenne.unit.di.server.UseServerRuntime;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @since 4.2
+ */
+@UseServerRuntime(CayenneProjects.TESTMAP_PROJECT)
+public class IdPropertyIT extends ServerCase {
+
+    @Inject
+    private DataContext context;
+
+    @Inject
+    private DBHelper dbHelper;
+
+    @Before
+    public void createArtistsDataSet() throws Exception {
+        TableHelper tArtist = new TableHelper(dbHelper, "ARTIST");
+        tArtist.setColumns("ARTIST_ID", "ARTIST_NAME", "DATE_OF_BIRTH");
+
+        long dateBase = System.currentTimeMillis();
+        int artistCount = 4;
+        for (int i = 1; i <= artistCount; i++) {
+            tArtist.insert(i, "artist" + i, new java.sql.Date(dateBase + 10000 * i));
+        }
+
+        TableHelper tGallery = new TableHelper(dbHelper, "GALLERY");
+        tGallery.setColumns("GALLERY_ID", "GALLERY_NAME");
+        tGallery.insert(1, "tate modern");
+
+        TableHelper tPaintings = new TableHelper(dbHelper, "PAINTING");
+        tPaintings.setColumns("PAINTING_ID", "PAINTING_TITLE", "ARTIST_ID", "GALLERY_ID");
+        for (int i = 1; i <= 16; i++) {
+            tPaintings.insert(i, "painting" + i, i % artistCount + 1, 1);
+        }
+    }
+
+    @Test
+    public void filterDb() {
+        List<Artist> artists = ObjectSelect.query(Artist.class)
+                .where(Artist.ARTIST_ID_PK_PROPERTY.gt(2L))
+                .select(context);
+        assertEquals(2, artists.size());
+    }
+
+    @Test
+    public void filterDbRelated() {
+        List<Artist> artists = ObjectSelect.query(Artist.class)
+                .where(Artist.PAINTING_ARRAY.dot(Painting.PAINTING_ID_PK_PROPERTY).gt(13))
+                .select(context);
+        assertEquals(3, artists.size());
+    }
+
+    @Test
+    public void filterInMemory() {
+        List<Artist> artists = Artist.ARTIST_ID_PK_PROPERTY.gt(2L)
+                .filterObjects(ObjectSelect.query(Artist.class).select(context));
+        assertEquals(2, artists.size());
+    }
+
+    @Test
+    public void filterInMemoryRelated() {
+        List<Artist> artists = Artist.PAINTING_ARRAY.dot(Painting.PAINTING_ID_PK_PROPERTY).gt(13)
+                .filterObjects(ObjectSelect.query(Artist.class).select(context));
+        assertEquals(3, artists.size());
+    }
+
+    @Test
+    public void orderingDb() {
+        List<Painting> paintings = ObjectSelect.query(Painting.class)
+                .orderBy(Painting.PAINTING_ID_PK_PROPERTY.desc())
+                .select(context);
+
+        assertEquals(16, paintings.size());
+        assertEquals(16L, Cayenne.longPKForObject(paintings.get(0)));
+        assertEquals(1L, Cayenne.longPKForObject(paintings.get(15)));
+    }
+
+    @Test
+    public void orderingDbRelated() {
+        List<Painting> paintings = ObjectSelect.query(Painting.class)
+                .orderBy(Painting.TO_ARTIST.dot(Artist.ARTIST_ID_PK_PROPERTY).asc())
+                .select(context);
+
+        assertEquals(16, paintings.size());
+        assertEquals(1L, Cayenne.longPKForObject(paintings.get(0).getToArtist()));
+        assertEquals(4L, Cayenne.longPKForObject(paintings.get(15).getToArtist()));
+    }
+
+    @Test
+    public void orderingInMemory() {
+        List<Painting> paintings = ObjectSelect.query(Painting.class)
+                .select(context);
+        Painting.PAINTING_ID_PK_PROPERTY.desc().orderList(paintings);
+
+        assertEquals(16, paintings.size());
+        assertEquals(16L, Cayenne.longPKForObject(paintings.get(0)));
+        assertEquals(1L, Cayenne.longPKForObject(paintings.get(15)));
+    }
+
+    @Test
+    public void orderingInMemoryRelated() {
+        List<Painting> paintings = ObjectSelect.query(Painting.class)
+                .select(context);
+        Painting.TO_ARTIST.dot(Artist.ARTIST_ID_PK_PROPERTY).asc().orderList(paintings);
+
+        assertEquals(16, paintings.size());
+        assertEquals(1L, Cayenne.longPKForObject(paintings.get(0).getToArtist()));
+        assertEquals(4L, Cayenne.longPKForObject(paintings.get(15).getToArtist()));
+    }
+
+    @Test
+    public void columnQuery() {
+        List<Long> ids = ObjectSelect.columnQuery(Artist.class, Artist.ARTIST_ID_PK_PROPERTY)
+                .orderBy(Artist.ARTIST_ID_PK_PROPERTY.desc())
+                .select(context);
+        assertEquals(4, ids.size());
+        assertEquals(Long.valueOf(1L), ids.get(3));
+        assertEquals(Long.valueOf(2L), ids.get(2));
+        assertEquals(Long.valueOf(3L), ids.get(1));
+        assertEquals(Long.valueOf(4L), ids.get(0));
+    }
+
+    @Test
+    public void columnQueryWithGroupBy() {
+        List<Object[]> ids = ObjectSelect.columnQuery(Artist.class, Artist.ARTIST_ID_PK_PROPERTY, Artist.PAINTING_ARRAY.count())
+                .orderBy(Artist.ARTIST_ID_PK_PROPERTY.asc())
+                .select(context);
+        assertEquals(4, ids.size());
+        assertEquals(1L, ids.get(0)[0]);
+        assertEquals(2L, ids.get(1)[0]);
+        assertEquals(3L, ids.get(2)[0]);
+        assertEquals(4L, ids.get(3)[0]);
+    }
+
+    @Test
+    public void filterDirectExpression() {
+        List<Artist> artists = ObjectSelect.query(Artist.class)
+                .where(ExpressionFactory.matchAllExp("@id", 2))
+                .select(context);
+        assertEquals(1, artists.size());
+    }
+
+    @Test
+    public void filterDirectAttributeExpression() {
+        List<Artist> artists = ObjectSelect.query(Artist.class)
+                .where(ExpressionFactory.matchAllExp("@id:ARTIST_ID", 2))
+                .select(context);
+        assertEquals(1, artists.size());
+    }
+
+    @Test
+    public void filterByObjectId() {
+        Artist artist = ObjectSelect.query(Artist.class).selectFirst(context);
+        assertNotNull(artist);
+
+        List<Painting> paintings = ObjectSelect.query(Painting.class)
+                .where(Painting.TO_ARTIST.dot(Artist.ARTIST_ID_PK_PROPERTY).eq(artist.getObjectId()))
+                .select(context);
+        assertEquals(4, paintings.size());
+    }
+}

--- a/cayenne-server/src/test/java/org/apache/cayenne/exp/property/IdPropertyTest.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/exp/property/IdPropertyTest.java
@@ -1,0 +1,100 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.exp.property;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.cayenne.CayenneRuntimeException;
+import org.apache.cayenne.ObjectId;
+import org.junit.Test;
+
+import static org.apache.cayenne.exp.ExpressionFactory.*;
+import static org.apache.cayenne.exp.property.PropertyFactory.createNumericId;
+import static org.junit.Assert.*;
+
+/**
+ * @since 4.2
+ */
+public class IdPropertyTest {
+
+    @Test
+    public void expressionContentAttribute() {
+        assertEquals(pathExp("@id:ARTIST_ID"),
+                createNumericId("ARTIST_ID", "Artist", Long.class).getExpression());
+    }
+
+    @Test
+    public void expressionContentPathAttribute() {
+        assertEquals(pathExp("path.@id:ARTIST_ID"),
+                createNumericId("ARTIST_ID", "path", "Artist", Long.class).getExpression());
+    }
+
+    @Test
+    public void expressionContentPath() {
+        assertEquals(pathExp("path.@id"),
+                createNumericId(null, "path", "Artist", Long.class).getExpression());
+    }
+
+    @Test
+    public void expressionContent() {
+        assertEquals(pathExp("@id"),
+                createNumericId("Artist", Long.class).getExpression());
+    }
+
+    @Test
+    public void eqObjectId() {
+        ObjectId id = ObjectId.of("Artist", "ARTIST_ID", 2);
+        assertEquals(matchExp("@id", 2),
+                createNumericId("Artist", Integer.class).eq(id));
+    }
+
+    @Test
+    public void eqObjectIdAttribute() {
+        ObjectId id = ObjectId.of("Artist", "ARTIST_ID", 2);
+        assertEquals(matchExp("@id:ARTIST_ID", 2),
+                createNumericId("ARTIST_ID", "Artist", Integer.class).eq(id));
+    }
+
+    @Test(expected = CayenneRuntimeException.class)
+    public void eqObjectIdWrongAttribute() {
+        ObjectId id = ObjectId.of("Artist", "ARTIST_ID", 2);
+        createNumericId("ARTIST_PK", "Artist", Integer.class).eq(id);
+    }
+
+    @Test
+    public void eqObjectIdCompound() {
+        Map<String, Object> key = new HashMap<>();
+        key.put("ARTIST_ID", 2);
+        key.put("SERIAL", 1);
+        ObjectId id = ObjectId.of("Artist", key);
+        assertEquals(matchExp("@id:ARTIST_ID", 2),
+                createNumericId("ARTIST_ID", "Artist", Integer.class).eq(id));
+    }
+
+    @Test(expected = CayenneRuntimeException.class)
+    public void eqObjectIdWrongCompound() {
+        Map<String, Object> key = new HashMap<>();
+        key.put("ARTIST_ID", 2);
+        key.put("SERIAL", 1);
+        ObjectId id = ObjectId.of("Artist", key);
+        createNumericId("Artist", Integer.class).eq(id);
+    }
+}

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_ArtGroup.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_ArtGroup.java
@@ -6,10 +6,9 @@ import java.io.ObjectOutputStream;
 import java.util.List;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.ExpressionFactory;
 import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.ListProperty;
-import org.apache.cayenne.exp.property.NumericProperty;
+import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
 import org.apache.cayenne.exp.property.StringProperty;
 import org.apache.cayenne.testdo.testmap.ArtGroup;
@@ -25,7 +24,7 @@ public abstract class _ArtGroup extends BaseDataObject {
 
     private static final long serialVersionUID = 1L; 
 
-    public static final NumericProperty<Integer> GROUP_ID_PK_PROPERTY = PropertyFactory.createNumeric(ExpressionFactory.dbPathExp("GROUP_ID"), Integer.class);
+    public static final NumericIdProperty<Integer> GROUP_ID_PK_PROPERTY = PropertyFactory.createNumericId("GROUP_ID", "ArtGroup", Integer.class);
     public static final String GROUP_ID_PK_COLUMN = "GROUP_ID";
 
     public static final StringProperty<String> NAME = PropertyFactory.createString("name", String.class);

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_Artist.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_Artist.java
@@ -7,10 +7,9 @@ import java.util.Date;
 import java.util.List;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.ExpressionFactory;
 import org.apache.cayenne.exp.property.DateProperty;
 import org.apache.cayenne.exp.property.ListProperty;
-import org.apache.cayenne.exp.property.NumericProperty;
+import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
 import org.apache.cayenne.exp.property.StringProperty;
 import org.apache.cayenne.testdo.testmap.ArtGroup;
@@ -27,7 +26,7 @@ public abstract class _Artist extends BaseDataObject {
 
     private static final long serialVersionUID = 1L; 
 
-    public static final NumericProperty<Long> ARTIST_ID_PK_PROPERTY = PropertyFactory.createNumeric(ExpressionFactory.dbPathExp("ARTIST_ID"), Long.class);
+    public static final NumericIdProperty<Long> ARTIST_ID_PK_PROPERTY = PropertyFactory.createNumericId("ARTIST_ID", "Artist", Long.class);
     public static final String ARTIST_ID_PK_COLUMN = "ARTIST_ID";
 
     public static final StringProperty<String> ARTIST_NAME = PropertyFactory.createString("artistName", String.class);

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_ArtistCallback.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_ArtistCallback.java
@@ -6,9 +6,8 @@ import java.io.ObjectOutputStream;
 import java.util.Date;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.ExpressionFactory;
 import org.apache.cayenne.exp.property.DateProperty;
-import org.apache.cayenne.exp.property.NumericProperty;
+import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
 import org.apache.cayenne.exp.property.StringProperty;
 
@@ -22,7 +21,7 @@ public abstract class _ArtistCallback extends BaseDataObject {
 
     private static final long serialVersionUID = 1L; 
 
-    public static final NumericProperty<Integer> ARTIST_ID_PK_PROPERTY = PropertyFactory.createNumeric(ExpressionFactory.dbPathExp("ARTIST_ID"), Integer.class);
+    public static final NumericIdProperty<Integer> ARTIST_ID_PK_PROPERTY = PropertyFactory.createNumericId("ARTIST_ID", "ArtistCallback", Integer.class);
     public static final String ARTIST_ID_PK_COLUMN = "ARTIST_ID";
 
     public static final StringProperty<String> ARTIST_NAME = PropertyFactory.createString("artistName", String.class);

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_ArtistExhibit.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_ArtistExhibit.java
@@ -5,9 +5,8 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.ExpressionFactory;
 import org.apache.cayenne.exp.property.EntityProperty;
-import org.apache.cayenne.exp.property.NumericProperty;
+import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
 import org.apache.cayenne.testdo.testmap.Artist;
 import org.apache.cayenne.testdo.testmap.Exhibit;
@@ -22,9 +21,9 @@ public abstract class _ArtistExhibit extends BaseDataObject {
 
     private static final long serialVersionUID = 1L; 
 
-    public static final NumericProperty<Long> ARTIST_ID_PK_PROPERTY = PropertyFactory.createNumeric(ExpressionFactory.dbPathExp("ARTIST_ID"), Long.class);
+    public static final NumericIdProperty<Long> ARTIST_ID_PK_PROPERTY = PropertyFactory.createNumericId("ARTIST_ID", "ArtistExhibit", Long.class);
     public static final String ARTIST_ID_PK_COLUMN = "ARTIST_ID";
-    public static final NumericProperty<Integer> EXHIBIT_ID_PK_PROPERTY = PropertyFactory.createNumeric(ExpressionFactory.dbPathExp("EXHIBIT_ID"), Integer.class);
+    public static final NumericIdProperty<Integer> EXHIBIT_ID_PK_PROPERTY = PropertyFactory.createNumericId("EXHIBIT_ID", "ArtistExhibit", Integer.class);
     public static final String EXHIBIT_ID_PK_COLUMN = "EXHIBIT_ID";
 
     public static final EntityProperty<Artist> TO_ARTIST = PropertyFactory.createEntity("toArtist", Artist.class);

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_CompoundPainting.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_CompoundPainting.java
@@ -6,8 +6,8 @@ import java.io.ObjectOutputStream;
 import java.math.BigDecimal;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.ExpressionFactory;
 import org.apache.cayenne.exp.property.EntityProperty;
+import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.NumericProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
 import org.apache.cayenne.exp.property.StringProperty;
@@ -25,7 +25,7 @@ public abstract class _CompoundPainting extends BaseDataObject {
 
     private static final long serialVersionUID = 1L; 
 
-    public static final NumericProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumeric(ExpressionFactory.dbPathExp("PAINTING_ID"), Integer.class);
+    public static final NumericIdProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumericId("PAINTING_ID", "CompoundPainting", Integer.class);
     public static final String PAINTING_ID_PK_COLUMN = "PAINTING_ID";
 
     public static final StringProperty<String> ARTIST_NAME = PropertyFactory.createString("artistName", String.class);

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_CompoundPaintingLongNames.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_CompoundPaintingLongNames.java
@@ -6,8 +6,8 @@ import java.io.ObjectOutputStream;
 import java.math.BigDecimal;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.ExpressionFactory;
 import org.apache.cayenne.exp.property.EntityProperty;
+import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.NumericProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
 import org.apache.cayenne.exp.property.StringProperty;
@@ -26,7 +26,7 @@ public abstract class _CompoundPaintingLongNames extends BaseDataObject {
 
     private static final long serialVersionUID = 1L; 
 
-    public static final NumericProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumeric(ExpressionFactory.dbPathExp("PAINTING_ID"), Integer.class);
+    public static final NumericIdProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumericId("PAINTING_ID", "CompoundPaintingLongNames", Integer.class);
     public static final String PAINTING_ID_PK_COLUMN = "PAINTING_ID";
 
     public static final StringProperty<String> ARTIST_LONG_NAME = PropertyFactory.createString("artistLongName", String.class);

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_Exhibit.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_Exhibit.java
@@ -7,11 +7,10 @@ import java.util.Date;
 import java.util.List;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.ExpressionFactory;
 import org.apache.cayenne.exp.property.DateProperty;
 import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.ListProperty;
-import org.apache.cayenne.exp.property.NumericProperty;
+import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
 import org.apache.cayenne.testdo.testmap.ArtistExhibit;
 import org.apache.cayenne.testdo.testmap.Gallery;
@@ -26,7 +25,7 @@ public abstract class _Exhibit extends BaseDataObject {
 
     private static final long serialVersionUID = 1L; 
 
-    public static final NumericProperty<Integer> EXHIBIT_ID_PK_PROPERTY = PropertyFactory.createNumeric(ExpressionFactory.dbPathExp("EXHIBIT_ID"), Integer.class);
+    public static final NumericIdProperty<Integer> EXHIBIT_ID_PK_PROPERTY = PropertyFactory.createNumericId("EXHIBIT_ID", "Exhibit", Integer.class);
     public static final String EXHIBIT_ID_PK_COLUMN = "EXHIBIT_ID";
 
     public static final DateProperty<Date> CLOSING_DATE = PropertyFactory.createDate("closingDate", Date.class);

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_Gallery.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_Gallery.java
@@ -6,9 +6,8 @@ import java.io.ObjectOutputStream;
 import java.util.List;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.ExpressionFactory;
 import org.apache.cayenne.exp.property.ListProperty;
-import org.apache.cayenne.exp.property.NumericProperty;
+import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
 import org.apache.cayenne.exp.property.StringProperty;
 import org.apache.cayenne.testdo.testmap.Exhibit;
@@ -24,7 +23,7 @@ public abstract class _Gallery extends BaseDataObject {
 
     private static final long serialVersionUID = 1L; 
 
-    public static final NumericProperty<Integer> GALLERY_ID_PK_PROPERTY = PropertyFactory.createNumeric(ExpressionFactory.dbPathExp("GALLERY_ID"), Integer.class);
+    public static final NumericIdProperty<Integer> GALLERY_ID_PK_PROPERTY = PropertyFactory.createNumericId("GALLERY_ID", "Gallery", Integer.class);
     public static final String GALLERY_ID_PK_COLUMN = "GALLERY_ID";
 
     public static final StringProperty<String> GALLERY_NAME = PropertyFactory.createString("galleryName", String.class);

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_MeaningfulGeneratedColumnTestEntity.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_MeaningfulGeneratedColumnTestEntity.java
@@ -5,7 +5,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.ExpressionFactory;
 import org.apache.cayenne.exp.property.NumericProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
 import org.apache.cayenne.exp.property.StringProperty;

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_NullTestEntity.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_NullTestEntity.java
@@ -5,8 +5,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.ExpressionFactory;
-import org.apache.cayenne.exp.property.NumericProperty;
+import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
 import org.apache.cayenne.exp.property.StringProperty;
 
@@ -20,7 +19,7 @@ public abstract class _NullTestEntity extends BaseDataObject {
 
     private static final long serialVersionUID = 1L; 
 
-    public static final NumericProperty<Integer> ID_PK_PROPERTY = PropertyFactory.createNumeric(ExpressionFactory.dbPathExp("ID"), Integer.class);
+    public static final NumericIdProperty<Integer> ID_PK_PROPERTY = PropertyFactory.createNumericId("ID", "NullTestEntity", Integer.class);
     public static final String ID_PK_COLUMN = "ID";
 
     public static final StringProperty<String> NAME = PropertyFactory.createString("name", String.class);

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_Painting.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_Painting.java
@@ -5,8 +5,8 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.math.BigDecimal;
 
-import org.apache.cayenne.exp.ExpressionFactory;
 import org.apache.cayenne.exp.property.EntityProperty;
+import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.NumericProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
 import org.apache.cayenne.exp.property.StringProperty;
@@ -25,7 +25,7 @@ public abstract class _Painting extends ArtDataObject {
 
     private static final long serialVersionUID = 1L; 
 
-    public static final NumericProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumeric(ExpressionFactory.dbPathExp("PAINTING_ID"), Integer.class);
+    public static final NumericIdProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumericId("PAINTING_ID", "Painting", Integer.class);
     public static final String PAINTING_ID_PK_COLUMN = "PAINTING_ID";
 
     public static final NumericProperty<BigDecimal> ESTIMATED_PRICE = PropertyFactory.createNumeric("estimatedPrice", BigDecimal.class);

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_Painting1.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_Painting1.java
@@ -6,8 +6,8 @@ import java.io.ObjectOutputStream;
 import java.math.BigDecimal;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.ExpressionFactory;
 import org.apache.cayenne.exp.property.EntityProperty;
+import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.NumericProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
 import org.apache.cayenne.exp.property.StringProperty;
@@ -23,7 +23,7 @@ public abstract class _Painting1 extends BaseDataObject {
 
     private static final long serialVersionUID = 1L; 
 
-    public static final NumericProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumeric(ExpressionFactory.dbPathExp("PAINTING_ID"), Integer.class);
+    public static final NumericIdProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumericId("PAINTING_ID", "Painting1", Integer.class);
     public static final String PAINTING_ID_PK_COLUMN = "PAINTING_ID";
 
     public static final NumericProperty<BigDecimal> ESTIMATED_PRICE = PropertyFactory.createNumeric("estimatedPrice", BigDecimal.class);

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_PaintingInfo.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_PaintingInfo.java
@@ -5,10 +5,9 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.ExpressionFactory;
 import org.apache.cayenne.exp.property.BaseProperty;
 import org.apache.cayenne.exp.property.EntityProperty;
-import org.apache.cayenne.exp.property.NumericProperty;
+import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
 import org.apache.cayenne.exp.property.StringProperty;
 import org.apache.cayenne.testdo.testmap.Painting;
@@ -23,7 +22,7 @@ public abstract class _PaintingInfo extends BaseDataObject {
 
     private static final long serialVersionUID = 1L; 
 
-    public static final NumericProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumeric(ExpressionFactory.dbPathExp("PAINTING_ID"), Integer.class);
+    public static final NumericIdProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumericId("PAINTING_ID", "PaintingInfo", Integer.class);
     public static final String PAINTING_ID_PK_COLUMN = "PAINTING_ID";
 
     public static final BaseProperty<byte[]> IMAGE_BLOB = PropertyFactory.createBase("imageBlob", byte[].class);

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_ROArtist.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_ROArtist.java
@@ -7,10 +7,9 @@ import java.sql.Date;
 import java.util.List;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.ExpressionFactory;
 import org.apache.cayenne.exp.property.DateProperty;
 import org.apache.cayenne.exp.property.ListProperty;
-import org.apache.cayenne.exp.property.NumericProperty;
+import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
 import org.apache.cayenne.exp.property.StringProperty;
 import org.apache.cayenne.testdo.testmap.Painting;
@@ -25,7 +24,7 @@ public abstract class _ROArtist extends BaseDataObject {
 
     private static final long serialVersionUID = 1L; 
 
-    public static final NumericProperty<Long> ARTIST_ID_PK_PROPERTY = PropertyFactory.createNumeric(ExpressionFactory.dbPathExp("ARTIST_ID"), Long.class);
+    public static final NumericIdProperty<Long> ARTIST_ID_PK_PROPERTY = PropertyFactory.createNumericId("ARTIST_ID", "ROArtist", Long.class);
     public static final String ARTIST_ID_PK_COLUMN = "ARTIST_ID";
 
     public static final StringProperty<String> ARTIST_NAME = PropertyFactory.createString("artistName", String.class);

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_ROPainting.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_ROPainting.java
@@ -6,8 +6,8 @@ import java.io.ObjectOutputStream;
 import java.math.BigDecimal;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.ExpressionFactory;
 import org.apache.cayenne.exp.property.EntityProperty;
+import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.NumericProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
 import org.apache.cayenne.exp.property.StringProperty;
@@ -23,7 +23,7 @@ public abstract class _ROPainting extends BaseDataObject {
 
     private static final long serialVersionUID = 1L; 
 
-    public static final NumericProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumeric(ExpressionFactory.dbPathExp("PAINTING_ID"), Integer.class);
+    public static final NumericIdProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumericId("PAINTING_ID", "ROPainting", Integer.class);
     public static final String PAINTING_ID_PK_COLUMN = "PAINTING_ID";
 
     public static final NumericProperty<BigDecimal> ESTIMATED_PRICE = PropertyFactory.createNumeric("estimatedPrice", BigDecimal.class);

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_RWCompoundPainting.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_RWCompoundPainting.java
@@ -6,7 +6,7 @@ import java.io.ObjectOutputStream;
 import java.math.BigDecimal;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.ExpressionFactory;
+import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.NumericProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
 import org.apache.cayenne.exp.property.StringProperty;
@@ -21,7 +21,7 @@ public abstract class _RWCompoundPainting extends BaseDataObject {
 
     private static final long serialVersionUID = 1L; 
 
-    public static final NumericProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumeric(ExpressionFactory.dbPathExp("PAINTING_ID"), Integer.class);
+    public static final NumericIdProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumericId("PAINTING_ID", "RWCompoundPainting", Integer.class);
     public static final String PAINTING_ID_PK_COLUMN = "PAINTING_ID";
 
     public static final NumericProperty<BigDecimal> ESTIMATED_PRICE = PropertyFactory.createNumeric("estimatedPrice", BigDecimal.class);

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_SubPainting.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_SubPainting.java
@@ -5,8 +5,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.ExpressionFactory;
-import org.apache.cayenne.exp.property.NumericProperty;
+import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
 import org.apache.cayenne.exp.property.StringProperty;
 
@@ -20,7 +19,7 @@ public abstract class _SubPainting extends BaseDataObject {
 
     private static final long serialVersionUID = 1L; 
 
-    public static final NumericProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumeric(ExpressionFactory.dbPathExp("PAINTING_ID"), Integer.class);
+    public static final NumericIdProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumericId("PAINTING_ID", "SubPainting", Integer.class);
     public static final String PAINTING_ID_PK_COLUMN = "PAINTING_ID";
 
     public static final StringProperty<String> PAINTING_TITLE = PropertyFactory.createString("paintingTitle", String.class);


### PR DESCRIPTION
You can optionally generate PK properties like this in `cgen`:
```java
public static final NumericIdProperty<Long> ARTIST_ID_PK_PROPERTY = 
    PropertyFactory.createNumericId("ARTIST_ID", "Artist", Long.class);
```

They can be used in all cases:
- directly in `where`
```java
Artist.ARTIST_ID_PK_PROPERTY.gt(2L)
```
- with `dot()` operator
```java
Artist.PAINTING_ARRAY.dot(Painting.PAINTING_ID_PK_PROPERTY).eq(13)
```
- to sort in db and in memory
```java
Painting.PAINTING_ID_PK_PROPERTY.desc().orderList(paintings);
```
- for in-memory evaluation
```java
Artist.PAINTING_ARRAY.dot(Painting.PAINTING_ID_PK_PROPERTY).gt(13)
                .filterObjects(artists);
```