### PR TITLE
fixed return of statement when using FrontBase DB

### DIFF
--- a/cayenne-server/src/main/java/org/apache/cayenne/access/jdbc/SQLTemplateAction.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/jdbc/SQLTemplateAction.java
@@ -41,6 +41,7 @@ import org.apache.cayenne.access.types.ExtendedType;
 import org.apache.cayenne.access.types.ExtendedTypeMap;
 import org.apache.cayenne.dba.DbAdapter;
 import org.apache.cayenne.dba.TypesMapping;
+import org.apache.cayenne.dba.frontbase.FrontBaseAdapter;
 import org.apache.cayenne.map.DbAttribute;
 import org.apache.cayenne.map.DbEntity;
 import org.apache.cayenne.map.DefaultScalarResultSegment;
@@ -188,6 +189,9 @@ public class SQLTemplateAction implements SQLAction {
 		boolean iteratedResult = callback.isIteratedResult();
 		int generatedKeys = query.isReturnGeneratedKeys() ? Statement.RETURN_GENERATED_KEYS : Statement.NO_GENERATED_KEYS;
 		PreparedStatement statement = connection.prepareStatement(compiled.getSql(), generatedKeys);
+		if (statement == null && this.dbAdapter instanceof FrontBaseAdapter) {
+			statement = connection.prepareStatement(compiled.getSql());
+		}
 		try {
 			bind(statement, compiled.getBindings());
 

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/jdbc/SQLTemplateAction.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/jdbc/SQLTemplateAction.java
@@ -41,7 +41,6 @@ import org.apache.cayenne.access.types.ExtendedType;
 import org.apache.cayenne.access.types.ExtendedTypeMap;
 import org.apache.cayenne.dba.DbAdapter;
 import org.apache.cayenne.dba.TypesMapping;
-import org.apache.cayenne.dba.frontbase.FrontBaseAdapter;
 import org.apache.cayenne.map.DbAttribute;
 import org.apache.cayenne.map.DbEntity;
 import org.apache.cayenne.map.DefaultScalarResultSegment;
@@ -189,9 +188,7 @@ public class SQLTemplateAction implements SQLAction {
 		boolean iteratedResult = callback.isIteratedResult();
 		int generatedKeys = query.isReturnGeneratedKeys() ? Statement.RETURN_GENERATED_KEYS : Statement.NO_GENERATED_KEYS;
 		PreparedStatement statement = connection.prepareStatement(compiled.getSql(), generatedKeys);
-		if (statement == null && this.dbAdapter instanceof FrontBaseAdapter) {
-			statement = connection.prepareStatement(compiled.getSql());
-		}
+
 		try {
 			bind(statement, compiled.getBindings());
 

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/frontbase/FrontBaseActionBuilder.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/frontbase/FrontBaseActionBuilder.java
@@ -1,0 +1,45 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.dba.frontbase;
+
+import org.apache.cayenne.access.DataNode;
+import org.apache.cayenne.dba.JdbcActionBuilder;
+import org.apache.cayenne.query.SQLAction;
+import org.apache.cayenne.query.SQLTemplate;
+
+/**
+ * An action builder for FrontBaseActionBuilder.
+ *
+ * @since 4.2
+ */
+public class FrontBaseActionBuilder extends JdbcActionBuilder {
+    /**
+     * @param dataNode
+     * @since 4.2
+     */
+    public FrontBaseActionBuilder(DataNode dataNode) {
+        super(dataNode);
+    }
+
+    @Override
+    public SQLAction sqlAction(SQLTemplate query) {
+        return new FrontBaseTemplateAction(query, dataNode);
+    }
+}

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/frontbase/FrontBaseAdapter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/frontbase/FrontBaseAdapter.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.cayenne.CayenneRuntimeException;
+import org.apache.cayenne.access.DataNode;
 import org.apache.cayenne.access.sqlbuilder.sqltree.SQLTreeProcessor;
 import org.apache.cayenne.access.types.ExtendedType;
 import org.apache.cayenne.access.types.ExtendedTypeFactory;
@@ -40,6 +41,8 @@ import org.apache.cayenne.dba.TypesMapping;
 import org.apache.cayenne.di.Inject;
 import org.apache.cayenne.map.DbAttribute;
 import org.apache.cayenne.map.DbEntity;
+import org.apache.cayenne.query.Query;
+import org.apache.cayenne.query.SQLAction;
 import org.apache.cayenne.resource.ResourceLocator;
 
 /**
@@ -214,5 +217,15 @@ public class FrontBaseAdapter extends JdbcAdapter {
 	@Override
 	protected PkGenerator createPkGenerator() {
 		return new FrontBasePkGenerator(this);
+	}
+
+	/**
+	 * Uses FrontBaseActionBuilder to create the right action.
+	 *
+	 * @since 4.2
+	 */
+	@Override
+	public SQLAction getAction(Query query, DataNode node) {
+		return query.createSQLAction(new FrontBaseActionBuilder(node));
 	}
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/frontbase/FrontBaseTemplateAction.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/frontbase/FrontBaseTemplateAction.java
@@ -1,0 +1,107 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.dba.frontbase;
+
+import org.apache.cayenne.access.DataNode;
+import org.apache.cayenne.access.OperationObserver;
+import org.apache.cayenne.access.jdbc.SQLStatement;
+import org.apache.cayenne.access.jdbc.SQLTemplateAction;
+import org.apache.cayenne.query.SQLTemplate;
+
+import java.sql.*;
+import java.util.Collection;
+
+/**
+ * @since 4.2
+ */
+public class FrontBaseTemplateAction extends SQLTemplateAction {
+    /**
+     * @param query
+     * @param dataNode
+     * @since 4.2
+     */
+    public FrontBaseTemplateAction(SQLTemplate query, DataNode dataNode) {
+        super(query, dataNode);
+    }
+
+    @Override
+    protected void execute(Connection connection, OperationObserver callback, SQLStatement compiled,
+                 Collection<Number> updateCounts) throws SQLException, Exception {
+
+        long t1 = System.currentTimeMillis();
+        boolean iteratedResult = callback.isIteratedResult();
+        PreparedStatement statement = connection.prepareStatement(compiled.getSql());
+
+        try {
+            bind(statement, compiled.getBindings());
+
+            // process a mix of results
+            boolean isResultSet = statement.execute();
+
+            if(query.isReturnGeneratedKeys()) {
+                ResultSet generatedKeysResultSet = statement.getGeneratedKeys();
+                if (generatedKeysResultSet != null) {
+                    processSelectResult(compiled, connection, statement, generatedKeysResultSet, callback, t1);
+                }
+            }
+
+            boolean firstIteration = true;
+            while (true) {
+                if (firstIteration) {
+                    firstIteration = false;
+                } else {
+                    isResultSet = statement.getMoreResults();
+                }
+
+                if (isResultSet) {
+
+                    ResultSet resultSet = statement.getResultSet();
+                    if (resultSet != null) {
+
+                        try {
+                            processSelectResult(compiled, connection, statement, resultSet, callback, t1);
+                        } finally {
+                            if (!iteratedResult) {
+                                resultSet.close();
+                            }
+                        }
+
+                        // ignore possible following update counts and bail early on iterated results
+                        if (iteratedResult) {
+                            break;
+                        }
+                    }
+                } else {
+                    int updateCount = statement.getUpdateCount();
+                    if (updateCount == -1) {
+                        break;
+                    }
+
+                    updateCounts.add(updateCount);
+                    dataNode.getJdbcEventLogger().logUpdateCount(updateCount);
+                }
+            }
+        } finally {
+            if (!iteratedResult) {
+                statement.close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
FronBase jdbc driver incorrectly returns null instead of statement (or throwing SQLException at least) when connection.prepareStatement(sql, Statement.NO_GENERATED_KEYS) is called.
Driver just call connection.prepareStatement(sql), if dbAdapter is the FrontBaseAdapter.