### PR TITLE
CAY-2636 Modeler: Ordering in db import config

### DIFF
--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/action/dbimport/AddIncludeTableAction.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/action/dbimport/AddIncludeTableAction.java
@@ -53,7 +53,7 @@ public class AddIncludeTableAction extends TreeManipulationAction {
         IncludeTable newTable = new IncludeTable(name);
         if (canBeInserted(selectedElement)) {
             ((FilterContainer) selectedElement.getUserObject()).addIncludeTable(newTable);
-            selectedElement.add(new DbImportTreeNode(newTable));
+            selectedElement.insert(new DbImportTreeNode(newTable), this.getLastPositionIncludeTable());
             updateSelected = true;
         } else {
             if (parentElement == null) {

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/action/dbimport/AddPatternParamAction.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/action/dbimport/AddPatternParamAction.java
@@ -73,12 +73,12 @@ public abstract class AddPatternParamAction extends TreeManipulationAction {
         if (paramClass == IncludeColumn.class) {
             element = new IncludeColumn(name);
             includeTable.addIncludeColumn((IncludeColumn) element);
-
+            node.insert(new DbImportTreeNode(element), includeTable.getIncludeColumns().size() - 1);
         } else if (paramClass == ExcludeColumn.class) {
             element = new ExcludeColumn(name);
             includeTable.addExcludeColumn((ExcludeColumn) element);
+            node.add(new DbImportTreeNode(element));
         }
-        node.add(new DbImportTreeNode(element));
     }
 
     @Override

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/action/dbimport/TreeManipulationAction.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/action/dbimport/TreeManipulationAction.java
@@ -19,15 +19,7 @@
 
 package org.apache.cayenne.modeler.action.dbimport;
 
-import org.apache.cayenne.dbsync.reverse.dbimport.Catalog;
-import org.apache.cayenne.dbsync.reverse.dbimport.ExcludeColumn;
-import org.apache.cayenne.dbsync.reverse.dbimport.ExcludeProcedure;
-import org.apache.cayenne.dbsync.reverse.dbimport.ExcludeTable;
-import org.apache.cayenne.dbsync.reverse.dbimport.IncludeColumn;
-import org.apache.cayenne.dbsync.reverse.dbimport.IncludeProcedure;
-import org.apache.cayenne.dbsync.reverse.dbimport.IncludeTable;
-import org.apache.cayenne.dbsync.reverse.dbimport.ReverseEngineering;
-import org.apache.cayenne.dbsync.reverse.dbimport.Schema;
+import org.apache.cayenne.dbsync.reverse.dbimport.*;
 import org.apache.cayenne.modeler.Application;
 import org.apache.cayenne.modeler.dialog.db.load.DbImportTreeNode;
 import org.apache.cayenne.modeler.editor.dbimport.DbImportModel;
@@ -228,5 +220,10 @@ public abstract class TreeManipulationAction extends CayenneAction {
 
     void setFoundNode(DbImportTreeNode node) {
         this.foundNode = node;
+    }
+
+    public int getLastPositionIncludeTable() {
+        FilterContainer catalog = (FilterContainer) this.selectedElement.getUserObject();
+        return catalog.getIncludeTables().size() - 1;
     }
 }


### PR DESCRIPTION
Completed first item: when elements are including or excluding, they are immediately order, all includes are precede all excludes.