### PR TITLE
CAY-2527 Map Object[] result to pojo

### DIFF
--- a/cayenne-server/src/main/java/org/apache/cayenne/query/ColumnSelect.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/query/ColumnSelect.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.function.Function;
 
 import org.apache.cayenne.ObjectContext;
 import org.apache.cayenne.exp.property.BaseProperty;
@@ -629,5 +630,18 @@ public class ColumnSelect<T> extends FluentSelect<T> {
     @Override
     protected BaseQueryMetadata getBaseMetaData() {
         return metaData;
+    }
+
+    /**
+     * Wrap result to given class.  Wrapper class should be public and have public constructor with no args.
+     * Columns order in the query should corespond to fields defined in that class.
+     *
+     * @param mapper function that maps result to required form.
+     * @since 4.2
+     */
+    @SuppressWarnings("unchecked")
+    public <E> ColumnSelect<E> map(Function<T, E> mapper) {
+        this.metaData.setResultMapper(mapper);
+        return (ColumnSelect<E>)this;
     }
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/query/ColumnSelectMetadata.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/query/ColumnSelectMetadata.java
@@ -136,8 +136,13 @@ class ColumnSelectMetadata extends ObjectSelectMetadata {
 		this.suppressingDistinct = suppressingDistinct;
 	}
 
+	@SuppressWarnings("unchecked")
 	void setResultMapper(Function<?, ?> resultMapper) {
-		this.resultMapper = resultMapper;
+		if(this.resultMapper != null) {
+			this.resultMapper = this.resultMapper.andThen((Function)resultMapper);
+		} else {
+			this.resultMapper = resultMapper;
+		}
 	}
 
 	@Override

--- a/cayenne-server/src/main/java/org/apache/cayenne/query/ColumnSelectMetadata.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/query/ColumnSelectMetadata.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.apache.cayenne.exp.Expression;
 import org.apache.cayenne.exp.property.BaseProperty;
@@ -44,6 +45,7 @@ class ColumnSelectMetadata extends ObjectSelectMetadata {
 
 	private boolean isSingleResultSetMapping;
 	private boolean suppressingDistinct;
+	private Function<?, ?> resultMapper;
 
 	boolean resolve(Object root, EntityResolver resolver, ColumnSelect<?> query) {
 
@@ -132,5 +134,14 @@ class ColumnSelectMetadata extends ObjectSelectMetadata {
 
 	public void setSuppressingDistinct(boolean suppressingDistinct) {
 		this.suppressingDistinct = suppressingDistinct;
+	}
+
+	void setResultMapper(Function<?, ?> resultMapper) {
+		this.resultMapper = resultMapper;
+	}
+
+	@Override
+	public Function<?, ?> getResultMapper() {
+		return resultMapper;
 	}
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/query/QueryMetadata.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/query/QueryMetadata.java
@@ -21,6 +21,7 @@ package org.apache.cayenne.query;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.apache.cayenne.map.DataMap;
 import org.apache.cayenne.map.DbEntity;
@@ -256,4 +257,11 @@ public interface QueryMetadata {
      * @since 4.0
      */
     boolean isSuppressingDistinct();
+
+    /**
+     * @since 4.2
+     */
+    default Function<?, ?> getResultMapper() {
+        return null;
+    }
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/query/SQLSelect.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/query/SQLSelect.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.apache.cayenne.CayenneRuntimeException;
 import org.apache.cayenne.DataRow;
@@ -46,6 +47,7 @@ public class SQLSelect<T> extends IndirectQuery implements Select<T> {
 	private List<Class<?>> resultColumnsTypes;
 	private boolean useScalar;
 	private boolean isFetchingDataRows;
+	private Function<T, ?> resultMapper;
 
 	/**
 	 * Creates a query that selects DataRows and uses default routing.
@@ -443,6 +445,7 @@ public class SQLSelect<T> extends IndirectQuery implements Select<T> {
 		template.setStatementFetchSize(statementFetchSize);
 		template.setQueryTimeout(queryTimeout);
 		template.setUseScalar(useScalar);
+		template.setResultMapper(resultMapper);
 
 		return template;
 	}
@@ -681,6 +684,12 @@ public class SQLSelect<T> extends IndirectQuery implements Select<T> {
 		}
 		prefetches.merge(node);
 		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public <E> SQLSelect<E> map(Function<T, E> mapper) {
+		this.resultMapper = mapper;
+		return (SQLSelect<E>)this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/cayenne-server/src/main/java/org/apache/cayenne/query/SQLTemplate.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/query/SQLTemplate.java
@@ -700,4 +700,11 @@ public class SQLTemplate extends AbstractQuery implements ParameterizedQuery {
 	public boolean isUseScalar() {
 		return useScalar;
 	}
+
+	/**
+	 * @since 4.2
+	 */
+    public void setResultMapper(Function<?,?> resultMapper) {
+		this.metaData.setResultMapper(resultMapper);
+    }
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/query/SQLTemplateMetadata.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/query/SQLTemplateMetadata.java
@@ -129,7 +129,11 @@ public class SQLTemplateMetadata extends BaseQueryMetadata {
 	}
 
 	void setResultMapper(Function<?,?> resultMapper) {
-		this.resultMapper = resultMapper;
+		if(this.resultMapper != null) {
+			this.resultMapper = this.resultMapper.andThen((Function)resultMapper);
+		} else {
+			this.resultMapper = resultMapper;
+		}
     }
 
 	@Override

--- a/cayenne-server/src/main/java/org/apache/cayenne/query/SQLTemplateMetadata.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/query/SQLTemplateMetadata.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * @since 3.0
@@ -34,6 +35,7 @@ import java.util.Map;
 public class SQLTemplateMetadata extends BaseQueryMetadata {
 
 	private boolean isSingleResultSetMapping;
+	private Function<?, ?> resultMapper;
 
 	@Override
 	public boolean isSingleResultSetMapping() {
@@ -124,5 +126,14 @@ public class SQLTemplateMetadata extends BaseQueryMetadata {
 			result.addColumnResult(String.valueOf(i));
 		}
 		query.setResult(result);
+	}
+
+	void setResultMapper(Function<?,?> resultMapper) {
+		this.resultMapper = resultMapper;
+    }
+
+	@Override
+	public Function<?, ?> getResultMapper() {
+		return resultMapper;
 	}
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/reflect/PojoMapper.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/reflect/PojoMapper.java
@@ -1,0 +1,93 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.reflect;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+import java.util.function.Function;
+
+import org.apache.cayenne.CayenneRuntimeException;
+
+/**
+ * Simple mapper of Object[] to POJO class. This class relies on field order, so use with caution.
+ * @param <T> type of object to produce
+ * @since 4.2
+ */
+public class PojoMapper<T> implements Function<Object[], T> {
+
+    private static MethodHandles.Lookup lookup = MethodHandles.lookup();
+
+    private final Class<T> type;
+    private final MethodHandle constructor;
+    private final MethodHandle[] setters;
+
+    public PojoMapper(Class<T> type) {
+        this.type = type;
+        try {
+            this.constructor = lookup.unreflectConstructor(type.getConstructor());
+        } catch (NoSuchMethodException | IllegalAccessException ex) {
+            throw new CayenneRuntimeException("No default constructor found for class '%s'.", type.getName());
+        }
+
+        Field[] declaredFields = type.getDeclaredFields();
+        this.setters = new MethodHandle[declaredFields.length];
+        int i = 0;
+        for(Field field : declaredFields) {
+            field.setAccessible(true);
+            try {
+                setters[i++] = lookup.unreflectSetter(field);
+            } catch (IllegalAccessException e) {
+                throw new CayenneRuntimeException("Field '%s'.'%s' is inaccessible.", e, type.getName(), field.getName());
+            }
+        }
+    }
+
+    private T newObject() {
+        try {
+            @SuppressWarnings("unchecked")
+            T object = (T)constructor.invoke();
+            return object;
+        } catch (Throwable ex) {
+            throw new CayenneRuntimeException("Unable to instantiate %s.", ex, type.getName());
+        }
+    }
+
+    public T apply(Object[] data) {
+        if(data.length > setters.length) {
+            throw new CayenneRuntimeException("Unable to create '%s'. Values length (%d) > fields count (%d)"
+                    , type.getName(), data.length, setters.length);
+        }
+
+        T object = newObject();
+
+        for (int i = 0; i < data.length; i++) {
+            if (data[i] != null) {
+                try {
+                    setters[i].invoke(object, data[i]);
+                } catch (Throwable ex) {
+                    throw new CayenneRuntimeException("Unable to set field of %s.", ex, type.getName());
+                }
+            }
+        }
+
+        return object;
+    }
+}

--- a/cayenne-server/src/test/java/org/apache/cayenne/query/ColumnSelectIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/query/ColumnSelectIT.java
@@ -41,6 +41,7 @@ import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.NumericProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
 import org.apache.cayenne.exp.property.StringProperty;
+import org.apache.cayenne.reflect.PojoMapper;
 import org.apache.cayenne.test.jdbc.DBHelper;
 import org.apache.cayenne.test.jdbc.TableHelper;
 import org.apache.cayenne.testdo.testmap.Artist;
@@ -1151,5 +1152,40 @@ public class ColumnSelectIT extends ServerCase {
         assertEquals("artist1", results.get(0)[0]);
         assertEquals("artist1", ((Artist)results.get(0)[1]).getArtistName());
         assertEquals(1, results.get(0)[2]);
+    }
+
+    @Test
+    public void testMapToPojo() {
+        List<TestPojo> result = ObjectSelect.query(Artist.class)
+                .columns(Artist.ARTIST_NAME, Artist.DATE_OF_BIRTH, Artist.ARTIST_NAME.trim().length())
+                .where(Artist.ARTIST_NAME.like("artist%"))
+                .orderBy(Artist.ARTIST_ID_PK_PROPERTY.asc())
+                .map(TestPojo::new)
+                .select(context);
+
+        assertEquals(20, result.size());
+
+        TestPojo testPojo0 = result.get(0);
+        assertNotNull(testPojo0);
+        assertEquals("artist1", testPojo0.name);
+        assertNotNull(testPojo0.date);
+        assertEquals(7, testPojo0.length);
+
+        TestPojo testPojo19 = result.get(19);
+        assertNotNull(testPojo19);
+        assertEquals("artist20", testPojo19.name);
+        assertEquals(8, testPojo19.length);
+        assertNotNull(testPojo19.date);
+    }
+
+    static class TestPojo {
+        String name;
+        Date date;
+        int length;
+        TestPojo(Object[] data) {
+            name = (String)data[0];
+            date = (Date)data[1];
+            length = (Integer)data[2];
+        }
     }
 }

--- a/cayenne-server/src/test/java/org/apache/cayenne/query/ColumnSelectIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/query/ColumnSelectIT.java
@@ -1178,6 +1178,25 @@ public class ColumnSelectIT extends ServerCase {
         assertNotNull(testPojo19.date);
     }
 
+    @Test
+    public void testDoubleMapToPojo() {
+        List<TestPojo2> result = ObjectSelect.query(Artist.class)
+                .columns(Artist.ARTIST_NAME, Artist.DATE_OF_BIRTH, Artist.ARTIST_NAME.trim().length())
+                .where(Artist.ARTIST_NAME.like("artist%"))
+                .orderBy(Artist.ARTIST_ID_PK_PROPERTY.asc())
+                .map(TestPojo::new)
+                .map(TestPojo2::new)
+                .select(context);
+        assertEquals(20, result.size());
+
+        TestPojo2 testPojo0 = result.get(0);
+        assertNotNull(testPojo0);
+        assertEquals("artist1", testPojo0.pojo.name);
+        assertNotNull(testPojo0.pojo.date);
+        assertEquals(7, testPojo0.pojo.length);
+
+    }
+
     static class TestPojo {
         String name;
         Date date;
@@ -1186,6 +1205,13 @@ public class ColumnSelectIT extends ServerCase {
             name = (String)data[0];
             date = (Date)data[1];
             length = (Integer)data[2];
+        }
+    }
+
+    static class TestPojo2 {
+        TestPojo pojo;
+        TestPojo2(TestPojo pojo) {
+            this.pojo = pojo;
         }
     }
 }

--- a/cayenne-server/src/test/java/org/apache/cayenne/reflect/PojoMapperTest.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/reflect/PojoMapperTest.java
@@ -1,0 +1,88 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.reflect;
+
+import org.apache.cayenne.CayenneRuntimeException;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @since 4.2
+ */
+public class PojoMapperTest {
+
+    @Test
+    public void testObjectCreation() {
+        PojoMapper<C1> descriptor = new PojoMapper<>(C1.class);
+
+        Object o = new Object();
+        Object[] data = {"123", o, 42};
+        C1 object = descriptor.apply(data);
+        assertEquals("123", object.a);
+        assertSame(o, object.b);
+        assertEquals(42, object.c);
+    }
+
+    @Test(expected = CayenneRuntimeException.class)
+    public void testNonPublicClass() {
+        new PojoMapper<>(C2.class);
+    }
+
+    @Test(expected = CayenneRuntimeException.class)
+    public void testNonPublicConstructor() {
+        new PojoMapper<>(C3.class);
+    }
+
+    @Test(expected = CayenneRuntimeException.class)
+    public void testNonDefaultConstructor() {
+        new PojoMapper<>(C4.class);
+    }
+
+    @Test(expected = CayenneRuntimeException.class)
+    public void testWrongArgumentCount() {
+        PojoMapper<C1> descriptor = new PojoMapper<>(C1.class);
+
+        Object[] data = {"123", new Object(), 42, 32};
+        descriptor.apply(data);
+    }
+
+    public static class C1 {
+        String a;
+        Object b;
+        int c;
+    }
+
+    private static class C2 {
+        int a;
+    }
+
+    public static class C3 {
+        int a;
+        private C3() {
+        }
+    }
+
+    public static class C4 {
+        int a;
+        public C4(int a) {
+        }
+    }
+}


### PR DESCRIPTION
This PR adds simple `map(Function<T,R> mapper)` method to all fluent queries that can return `Object[]` result.

Usage example:
```java
class ArtistDTO {
    ArtistDTO(Object[]) {
         // ...
    }
}
// ...
List<ArtistDTO> result = ObjectSelect.columnQuery(Artist.class, Artist.ARTIST_NAME, Artist.DATE_OF_BIRTH)
                .map(ArtistDTO::new)
                .select(context);
```