### PR TITLE
No methods for queries with qualifier parameters generated

### DIFF
--- a/cayenne-cgen/src/main/java/org/apache/cayenne/gen/DataMapUtils.java
+++ b/cayenne-cgen/src/main/java/org/apache/cayenne/gen/DataMapUtils.java
@@ -179,7 +179,7 @@ public class DataMapUtils {
 
 				if (operand instanceof ASTObjPath) {
 					PathComponent<ObjAttribute, ObjRelationship> component = ((Entity) root).lastPathComponent(
-							(ASTObjPath) operand, null);
+							(ASTObjPath) operand, Collections.emptyMap());
 					ObjAttribute attribute = component.getAttribute();
 					if (attribute != null) {
 						typeName = attribute.getType();


### PR DESCRIPTION
Cgen should generate a `perform`-method for queries with qualifiers (e.g. `username = $ausername`) stored in the datamap, but there is no method generated. Queries without qualifiers get such a method.

If the alias map for `Entity.lastPathComponent(Expression, Map)` is null then an exception is thrown later in the constructor of `org.apache.cayenne.map.PathComponentIterator` at the line 

```
this.aliasMap = Objects.requireNonNull(aliasMap)
```

This means the qualifier is seen as invalid and therefore no `perform`-method is generated.