### PR TITLE
Exception in dbimport when relationships should be imported, but no explicit configuration exists

### DIFF
--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/dbload/RelationshipLoader.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/dbload/RelationshipLoader.java
@@ -120,7 +120,7 @@ public class RelationshipLoader extends AbstractLoader {
                 .tableFilter(relationship.getTargetEntity().getCatalog(), relationship.getTargetEntity().getSchema());
 
         // check that relationship can be included
-        if(!sourceTableFilter.getIncludeTableRelationshipFilter(entity.getName())
+        if(sourceTableFilter != null && !sourceTableFilter.getIncludeTableRelationshipFilter(entity.getName())
                 .isIncluded(relationship.getName())) {
             return;
         }
@@ -131,12 +131,14 @@ public class RelationshipLoader extends AbstractLoader {
             return;
         }
 
-        // check that all join attributes are included
-        for(DbJoin join : relationship.getJoins()) {
-            if(!sourceTableFilter.getIncludeTableColumnFilter(entity.getName()).isIncluded(join.getSourceName()) ||
-                    !targetTableFilter.getIncludeTableColumnFilter(relationship.getTargetEntityName()).isIncluded(join.getTargetName())) {
-                return;
-            }
+        if(sourceTableFilter != null && targetTableFilter != null) {
+	        // check that all join attributes are included
+	        for(DbJoin join : relationship.getJoins()) {
+	            if(!sourceTableFilter.getIncludeTableColumnFilter(entity.getName()).isIncluded(join.getSourceName()) ||
+	                    !targetTableFilter.getIncludeTableColumnFilter(relationship.getTargetEntityName()).isIncluded(join.getTargetName())) {
+	                return;
+	            }
+	        }
         }
 
         // add relationship if delegate permit it


### PR DESCRIPTION
If there is no explicit database import configuration (e.g. included or excluded tables) then the database import may fail with a NullPointerException when 'Skip relationship loading' is *not* activated. When relationships are skipped, the import succeeds.

Check if `sourceTableFilter` in `RelationshipFilter.checkAndAddRelationship(DbEntity, DbRelationship` is null and skip then the include check (under the assumption that then all relationships should get imported).
