### PR TITLE
Experimental graph-based db operations sorter

### DIFF
--- a/cayenne-server/src/main/java/org/apache/cayenne/ObjectIdTmp.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/ObjectIdTmp.java
@@ -111,7 +111,7 @@ class ObjectIdTmp implements ObjectId {
         }
 
         ObjectIdTmp that = (ObjectIdTmp) o;
-        if (!Arrays.equals(id, that.id)) {
+        if (id != that.id && !Arrays.equals(id, that.id)) {
             return false;
         }
         return entityName.equals(that.entityName);

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/flush/DefaultDataDomainFlushAction.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/flush/DefaultDataDomainFlushAction.java
@@ -107,7 +107,9 @@ public class DefaultDataDomainFlushAction implements DataDomainFlushAction {
         Set<ArcTarget> processedArcs = new HashSet<>();
 
         DbRowOpFactory factory = new DbRowOpFactory(resolver, objectStore, processedArcs);
-        changesByObjectId.forEach((obj, diff) -> ops.addAll(factory.createRows(diff)));
+        // ops.addAll() method is slower in this case as it will allocate new array for all values
+        //noinspection UseBulkOperation
+        changesByObjectId.forEach((obj, diff) -> factory.createRows(diff).forEach(ops::add));
 
         return ops;
     }

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/flush/EffectiveOpId.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/flush/EffectiveOpId.java
@@ -104,4 +104,9 @@ public class EffectiveOpId {
         result = 31 * result + snapshot.hashCode();
         return result;
     }
+
+    @Override
+    public String toString() {
+        return "EffectiveOpId{" + entityName + ": " + snapshot + '}';
+    }
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/flush/IdGenerationMarker.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/flush/IdGenerationMarker.java
@@ -1,0 +1,52 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.access.flush;
+
+import java.io.Serializable;
+
+import org.apache.cayenne.ObjectId;
+
+/**
+ * Special value that denotes generated id attribute
+ *
+ * @since 4.2
+ */
+class IdGenerationMarker implements Serializable {
+    private static final long serialVersionUID = -5339942931435878094L;
+
+    private final int id;
+
+    IdGenerationMarker(ObjectId id) {
+        this.id = id.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        IdGenerationMarker that = (IdGenerationMarker) o;
+        return id == that.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return id;
+    }
+}

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/flush/operation/BaseDbRowOp.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/flush/operation/BaseDbRowOp.java
@@ -34,11 +34,13 @@ public abstract class BaseDbRowOp implements DbRowOp {
     protected final DbEntity entity;
     // Can be ObjEntity id or a DB row id for flattened rows
     protected ObjectId changeId;
+    protected int hashCode;
 
     protected BaseDbRowOp(Persistent object, DbEntity entity, ObjectId id) {
         this.object = Objects.requireNonNull(object);
         this.entity = Objects.requireNonNull(entity);
         this.changeId = Objects.requireNonNull(id);
+        this.hashCode = changeId.hashCode();
     }
 
     @Override
@@ -67,7 +69,7 @@ public abstract class BaseDbRowOp implements DbRowOp {
 
     @Override
     public int hashCode() {
-        return changeId.hashCode();
+        return hashCode;
     }
 
     @Override

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/flush/operation/BaseDbRowOp.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/flush/operation/BaseDbRowOp.java
@@ -33,7 +33,7 @@ public abstract class BaseDbRowOp implements DbRowOp {
     protected final Persistent object;
     protected final DbEntity entity;
     // Can be ObjEntity id or a DB row id for flattened rows
-    protected final ObjectId changeId;
+    protected ObjectId changeId;
 
     protected BaseDbRowOp(Persistent object, DbEntity entity, ObjectId id) {
         this.object = Objects.requireNonNull(object);

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/flush/operation/DbRowOpGraph.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/flush/operation/DbRowOpGraph.java
@@ -1,0 +1,118 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.access.flush.operation;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Graph sorting, copy of DIGraph implementation from cayenne-di.
+ */
+class DbRowOpGraph {
+
+	/**
+	 * {@link LinkedHashMap} is used for supporting insertion order.
+	 */
+	private final Map<DbRowOp, List<DbRowOp>> neighbors = new LinkedHashMap<>();
+
+	DbRowOpGraph() {
+	}
+
+	/**
+	 * Add a vertex to the graph. Nothing happens if vertex is already in graph.
+	 */
+	void add(DbRowOp vertex) {
+		neighbors.putIfAbsent(vertex, new ArrayList<>(0));
+	}
+
+	/**
+	 * Add an edge to the graph; if either vertex does not exist, it's added.
+	 * This implementation allows the creation of multi-edges and self-loops.
+	 */
+	void add(DbRowOp from, DbRowOp to) {
+		neighbors.computeIfAbsent(from, k -> new ArrayList<>()).add(to);
+		this.add(to);
+	}
+
+	/**
+	 * Return (as a Map) the in-degree of each vertex.
+	 */
+	private Map<DbRowOp, Integer> inDegree() {
+		Map<DbRowOp, Integer> result = new LinkedHashMap<>();
+
+		neighbors.forEach((from, neighbors) -> {
+			neighbors.forEach(to -> result.compute(to, (k, old) -> {
+				if(old == null) {
+					return 1;
+				}
+				return old + 1;
+			}));
+			result.putIfAbsent(from, 0);
+		});
+
+		return result;
+	}
+
+	/**
+	 * Return (as a List) the topological sort of the vertices. Throws an exception if cycles are detected.
+	 */
+	List<DbRowOp> topSort() {
+		Map<DbRowOp, Integer> degree = inDegree();
+		Deque<DbRowOp> zeroDegree = new ArrayDeque<>();
+		LinkedList<DbRowOp> result = new LinkedList<>();
+
+		degree.forEach((k, v) -> {
+			if(v == 0) {
+				zeroDegree.push(k);
+			}
+		});
+
+		while (!zeroDegree.isEmpty()) {
+			DbRowOp v = zeroDegree.removeFirst();
+			result.push(v);
+
+			neighbors.get(v).forEach(neighbor ->
+					degree.computeIfPresent(neighbor, (k, oldValue) -> {
+						int newValue = --oldValue;
+						if(newValue == 0) {
+							zeroDegree.addLast(neighbor);
+						}
+						return newValue;
+					})
+			);
+		}
+
+		// Check that we have used the entire graph (if not, there was a cycle)
+		if (result.size() != neighbors.size()) {
+			Set<DbRowOp> remainingKeys = new HashSet<>(neighbors.keySet());
+			remainingKeys.removeIf(result::contains);
+			throw new IllegalStateException("Cycle detected in list for keys: " + remainingKeys);
+		}
+
+		return result;
+	}
+}

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/flush/operation/DbRowOpGraph.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/flush/operation/DbRowOpGraph.java
@@ -29,15 +29,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Graph sorting, copy of DIGraph implementation from cayenne-di.
  */
 class DbRowOpGraph {
-
-	private static final Logger LOGGER = LoggerFactory.getLogger(DbRowOpSorter.class);
 
 	/**
 	 * {@link LinkedHashMap} is used for supporting insertion order.
@@ -51,9 +46,7 @@ class DbRowOpGraph {
 	 * Add a vertex to the graph. Nothing happens if vertex is already in graph.
 	 */
 	void add(DbRowOp vertex) {
-		if(null == neighbors.putIfAbsent(vertex, new ArrayList<>(0))) {
-			LOGGER.info("Add graph vertex: {}", vertex);
-		}
+		neighbors.putIfAbsent(vertex, new ArrayList<>(0));
 	}
 
 	/**
@@ -62,7 +55,6 @@ class DbRowOpGraph {
 	 */
 	void add(DbRowOp from, DbRowOp to) {
 		neighbors.computeIfAbsent(from, k -> new ArrayList<>(4)).add(to);
-		LOGGER.info("Add graph edge: {} -> {}", from, to);
 		this.add(to);
 	}
 

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/flush/operation/DbRowOpGraph.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/flush/operation/DbRowOpGraph.java
@@ -29,10 +29,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Graph sorting, copy of DIGraph implementation from cayenne-di.
  */
 class DbRowOpGraph {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(DbRowOpSorter.class);
 
 	/**
 	 * {@link LinkedHashMap} is used for supporting insertion order.
@@ -46,7 +51,9 @@ class DbRowOpGraph {
 	 * Add a vertex to the graph. Nothing happens if vertex is already in graph.
 	 */
 	void add(DbRowOp vertex) {
-		neighbors.putIfAbsent(vertex, new ArrayList<>(0));
+		if(null == neighbors.putIfAbsent(vertex, new ArrayList<>(0))) {
+			LOGGER.info("Add graph vertex: {}", vertex);
+		}
 	}
 
 	/**
@@ -55,6 +62,7 @@ class DbRowOpGraph {
 	 */
 	void add(DbRowOp from, DbRowOp to) {
 		neighbors.computeIfAbsent(from, k -> new ArrayList<>(4)).add(to);
+		LOGGER.info("Add graph edge: {} -> {}", from, to);
 		this.add(to);
 	}
 

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/flush/operation/DbRowOpMerger.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/flush/operation/DbRowOpMerger.java
@@ -32,7 +32,7 @@ public class DbRowOpMerger implements DbRowOpVisitor<DbRowOp>, BiFunction<DbRowO
 
     private DbRowOp dbRow;
 
-    public DbRowOpMerger() {
+    DbRowOpMerger() {
     }
 
     @Override

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/flush/operation/DeleteDbRowOp.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/flush/operation/DeleteDbRowOp.java
@@ -42,6 +42,7 @@ public class DeleteDbRowOp extends BaseDbRowOp implements DbRowOpWithQualifier {
 
     public void setChangeId(ObjectId changeId) {
         this.changeId = changeId;
+        this.hashCode = changeId.hashCode();
     }
 
     @Override

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/flush/operation/DeleteDbRowOp.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/flush/operation/DeleteDbRowOp.java
@@ -40,6 +40,10 @@ public class DeleteDbRowOp extends BaseDbRowOp implements DbRowOpWithQualifier {
         return visitor.visitDelete(this);
     }
 
+    public void setChangeId(ObjectId changeId) {
+        this.changeId = changeId;
+    }
+
     @Override
     public boolean equals(Object o) {
         if(!(o instanceof DbRowOpWithQualifier)) {

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/flush/operation/GraphBasedDbRowOpSorter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/flush/operation/GraphBasedDbRowOpSorter.java
@@ -40,6 +40,8 @@ import org.apache.cayenne.map.DbRelationship;
 import org.apache.cayenne.map.EntityResolver;
 import org.apache.cayenne.query.ObjectIdQuery;
 import org.apache.cayenne.util.SingleEntryMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Db operation sorted that builds dependency graph and uses topological sort to get final order.
@@ -51,6 +53,8 @@ import org.apache.cayenne.util.SingleEntryMap;
  * @since 4.2
  */
 public class GraphBasedDbRowOpSorter implements DbRowOpSorter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DbRowOpSorter.class);
 
     private final DbRowOpTypeVisitor rowOpTypeVisitor = new DbRowOpTypeVisitor();
     private final Provider<DataDomain> dataDomainProvider;
@@ -176,6 +180,8 @@ public class GraphBasedDbRowOpSorter implements DbRowOpSorter {
         if(parentIdSnapshots.size() == 1) {
             EffectiveOpId id = effectiveIdFor(relationship, parentIdSnapshots.get(0));
             if(id != null) {
+                LOGGER.info("Found parent op for {} and relationship '{}': {}",
+                        op, relationship.getName(), id);
                 return Collections.singletonList(id);
             } else {
                 return Collections.emptyList();
@@ -185,6 +191,8 @@ public class GraphBasedDbRowOpSorter implements DbRowOpSorter {
             parentIdSnapshots.forEach(snapshot -> {
                 EffectiveOpId id = this.effectiveIdFor(relationship, snapshot);
                 if(id != null) {
+                    LOGGER.info("Found parent op for {} and relationship '{}': {}",
+                            op, relationship.getName(), id);
                     effectiveOpIds.add(id);
                 }
             });

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/flush/operation/GraphBasedDbRowOpSorter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/flush/operation/GraphBasedDbRowOpSorter.java
@@ -40,8 +40,6 @@ import org.apache.cayenne.map.DbRelationship;
 import org.apache.cayenne.map.EntityResolver;
 import org.apache.cayenne.query.ObjectIdQuery;
 import org.apache.cayenne.util.SingleEntryMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Db operation sorted that builds dependency graph and uses topological sort to get final order.
@@ -53,8 +51,6 @@ import org.slf4j.LoggerFactory;
  * @since 4.2
  */
 public class GraphBasedDbRowOpSorter implements DbRowOpSorter {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(DbRowOpSorter.class);
 
     private final DbRowOpTypeVisitor rowOpTypeVisitor = new DbRowOpTypeVisitor();
     private final Provider<DataDomain> dataDomainProvider;
@@ -122,8 +118,7 @@ public class GraphBasedDbRowOpSorter implements DbRowOpSorter {
         });
 
         // sort
-        List<DbRowOp> sortedOps = graph.topSort();
-        return sortedOps;
+        return graph.topSort();
     }
 
     private void processRelationships(Map<EffectiveOpId, List<DbRowOp>> indexByDbId, DbRowOpGraph graph, DbRowOp op) {
@@ -180,8 +175,6 @@ public class GraphBasedDbRowOpSorter implements DbRowOpSorter {
         if(parentIdSnapshots.size() == 1) {
             EffectiveOpId id = effectiveIdFor(relationship, parentIdSnapshots.get(0));
             if(id != null) {
-                LOGGER.info("Found parent op for {} and relationship '{}': {}",
-                        op, relationship.getName(), id);
                 return Collections.singletonList(id);
             } else {
                 return Collections.emptyList();
@@ -191,8 +184,6 @@ public class GraphBasedDbRowOpSorter implements DbRowOpSorter {
             parentIdSnapshots.forEach(snapshot -> {
                 EffectiveOpId id = this.effectiveIdFor(relationship, snapshot);
                 if(id != null) {
-                    LOGGER.info("Found parent op for {} and relationship '{}': {}",
-                            op, relationship.getName(), id);
                     effectiveOpIds.add(id);
                 }
             });

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/flush/operation/GraphBasedDbRowOpSorter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/flush/operation/GraphBasedDbRowOpSorter.java
@@ -1,0 +1,290 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.access.flush.operation;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.apache.cayenne.DataRow;
+import org.apache.cayenne.ObjectId;
+import org.apache.cayenne.Persistent;
+import org.apache.cayenne.QueryResponse;
+import org.apache.cayenne.access.DataDomain;
+import org.apache.cayenne.access.ObjectStore;
+import org.apache.cayenne.access.flush.EffectiveOpId;
+import org.apache.cayenne.di.Inject;
+import org.apache.cayenne.di.Provider;
+import org.apache.cayenne.exp.parser.ASTDbPath;
+import org.apache.cayenne.graph.GraphManager;
+import org.apache.cayenne.map.DbEntity;
+import org.apache.cayenne.map.DbRelationship;
+import org.apache.cayenne.map.EntityResolver;
+import org.apache.cayenne.query.ObjectIdQuery;
+import org.apache.cayenne.util.SingleEntryMap;
+
+/**
+ * Db operation sorted that builds dependency graph and uses topological sort to get final order.
+ * This in general slower than {@link DefaultDbRowOpSorter} but can handle more edge cases (like multiple meaningful PKs/FKs).
+ *
+ * TODO: possible optimizations could be optional logic parts (e.g. detecting effective id intersections,
+ *       reflexive dependencies, etc.)
+ *
+ * @since 4.2
+ */
+public class GraphBasedDbRowOpSorter implements DbRowOpSorter {
+
+    private final DbRowOpTypeVisitor rowOpTypeVisitor = new DbRowOpTypeVisitor();
+    private final Provider<DataDomain> dataDomainProvider;
+
+    private volatile Map<DbEntity, List<DbRelationship>> relationships;
+
+    public GraphBasedDbRowOpSorter(@Inject Provider<DataDomain> dataDomainProvider) {
+        this.dataDomainProvider = dataDomainProvider;
+    }
+
+    private void initDataSync() {
+        Map<DbEntity, List<DbRelationship>> localRelationships = relationships;
+        if(localRelationships == null) {
+            synchronized (this) {
+                localRelationships = relationships;
+                if(localRelationships == null) {
+                    initDataNoSync();
+                }
+            }
+        }
+    }
+
+    /**
+     * Init all the data we need for faster processing actual rows.
+     */
+    private void initDataNoSync() {
+        relationships = new HashMap<>();
+        EntityResolver resolver = dataDomainProvider.get().getEntityResolver();
+
+        resolver.getDbEntities().forEach(entity ->
+            entity.getRelationships().forEach(dbRelationship -> {
+                if(dbRelationship.isToMany() || !dbRelationship.isToPK() || dbRelationship.isToDependentPK()) {
+                    // TODO: can we ignore all of these relationships?
+                    return;
+                }
+
+                relationships
+                        .computeIfAbsent(entity, e -> new ArrayList<>())
+                        .add(dbRelationship);
+            })
+        );
+    }
+
+    @Override
+    public List<DbRowOp> sort(List<DbRowOp> dbRows) {
+        // lazy init Cayenne model data
+        initDataSync();
+
+        // build index op by ID
+        Map<EffectiveOpId, List<DbRowOp>> indexById = new HashMap<>(dbRows.size());
+        dbRows.forEach(op -> indexById
+                .computeIfAbsent(effectiveIdFor(op), id -> new ArrayList<>(2))
+                .add(op)
+        );
+
+        // build ops dependency graph
+        DbRowOpGraph graph = new DbRowOpGraph();
+        dbRows.forEach(op -> {
+            processRelationships(indexById, graph, op);
+            processMeaningfulIds(indexById, graph, op);
+            graph.add(op);
+        });
+
+        // sort
+        List<DbRowOp> sortedOps = graph.topSort();
+        return sortedOps;
+    }
+
+    private void processRelationships(Map<EffectiveOpId, List<DbRowOp>> indexByDbId, DbRowOpGraph graph, DbRowOp op) {
+        // get graph edges for reflexive relationships
+        DbRowOpType opType = op.accept(rowOpTypeVisitor);
+        relationships.getOrDefault(op.getEntity(), Collections.emptyList()).forEach(relationship ->
+            getParentsOpId(op, relationship).forEach(parentOpId ->
+                indexByDbId.getOrDefault(parentOpId, Collections.emptyList()).forEach(parentOp -> {
+                    if(op == parentOp) {
+                        return;
+                    }
+                    DbRowOpType parentOpType = parentOp.accept(rowOpTypeVisitor);
+                    // 1. Our insert can depend on others insert or update
+                    // 2. Our update can depend on others insert or update, or others delete can depend on our update
+                    // 3. Others delete can depend on our delete
+                    switch (opType) {
+                        case INSERT:
+                            if(parentOpType != DbRowOpType.DELETE) {
+                                graph.add(op, parentOp);
+                            }
+                            break;
+                        case UPDATE:
+                            if(parentOpType != DbRowOpType.DELETE) {
+                                graph.add(op, parentOp);
+                            } else {
+                                graph.add(parentOp, op);
+                            }
+                            break;
+                        case DELETE:
+                            if(parentOpType == DbRowOpType.DELETE) {
+                                graph.add(parentOp, op);
+                            }
+                    }
+                })
+            )
+        );
+    }
+
+    private void processMeaningfulIds(Map<EffectiveOpId, List<DbRowOp>> indexById, DbRowOpGraph graph, DbRowOp op) {
+        // get graph edges from same ID operations, for such operations delete depends on other operations
+        indexById.get(effectiveIdFor(op)).forEach(sameIdOp -> {
+            if(op == sameIdOp) {
+                return;
+            }
+            DbRowOpType sameIdOpType = sameIdOp.accept(rowOpTypeVisitor);
+            if(sameIdOpType == DbRowOpType.DELETE) {
+                graph.add(op, sameIdOp);
+            }
+        });
+    }
+
+    private Collection<EffectiveOpId> getParentsOpId(DbRowOp op, DbRelationship relationship) {
+        return op.accept(new DbRowOpSnapshotVisitor(relationship)).stream()
+                .map(snapshot -> this.effectiveIdFor(relationship, snapshot))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    private EffectiveOpId effectiveIdFor(DbRowOp op) {
+        return new EffectiveOpId(op.getEntity().getName(), op.getChangeId());
+    }
+
+    private EffectiveOpId effectiveIdFor(DbRelationship relationship, Map<String, Object> opSnapshot) {
+        int len = relationship.getJoins().size();
+        Map<String, Object> idMap = len == 1
+                ? new SingleEntryMap<>(relationship.getJoins().get(0).getTargetName())
+                : new HashMap<>(len);
+        relationship.getJoins().forEach(join -> {
+            Object value = opSnapshot.get(join.getSourceName());
+            if(value == null) {
+                return;
+            }
+            idMap.put(join.getTargetName(), value);
+        });
+        if(idMap.size() != len) {
+            return null;
+        }
+        return new EffectiveOpId(ObjectId.of(relationship.getTargetEntityName(), idMap));
+    }
+
+    private static class DbRowOpSnapshotVisitor implements DbRowOpVisitor<Collection<Map<String, Object>>> {
+
+        private final DbRelationship relationship;
+
+        private DbRowOpSnapshotVisitor(DbRelationship relationship) {
+            this.relationship = relationship;
+        }
+
+        @Override
+        public Collection<Map<String, Object>> visitInsert(InsertDbRowOp dbRow) {
+            return Collections.singletonList(dbRow.getValues().getSnapshot());
+        }
+
+        @Override
+        public Collection<Map<String, Object>> visitUpdate(UpdateDbRowOp dbRow) {
+            List<Map<String, Object>> result;
+            Map<String, Object> updatedSnapshot = dbRow.getValues().getSnapshot();
+            if(dbRow.getChangeId().getEntityName().startsWith(ASTDbPath.DB_PREFIX)) {
+                return Collections.singletonList(updatedSnapshot);
+            }
+            result = new ArrayList<>(2);
+            // get updated state from operation
+            result.add(updatedSnapshot);
+            // get previous state from cache, but only for update attributes
+            Map<String, Object> cachedSnapshot = getCachedSnapshot(dbRow.getObject());
+            cachedSnapshot.entrySet().forEach(entry -> {
+                if(!updatedSnapshot.containsKey(entry.getKey())) {
+                    entry.setValue(null);
+                }
+            });
+            result.add(cachedSnapshot);
+            return result;
+        }
+
+        @Override
+        public Collection<Map<String, Object>> visitDelete(DeleteDbRowOp dbRow) {
+            Map<String, Object> cachedSnapshot = getCachedSnapshot(dbRow.getObject());
+
+            // check and merge flattened IDs snapshots
+            GraphManager graphManager = dbRow.getObject().getObjectContext().getGraphManager();
+            if(graphManager instanceof ObjectStore) {
+                ObjectStore store = (ObjectStore)graphManager;
+                store.getFlattenedIds(dbRow.getObject().getObjectId()).forEach(flattenedId -> {
+                    // map values of flattened ids from target to source
+                    Map<String, Object> idSnapshot = flattenedId.getIdSnapshot();
+                    relationship.getJoins().forEach(join -> {
+                        Object value = idSnapshot.get(join.getTargetName());
+                        if(value != null) {
+                            cachedSnapshot.put(join.getSourceName(), value);
+                        }
+                    });
+                });
+            }
+            cachedSnapshot.putAll(dbRow.getQualifier().getSnapshot());
+            return Collections.singletonList(cachedSnapshot);
+        }
+
+        private Map<String, Object> getCachedSnapshot(Persistent object) {
+            ObjectIdQuery query = new ObjectIdQuery(object.getObjectId(), true, ObjectIdQuery.CACHE);
+            QueryResponse response = object.getObjectContext().getChannel().onQuery(null, query);
+            @SuppressWarnings("unchecked")
+            List<DataRow> result = (List<DataRow>) response.firstList();
+            if (result == null || result.size() == 0) {
+                return Collections.emptyMap();
+            }
+            // copy snapshot as we can modify it later
+            return new HashMap<>(result.get(0));
+        }
+    }
+
+    private static class DbRowOpTypeVisitor implements DbRowOpVisitor<DbRowOpType> {
+        @Override
+        public DbRowOpType visitDelete(DeleteDbRowOp dbRow) {
+            return DbRowOpType.DELETE;
+        }
+
+        @Override
+        public DbRowOpType visitInsert(InsertDbRowOp dbRow) {
+            return DbRowOpType.INSERT;
+        }
+
+        @Override
+        public DbRowOpType visitUpdate(UpdateDbRowOp dbRow) {
+            return DbRowOpType.UPDATE;
+        }
+    }
+}

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/sqlbuilder/sqltree/ValueNode.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/sqlbuilder/sqltree/ValueNode.java
@@ -19,6 +19,8 @@
 
 package org.apache.cayenne.access.sqlbuilder.sqltree;
 
+import java.util.function.Supplier;
+
 import org.apache.cayenne.CayenneRuntimeException;
 import org.apache.cayenne.ObjectId;
 import org.apache.cayenne.Persistent;
@@ -101,6 +103,8 @@ public class ValueNode extends Node {
                 appendValue((Persistent) val, buffer);
             } else if(val instanceof ObjectId) {
                 appendValue((ObjectId) val, buffer);
+            } else if(val instanceof Supplier) {
+                appendValue(((Supplier<?>) val).get(), buffer);
             } else if(val instanceof CharSequence) {
                 appendStringValue(buffer, (CharSequence)val);
             } else {
@@ -135,7 +139,7 @@ public class ValueNode extends Node {
         // value can't be null here
         SQLGenerationContext context = buffer.getContext();
         // allow translation in out-of-context scope, to be able to use as a standalone SQL generator
-        ExtendedType extendedType = context.getAdapter().getExtendedTypes().getRegisteredType(value.getClass());
+        ExtendedType<?> extendedType = context.getAdapter().getExtendedTypes().getRegisteredType(value.getClass());
         DbAttributeBinding binding = new DbAttributeBinding(attribute);
         binding.setStatementPosition(context.getBindings().size() + 1);
         binding.setExtendedType(extendedType);

--- a/cayenne-server/src/test/java/org/apache/cayenne/access/DataContextEntityWithMeaningfulPKIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/access/DataContextEntityWithMeaningfulPKIT.java
@@ -204,4 +204,32 @@ public class DataContextEntityWithMeaningfulPKIT extends ServerCase {
         pkObj2.setPk("123");
         context.commitChanges();
     }
+
+    @Test
+    @Ignore
+    public void test_MeaningfulPkInsertDeleteCascade() {
+        // setup
+        MeaningfulPKTest1 obj = context.newObject(MeaningfulPKTest1.class);
+        obj.setPkAttribute(1000);
+        obj.setDescr("aaa");
+        context.commitChanges();
+
+        // must be able to set reverse relationship
+        MeaningfulPKDep dep = context.newObject(MeaningfulPKDep.class);
+        dep.setToMeaningfulPK(obj);
+        dep.setPk(10);
+        context.commitChanges();
+
+        // test
+        context.deleteObject(obj);
+
+        MeaningfulPKTest1 obj2 = context.newObject(MeaningfulPKTest1.class);
+        obj2.setPkAttribute(1000);
+        obj2.setDescr("bbb");
+
+        MeaningfulPKDep dep2 = context.newObject(MeaningfulPKDep.class);
+        dep2.setToMeaningfulPK(obj2);
+        dep2.setPk(10);
+        context.commitChanges();
+    }
 }

--- a/cayenne-server/src/test/java/org/apache/cayenne/access/flush/EffectiveOpIdTest.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/access/flush/EffectiveOpIdTest.java
@@ -1,0 +1,46 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.access.flush;
+
+import java.util.Collections;
+
+import org.apache.cayenne.ObjectId;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @since 4.2
+ */
+public class EffectiveOpIdTest {
+
+    @Test
+    public void testEqualsTempGeneratedId() {
+        ObjectId id1 = ObjectId.of("test");
+        id1.getReplacementIdMap().put("pk", new IdGenerationMarker(id1));
+        EffectiveOpId effectiveOpId1 = new EffectiveOpId(id1);
+
+        ObjectId id2 = ObjectId.of("test", Collections.singletonMap("pk", ObjectIdValueSupplier.getFor(id1, "pk")));
+        EffectiveOpId effectiveOpId2 = new EffectiveOpId(id2);
+
+        assertEquals(effectiveOpId1, effectiveOpId2);
+    }
+
+}

--- a/cayenne-server/src/test/java/org/apache/cayenne/access/flush/EffectiveOpIdTest.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/access/flush/EffectiveOpIdTest.java
@@ -35,10 +35,9 @@ public class EffectiveOpIdTest {
     public void testEqualsTempGeneratedId() {
         ObjectId id1 = ObjectId.of("test");
         id1.getReplacementIdMap().put("pk", new IdGenerationMarker(id1));
-        EffectiveOpId effectiveOpId1 = new EffectiveOpId(id1);
+        EffectiveOpId effectiveOpId1 = new EffectiveOpId("test", Collections.singletonMap("pk", new IdGenerationMarker(id1)));
 
-        ObjectId id2 = ObjectId.of("test", Collections.singletonMap("pk", ObjectIdValueSupplier.getFor(id1, "pk")));
-        EffectiveOpId effectiveOpId2 = new EffectiveOpId(id2);
+        EffectiveOpId effectiveOpId2 = new EffectiveOpId("test", Collections.singletonMap("pk", ObjectIdValueSupplier.getFor(id1, "pk")));
 
         assertEquals(effectiveOpId1, effectiveOpId2);
     }

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/meaningful_pk/auto/_MeaningfulPKDep.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/meaningful_pk/auto/_MeaningfulPKDep.java
@@ -5,7 +5,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.ExpressionFactory;
 import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.NumericProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
@@ -22,13 +21,14 @@ public abstract class _MeaningfulPKDep extends BaseDataObject {
 
     private static final long serialVersionUID = 1L; 
 
-    public static final NumericProperty<Integer> PK_ATTRIBUTE_PK_PROPERTY = PropertyFactory.createNumeric(ExpressionFactory.dbPathExp("PK_ATTRIBUTE"), Integer.class);
     public static final String PK_ATTRIBUTE_PK_COLUMN = "PK_ATTRIBUTE";
 
     public static final StringProperty<String> DESCR = PropertyFactory.createString("descr", String.class);
+    public static final NumericProperty<Integer> PK = PropertyFactory.createNumeric("pk", Integer.class);
     public static final EntityProperty<MeaningfulPKTest1> TO_MEANINGFUL_PK = PropertyFactory.createEntity("toMeaningfulPK", MeaningfulPKTest1.class);
 
     protected String descr;
+    protected int pk;
 
     protected Object toMeaningfulPK;
 
@@ -40,6 +40,16 @@ public abstract class _MeaningfulPKDep extends BaseDataObject {
     public String getDescr() {
         beforePropertyRead("descr");
         return this.descr;
+    }
+
+    public void setPk(int pk) {
+        beforePropertyWrite("pk", this.pk, pk);
+        this.pk = pk;
+    }
+
+    public int getPk() {
+        beforePropertyRead("pk");
+        return this.pk;
     }
 
     public void setToMeaningfulPK(MeaningfulPKTest1 toMeaningfulPK) {
@@ -59,6 +69,8 @@ public abstract class _MeaningfulPKDep extends BaseDataObject {
         switch(propName) {
             case "descr":
                 return this.descr;
+            case "pk":
+                return this.pk;
             case "toMeaningfulPK":
                 return this.toMeaningfulPK;
             default:
@@ -75,6 +87,9 @@ public abstract class _MeaningfulPKDep extends BaseDataObject {
         switch (propName) {
             case "descr":
                 this.descr = (String)val;
+                break;
+            case "pk":
+                this.pk = val == null ? 0 : (int)val;
                 break;
             case "toMeaningfulPK":
                 this.toMeaningfulPK = val;
@@ -96,6 +111,7 @@ public abstract class _MeaningfulPKDep extends BaseDataObject {
     protected void writeState(ObjectOutputStream out) throws IOException {
         super.writeState(out);
         out.writeObject(this.descr);
+        out.writeInt(this.pk);
         out.writeObject(this.toMeaningfulPK);
     }
 
@@ -103,6 +119,7 @@ public abstract class _MeaningfulPKDep extends BaseDataObject {
     protected void readState(ObjectInputStream in) throws IOException, ClassNotFoundException {
         super.readState(in);
         this.descr = (String)in.readObject();
+        this.pk = in.readInt();
         this.toMeaningfulPK = in.readObject();
     }
 

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/meaningful_pk/auto/_MeaningfulPKTest1.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/meaningful_pk/auto/_MeaningfulPKTest1.java
@@ -6,7 +6,6 @@ import java.io.ObjectOutputStream;
 import java.util.List;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.ExpressionFactory;
 import org.apache.cayenne.exp.property.ListProperty;
 import org.apache.cayenne.exp.property.NumericProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/meaningful_pk/auto/_MeaningfulPk.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/meaningful_pk/auto/_MeaningfulPk.java
@@ -5,7 +5,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.ExpressionFactory;
 import org.apache.cayenne.exp.property.PropertyFactory;
 import org.apache.cayenne.exp.property.StringProperty;
 

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/meaningful_pk/auto/_MeaningfulPkTest2.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/meaningful_pk/auto/_MeaningfulPkTest2.java
@@ -5,7 +5,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.ExpressionFactory;
 import org.apache.cayenne.exp.property.NumericProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
 

--- a/cayenne-server/src/test/resources/cayenne-meaningful-pk.xml
+++ b/cayenne-server/src/test/resources/cayenne-meaningful-pk.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <domain xmlns="http://cayenne.apache.org/schema/10/domain"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://cayenne.apache.org/schema/10/domain http://cayenne.apache.org/schema/10/domain.xsd"
+	 xsi:schemaLocation="http://cayenne.apache.org/schema/10/domain https://cayenne.apache.org/schema/10/domain.xsd"
 	 project-version="10">
 	<map name="meaningful-pk"/>
 </domain>

--- a/cayenne-server/src/test/resources/compound.map.xml
+++ b/cayenne-server/src/test/resources/compound.map.xml
@@ -89,7 +89,7 @@
 		<db-attribute-pair source="KEY1" target="F_KEY1"/>
 		<db-attribute-pair source="KEY2" target="F_KEY2"/>
 	</db-relationship>
-	<db-relationship name="lines" source="compound_order" target="compound_order_line" toMany="true">
+	<db-relationship name="lines" source="compound_order" target="compound_order_line" toDependentPK="true" toMany="true">
 		<db-attribute-pair source="order_number" target="order_number"/>
 	</db-relationship>
 	<db-relationship name="order" source="compound_order_line" target="compound_order">

--- a/cayenne-server/src/test/resources/meaningful-pk.map.xml
+++ b/cayenne-server/src/test/resources/meaningful-pk.map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <data-map xmlns="http://cayenne.apache.org/schema/10/modelMap"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://cayenne.apache.org/schema/10/modelMap http://cayenne.apache.org/schema/10/modelMap.xsd"
+	 xsi:schemaLocation="http://cayenne.apache.org/schema/10/modelMap https://cayenne.apache.org/schema/10/modelMap.xsd"
 	 project-version="10">
 	<property name="defaultPackage" value="org.apache.cayenne.testdo.meaningful_pk"/>
 	<property name="clientSupported" value="true"/>
@@ -27,6 +27,7 @@
 	</db-entity>
 	<obj-entity name="MeaningfulPKDep" className="org.apache.cayenne.testdo.meaningful_pk.MeaningfulPKDep" dbEntityName="MEANINGFUL_PK_DEP">
 		<obj-attribute name="descr" type="java.lang.String" db-attribute-path="DESCR"/>
+		<obj-attribute name="pk" type="int" db-attribute-path="PK_ATTRIBUTE"/>
 	</obj-entity>
 	<obj-entity name="MeaningfulPKTest1" className="org.apache.cayenne.testdo.meaningful_pk.MeaningfulPKTest1" dbEntityName="MEANINGFUL_PK_TEST1">
 		<obj-attribute name="descr" type="java.lang.String" db-attribute-path="DESCR"/>
@@ -49,5 +50,5 @@
 		<db-attribute-pair source="PK_ATTRIBUTE" target="MASTER_PK"/>
 	</db-relationship>
 	<obj-relationship name="toMeaningfulPK" source="MeaningfulPKDep" target="MeaningfulPKTest1" db-relationship-path="toMeaningfulPK"/>
-	<obj-relationship name="meaningfulPKDepArray" source="MeaningfulPKTest1" target="MeaningfulPKDep" db-relationship-path="meaningfulPKDepArray"/>
+	<obj-relationship name="meaningfulPKDepArray" source="MeaningfulPKTest1" target="MeaningfulPKDep" deleteRule="Cascade" db-relationship-path="meaningfulPKDepArray"/>
 </data-map>


### PR DESCRIPTION
This is an experimental implementation of a Db operations sorter that builds a directed graph and uses topological sort to get the final order of operations. 
This sorter can correctly order meaningful PK intersections (i.e. delete/insert rows with the same primary keys). 
Moreover, it opens a possibility to automatically break cycles in DB operations.
