### PR TITLE
Use whitelist for Hessian serialization

### DIFF
--- a/cayenne-client/src/main/java/org/apache/cayenne/remote/hessian/ClientSerializerFactory.java
+++ b/cayenne-client/src/main/java/org/apache/cayenne/remote/hessian/ClientSerializerFactory.java
@@ -19,13 +19,13 @@
 
 package org.apache.cayenne.remote.hessian;
 
+import com.caucho.hessian.io.FieldDeserializer2Factory;
 import org.apache.cayenne.DataRow;
 import org.apache.cayenne.util.PersistentObjectList;
 import org.apache.cayenne.util.PersistentObjectMap;
 
 import com.caucho.hessian.io.AbstractSerializerFactory;
 import com.caucho.hessian.io.Deserializer;
-import com.caucho.hessian.io.HessianProtocolException;
 import com.caucho.hessian.io.JavaDeserializer;
 import com.caucho.hessian.io.Serializer;
 
@@ -41,23 +41,23 @@ public class ClientSerializerFactory extends AbstractSerializerFactory {
     private Deserializer mapDeserializer;
 
     @Override
-    public Serializer getSerializer(Class cl) throws HessianProtocolException {
+    public Serializer getSerializer(Class cl) {
         return null;
     }
 
     @Override
-    public Deserializer getDeserializer(Class cl) throws HessianProtocolException {
+    public Deserializer getDeserializer(Class cl) {
         //turns out Hessian uses its own (incorrect) serialization mechanism for maps
         if (PersistentObjectMap.class.isAssignableFrom(cl)) {
             if (mapDeserializer == null) {
-                mapDeserializer = new JavaDeserializer(cl);
+                mapDeserializer = new JavaDeserializer(cl, FieldDeserializer2Factory.create());
             }
             return mapDeserializer;
         }
         
         if (PersistentObjectList.class.isAssignableFrom(cl)) {
             if (listDeserializer == null) {
-                listDeserializer = new JavaDeserializer(cl);
+                listDeserializer = new JavaDeserializer(cl, FieldDeserializer2Factory.create());
             }
             return listDeserializer;
         }

--- a/cayenne-client/src/main/java/org/apache/cayenne/rop/HttpClientConnectionProvider.java
+++ b/cayenne-client/src/main/java/org/apache/cayenne/rop/HttpClientConnectionProvider.java
@@ -33,7 +33,7 @@ public class HttpClientConnectionProvider implements Provider<ClientConnection> 
     protected RuntimeProperties runtimeProperties;
     
     @Inject
-    protected ROPSerializationService serializationService;
+    protected Provider<ROPSerializationService> serializationServiceProvider;
 
     @Override
     public ClientConnection get() throws DIRuntimeException {
@@ -41,7 +41,7 @@ public class HttpClientConnectionProvider implements Provider<ClientConnection> 
                 .get(ClientConstants.ROP_SERVICE_SHARED_SESSION_PROPERTY);
 
         HttpROPConnector ropConnector = createHttpRopConnector();
-        ProxyRemoteService remoteService = new ProxyRemoteService(serializationService, ropConnector);
+        ProxyRemoteService remoteService = new ProxyRemoteService(serializationServiceProvider.get(), ropConnector);
 
         HttpClientConnection clientConnection = new HttpClientConnection(remoteService, sharedSession);
         ropConnector.setClientConnection(clientConnection);

--- a/cayenne-client/src/test/java/org/apache/cayenne/rop/http/HessianROPSerializationServiceIT.java
+++ b/cayenne-client/src/test/java/org/apache/cayenne/rop/http/HessianROPSerializationServiceIT.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.util.Collections;
 
 import static org.junit.Assert.*;
 
@@ -107,7 +108,7 @@ public class HessianROPSerializationServiceIT extends ClientCase {
 	}
 
 	private ROPSerializationService createServerSerializationService() {
-		return new ServerHessianSerializationServiceProvider().get();
+		return new ServerHessianSerializationServiceProvider(() -> context.getChannel(), Collections.emptyList()).get();
 	}
 	
 }

--- a/cayenne-rop-server/src/main/java/org/apache/cayenne/configuration/rop/server/ROPServerModule.java
+++ b/cayenne-rop-server/src/main/java/org/apache/cayenne/configuration/rop/server/ROPServerModule.java
@@ -22,9 +22,11 @@ import java.util.Map;
 
 import org.apache.cayenne.configuration.Constants;
 import org.apache.cayenne.di.Binder;
+import org.apache.cayenne.di.ListBuilder;
 import org.apache.cayenne.di.MapBuilder;
 import org.apache.cayenne.di.Module;
 import org.apache.cayenne.remote.RemoteService;
+import org.apache.cayenne.rop.ROPConstants;
 import org.apache.cayenne.rop.ROPSerializationService;
 import org.apache.cayenne.rop.ServerHessianSerializationServiceProvider;
 import org.apache.cayenne.rop.ServerHttpRemoteService;
@@ -46,6 +48,14 @@ public class ROPServerModule implements Module {
         return binder.bindMap(String.class, Constants.SERVER_ROP_EVENT_BRIDGE_PROPERTIES_MAP);
     }
 
+    /**
+     * @since 4.2
+     */
+    public static ListBuilder<String> contributeSerializationWhitelist(Binder binder) {
+        return binder.bindList(String.class, ROPConstants.SERIALIZATION_WHITELIST);
+    }
+
+
     public ROPServerModule() {}
 
     /**
@@ -60,8 +70,9 @@ public class ROPServerModule implements Module {
     }
 
     public void configure(Binder binder) {
+        contributeSerializationWhitelist(binder);
+        MapBuilder<String> mapBuilder = contributeROPBridgeProperties(binder);
         if(eventBridgeProperties != null) {
-            MapBuilder<String> mapBuilder = contributeROPBridgeProperties(binder);
             mapBuilder.putAll(eventBridgeProperties);
         }
         binder.bind(RemoteService.class).to(ServerHttpRemoteService.class);

--- a/cayenne-rop-server/src/main/java/org/apache/cayenne/remote/hessian/HessianConfig.java
+++ b/cayenne-rop-server/src/main/java/org/apache/cayenne/remote/hessian/HessianConfig.java
@@ -21,8 +21,13 @@ package org.apache.cayenne.remote.hessian;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 import org.apache.cayenne.CayenneRuntimeException;
+import org.apache.cayenne.map.DataMap;
 import org.apache.cayenne.map.EntityResolver;
 import org.apache.cayenne.util.Util;
 
@@ -47,21 +52,57 @@ public class HessianConfig {
      *            and have a default constructor.
      * @param resolver if not null, EntityResolver will be injected into all factories
      *            that implement <em>setEntityResolver(EntityResolver)</em> method.
+     * @see #createFactory(String[], EntityResolver, Collection)
      */
     public static SerializerFactory createFactory(
             String[] factoryNames,
             EntityResolver resolver) {
+        return createFactory(factoryNames, resolver, Collections.emptyList());
+    }
+
+    /**
+     * Creates a Hessian SerializerFactory configured with zero or more
+     * AbstractSerializerFactory extensions. Extensions are specified as class names. This
+     * method can inject EntityResolver if an extension factory class defines
+     * <em>setEntityResolver(EntityResolver)</em> method.
+     *
+     * @param factoryNames an array of factory class names. Each class must be a concrete
+     *            subclass of <em>com.caucho.hessian.io.AbstractSerializerFactory</em>
+     *            and have a default constructor.
+     * @param resolver if not null, EntityResolver will be injected into all factories
+     *            that implement <em>setEntityResolver(EntityResolver)</em> method.
+     * @param additionalWhitelist serialization whitelist, examples: "java.util.*", "com.foo.io.Bean"
+     * @see #createFactory(String[], EntityResolver)
+     *
+     * @since 4.2
+     */
+    public static SerializerFactory createFactory(
+            String[] factoryNames,
+            EntityResolver resolver,
+            Collection<String> additionalWhitelist) {
 
         SerializerFactory factory = new CayenneSerializerFactory();
 
+        List<String> whitelist = new ArrayList<>(additionalWhitelist);
+        if(resolver != null) {
+            whitelist.add("org.apache.cayenne.*");
+            for (DataMap dataMap : resolver.getDataMaps()) {
+                whitelist.add(dataMap.getDefaultPackage() + ".*");
+            }
+        }
+
+        if(!whitelist.isEmpty()) {
+            for (String pattern : whitelist) {
+                factory.getClassFactory().allow(pattern);
+            }
+            factory.getClassFactory().setWhitelist(true);
+        }
+
         if (factoryNames != null && factoryNames.length > 0) {
-
             for (String factoryName : factoryNames) {
-
                 try {
                     factory.addFactory(loadFactory(factoryName, resolver));
-                }
-                catch (Exception e) {
+                } catch (Exception e) {
                     throw new CayenneRuntimeException("Error configuring factory class "
                             + factoryName, e);
                 }
@@ -83,16 +124,14 @@ public class HessianConfig {
                     + " is not a AbstractSerializerFactory");
         }
 
-        Constructor c = factoryClass.getDeclaredConstructor();
+        Constructor<?> c = factoryClass.getDeclaredConstructor();
         if (!Util.isAccessible(c)) {
             c.setAccessible(true);
         }
 
         AbstractSerializerFactory object = (AbstractSerializerFactory) c.newInstance();
-
         if (resolver != null) {
             try {
-
                 Method setter = factoryClass.getDeclaredMethod(
                         "setEntityResolver",
                         EntityResolver.class);
@@ -102,8 +141,7 @@ public class HessianConfig {
                 }
 
                 setter.invoke(object, resolver);
-            }
-            catch (Exception e) {
+            } catch (Exception ignore) {
                 // ignore injection exception
             }
         }

--- a/cayenne-rop-server/src/main/java/org/apache/cayenne/rop/ROPConstants.java
+++ b/cayenne-rop-server/src/main/java/org/apache/cayenne/rop/ROPConstants.java
@@ -25,4 +25,9 @@ public class ROPConstants {
 
     public static final String ESTABLISH_SESSION_OPERATION = "establish_session";
     public static final String ESTABLISH_SHARED_SESSION_OPERATION = "establish_shared_session";
+
+    /**
+     * @since 4.2
+     */
+    public static final String SERIALIZATION_WHITELIST = "serialization_whitelist";
 }

--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@
             <dependency>
                 <groupId>com.caucho</groupId>
                 <artifactId>hessian</artifactId>
-                <version>4.0.51</version>
+                <version>4.0.63</version>
                 <scope>provided</scope>
             </dependency>
 			<dependency>


### PR DESCRIPTION
This PR updates the Hessian version and enables whitelist only serialization.