### PR TITLE
Remove "use primitive type" checkbox and parameter from the dbimport

### DIFF
--- a/cayenne-ant/src/main/java/org/apache/cayenne/tools/DbImporterTask.java
+++ b/cayenne-ant/src/main/java/org/apache/cayenne/tools/DbImporterTask.java
@@ -59,7 +59,6 @@ public class DbImporterTask extends Task {
 
     public DbImporterTask() {
         this.config = new DbImportConfiguration();
-        this.config.setUsePrimitives(true);
         this.config.setUseJava7Types(false);
         this.config.setNamingStrategy(DefaultObjectNameGenerator.class.getName());
 
@@ -243,8 +242,12 @@ public class DbImporterTask extends Task {
         config.setUsername(username);
     }
 
+    /**
+     * @deprecated since 4.2
+     */
+    @Deprecated
     public void setUsePrimitives(boolean flag) {
-        config.setUsePrimitives(flag);
+
     }
 
     /**

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/context/EntityMergeSupport.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/context/EntityMergeSupport.java
@@ -89,20 +89,17 @@ public class EntityMergeSupport {
     private final List<EntityMergeListener> listeners;
     private final boolean removingMeaningfulFKs;
     private final NameFilter meaningfulPKsFilter;
-    private final boolean usingPrimitives;
     private final boolean usingJava7Types;
 
     public EntityMergeSupport(ObjectNameGenerator nameGenerator,
                               NameFilter meaningfulPKsFilter,
                               boolean removingMeaningfulFKs,
-                              boolean usingPrimitives,
                               boolean usingJava7Types) {
 
         this.listeners = new ArrayList<>();
         this.nameGenerator = nameGenerator;
         this.removingMeaningfulFKs = removingMeaningfulFKs;
         this.meaningfulPKsFilter = meaningfulPKsFilter;
-        this.usingPrimitives = usingPrimitives;
         this.usingJava7Types = usingJava7Types;
 
         // will ensure that all created ObjRelationships would have
@@ -310,8 +307,9 @@ public class EntityMergeSupport {
         }
 
         String type = TypesMapping.getJavaBySqlType(dbAttribute.getType());
-        String primitiveType;
-        if (usingPrimitives && (primitiveType = CLASS_TO_PRIMITIVE.get(type)) != null) {
+        String primitiveType = CLASS_TO_PRIMITIVE.get(type);
+        // use primitive types for non nullable attributes
+        if (primitiveType != null && dbAttribute.isMandatory()) {
             return primitiveType;
         }
         return type;

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/context/MergerContext.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/context/MergerContext.java
@@ -102,7 +102,6 @@ public class MergerContext {
     public static class Builder {
 
         private MergerContext context;
-        private boolean usingPrimitives;
         private boolean usingJava7Types;
         private NameFilter meaningfulPKsFilter;
 
@@ -135,7 +134,6 @@ public class MergerContext {
             context.entityMergeSupport = new EntityMergeSupport(context.nameGenerator,
                     meaningfulPKsFilter,
                     true,
-                    usingPrimitives,
                     usingJava7Types);
 
             return context;
@@ -148,11 +146,6 @@ public class MergerContext {
 
         public Builder nameGenerator(ObjectNameGenerator nameGenerator) {
             this.context.nameGenerator = Objects.requireNonNull(nameGenerator);
-            return this;
-        }
-
-        public Builder usingPrimitives(boolean flag) {
-            this.usingPrimitives = flag;
             return this;
         }
 

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/dbimport/DbImportConfiguration.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/dbimport/DbImportConfiguration.java
@@ -54,7 +54,6 @@ public class DbImportConfiguration {
     private String defaultPackage;
     private String meaningfulPkTables;
     private String adapter;
-    private boolean usePrimitives;
     private boolean useJava7Types;
     private Logger logger;
     private String namingStrategy;
@@ -140,12 +139,22 @@ public class DbImportConfiguration {
         this.meaningfulPkTables = meaningfulPkTables;
     }
 
+    /**
+     * @deprecated since 4.2
+     * @return false
+     */
+    @Deprecated
     public boolean isUsePrimitives() {
-        return usePrimitives;
+        return false;
     }
 
+    /**
+     * does nothing
+     * @param usePrimitives not used
+     * @deprecated since 4.2
+     */
+    @Deprecated
     public void setUsePrimitives(boolean usePrimitives) {
-        this.usePrimitives = usePrimitives;
     }
 
     public boolean isUseJava7Types() {

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/dbimport/DefaultDbImportAction.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/dbimport/DefaultDbImportAction.java
@@ -249,7 +249,6 @@ public class DefaultDbImportAction implements DbImportAction {
         config.setForceDataMapCatalog(reverseEngineering.isForceDataMapCatalog());
         config.setForceDataMapSchema(reverseEngineering.isForceDataMapSchema());
         config.setDefaultPackage(reverseEngineering.getDefaultPackage());
-        config.setUsePrimitives(reverseEngineering.isUsePrimitives());
         config.setUseJava7Types(reverseEngineering.isUseJava7Types());
     }
 
@@ -416,7 +415,6 @@ public class DefaultDbImportAction implements DbImportAction {
         MergerContext mergerContext = MergerContext.builder(targetDataMap)
                 .delegate(mergeDelegate)
                 .nameGenerator(nameGenerator)
-                .usingPrimitives(config.isUsePrimitives())
                 .usingJava7Types(config.isUseJava7Types())
                 .meaningfulPKFilter(config.createMeaningfulPKFilter())
                 .build();

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/dbimport/ReverseEngineering.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/dbimport/ReverseEngineering.java
@@ -98,12 +98,6 @@ public class ReverseEngineering extends SchemaContainer implements Serializable,
     private String stripFromTableNames = "";
 
     /**
-     * <p>If true, would use primitives instead of numeric and boolean classes.</p>
-     * <p>Default is <b>"true"</b>, i.e. primitives will be used.</p>
-     */
-    private boolean usePrimitives = true;
-
-    /**
      * Use old Java 7 date types
      */
     private boolean useJava7Types = false;
@@ -220,9 +214,6 @@ public class ReverseEngineering extends SchemaContainer implements Serializable,
         if (forceDataMapSchema) {
             res.append("\n  Force DataMap schema");
         }
-        if (usePrimitives) {
-            res.append("\n  Use primitives");
-        }
         if (useJava7Types) {
             res.append("\n  Use Java 7 types");
         }
@@ -253,8 +244,13 @@ public class ReverseEngineering extends SchemaContainer implements Serializable,
         return stripFromTableNames;
     }
 
+    /**
+     * @return false
+     * @deprecated since 4.2
+     */
+    @Deprecated
     public boolean isUsePrimitives() {
-        return usePrimitives;
+        return false;
     }
 
     public boolean isUseJava7Types() {
@@ -285,8 +281,12 @@ public class ReverseEngineering extends SchemaContainer implements Serializable,
         this.stripFromTableNames = stripFromTableNames;
     }
 
+    /**
+     * does nothing
+     * @deprecated since 4.2
+     */
+    @Deprecated
     public void setUsePrimitives(boolean usePrimitives) {
-        this.usePrimitives = usePrimitives;
     }
 
     public void setUseJava7Types(boolean useJava7Types) {
@@ -322,7 +322,6 @@ public class ReverseEngineering extends SchemaContainer implements Serializable,
                 .simpleTag("skipRelationshipsLoading", this.getSkipRelationshipsLoading().toString())
                 .simpleTag("stripFromTableNames", this.getStripFromTableNames())
                 .simpleTag("useJava7Types", Boolean.toString(this.isUseJava7Types()))
-                .simpleTag("usePrimitives", Boolean.toString(this.isUsePrimitives()))
                 .end();
     }
 

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/EntityMergeSupportIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/EntityMergeSupportIT.java
@@ -94,7 +94,6 @@ public class EntityMergeSupportIT extends MergeCase {
 				new DefaultObjectNameGenerator(NoStemStemmer.getInstance()),
 				NamePatternMatcher.EXCLUDE_ALL,
 				true,
-				true,
 				false);
 		assertTrue(entityMergeSupport.synchronizeWithDbEntities(Arrays.asList(objEntity1, objEntity2)));
 		assertNotNull(objEntity1.getAttribute("name"));

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/reverse/filters/FiltersConfigBuilderTest.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/reverse/filters/FiltersConfigBuilderTest.java
@@ -54,8 +54,7 @@ public class FiltersConfigBuilderTest {
                 "      IncludeTable: table2\n" +
                 "        IncludeColumn: includeColumn\n" +
                 "      IncludeTable: table3\n" +
-                "        IncludeColumn: includeColumn\n\n" +
-                "  Use primitives", engineering.toString());
+                "        IncludeColumn: includeColumn\n", engineering.toString());
     }
 
     @Test
@@ -82,8 +81,7 @@ public class FiltersConfigBuilderTest {
                 "    Schema: schemaName02\n" +
                 "      IncludeTable: table1\n" +
                 "        IncludeColumn: includeColumn\n" +
-                "      ExcludeTable: table2\n\n"+
-                "  Use primitives", engineering.toString());
+                "      ExcludeTable: table2\n", engineering.toString());
     }
 
     @Test
@@ -108,8 +106,7 @@ public class FiltersConfigBuilderTest {
                 "    Schema: null\n" +
                 "      IncludeTable: null\n" +
                 "        ExcludeColumn: calculated_.*\n" +
-                "      ExcludeTable: SYS_.*\n\n" +
-                "  Use primitives", engineering.toString());
+                "      ExcludeTable: SYS_.*\n", engineering.toString());
     }
 
     @Test
@@ -123,8 +120,7 @@ public class FiltersConfigBuilderTest {
                 "ReverseEngineering: \n" +
                 "  Catalog: null\n" +
                 "    Schema: s\n" +
-                "      IncludeTable: null\n\n" +
-                "  Use primitives", engineering.toString());
+                "      IncludeTable: null\n", engineering.toString());
     }
 
     @Test
@@ -207,8 +203,7 @@ public class FiltersConfigBuilderTest {
                 "    IncludeColumn: c_xxx1\n" +
                 "    ExcludeColumn: c_xxx2\n" +
                 "    IncludeProcedure: p7\n" +
-                "    ExcludeProcedure: p8\n\n" +
-                "  Use primitives", engineering.toString());
+                "    ExcludeProcedure: p8\n", engineering.toString());
 
 
         builder.compact();
@@ -264,8 +259,7 @@ public class FiltersConfigBuilderTest {
                         "      IncludeProcedure: p5\n" +
                         "      IncludeProcedure: p7\n" +
                         "      ExcludeProcedure: p6\n" +
-                        "      ExcludeProcedure: p8\n\n" +
-                        "  Use primitives", engineering.toString());
+                        "      ExcludeProcedure: p8\n", engineering.toString());
     }
 
     protected IncludeTable includeTable(String name, String incCol, String excCol) {

--- a/cayenne-gradle-plugin/src/test/java/org/apache/cayenne/tools/model/DbImportConfigTest.java
+++ b/cayenne-gradle-plugin/src/test/java/org/apache/cayenne/tools/model/DbImportConfigTest.java
@@ -56,7 +56,6 @@ public class DbImportConfigTest {
         assertFalse(rr.isForceDataMapCatalog());
         assertFalse(rr.isForceDataMapSchema());
         assertFalse(rr.isUseJava7Types());
-        assertTrue(rr.isUsePrimitives());
 
         assertTrue(rr.isEmptyContainer());
     }
@@ -80,7 +79,6 @@ public class DbImportConfigTest {
         config.setForceDataMapCatalog(true);
         config.setForceDataMapSchema(true);
         config.setUseJava7Types(true);
-        config.setUsePrimitives(false);
 
         ReverseEngineering rr = config.toReverseEngineering();
 
@@ -108,7 +106,6 @@ public class DbImportConfigTest {
         assertTrue(rr.isForceDataMapCatalog());
         assertTrue(rr.isForceDataMapSchema());
         assertTrue(rr.isUseJava7Types());
-        assertFalse(rr.isUsePrimitives());
     }
 
 }

--- a/maven-plugins/cayenne-maven-plugin/src/main/java/org/apache/cayenne/tools/DbImporterMojo.java
+++ b/maven-plugins/cayenne-maven-plugin/src/main/java/org/apache/cayenne/tools/DbImporterMojo.java
@@ -176,7 +176,6 @@ public class DbImporterMojo extends AbstractMojo {
         config.setCayenneProject(cayenneProject);
         config.setUrl(dataSource.getUrl());
         config.setUsername(dataSource.getUsername());
-        config.setUsePrimitives(dbImportConfig.isUsePrimitives());
         config.setUseJava7Types(dbImportConfig.isUseJava7Types());
 
         return config;

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testConfigFromDataMap.map.xml-result
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testConfigFromDataMap.map.xml-result
@@ -43,6 +43,5 @@
 		<skipPrimaryKeyLoading>false</skipPrimaryKeyLoading>
 		<skipRelationshipsLoading>false</skipRelationshipsLoading>
 		<useJava7Types>false</useJava7Types>
-		<usePrimitives>true</usePrimitives>
 	</dbImport>
 </data-map>

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testCustomObjectLayerSettings.map.xml-result
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testCustomObjectLayerSettings.map.xml-result
@@ -34,10 +34,10 @@
         <db-attribute name="ID" type="INTEGER" isPrimaryKey="true" isMandatory="true" length="10"/>
     </db-entity>
     <obj-entity name="ExistingTable" className="ExistingTable" dbEntityName="EXISTING_TABLE">
-    	 <obj-attribute name="col2" type="int" db-attribute-path="COL2"/>
+    	 <obj-attribute name="col2" type="java.lang.Integer" db-attribute-path="COL2"/>
     </obj-entity>
     <obj-entity name="NewTable" className="NewTable" dbEntityName="NEW_TABLE">
-    	 <obj-attribute name="col2" type="int" db-attribute-path="COL2"/>
+    	 <obj-attribute name="col2" type="java.lang.Integer" db-attribute-path="COL2"/>
     	 <obj-attribute name="id" type="int" db-attribute-path="ID"/>
     </obj-entity>
     <obj-entity name="PrefixedNewTable" className="PrefixedNewTable" dbEntityName="XYZ_PREFIXED_NEW_TABLE">

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testExcludeRelationshipFirst.map.xml-result
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testExcludeRelationshipFirst.map.xml-result
@@ -33,7 +33,7 @@
 
     <obj-entity name="Test1" className="Test1" dbEntityName="TEST1"/>
     <obj-entity name="Test2" className="Test2" dbEntityName="TEST2">
-    <obj-attribute name="test1Id" type="int" db-attribute-path="TEST1_ID"/>
+    <obj-attribute name="test1Id" type="java.lang.Integer" db-attribute-path="TEST1_ID"/>
     </obj-entity>
 
 

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testOneToOne.map.xml-result
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testOneToOne.map.xml-result
@@ -33,7 +33,7 @@
 		<db-attribute name="PLAYER_ID" type="INTEGER" isPrimaryKey="true" isMandatory="true" length="10"/>
 	</db-entity>
 	<obj-entity name="PickSchedule" className="PickSchedule" dbEntityName="PICK_SCHEDULE">
-		<obj-attribute name="ownerId" type="int" db-attribute-path="OWNER_ID"/>
+		<obj-attribute name="ownerId" type="java.lang.Integer" db-attribute-path="OWNER_ID"/>
 	</obj-entity>
 	<obj-entity name="Player" className="Player" dbEntityName="PLAYER">
 	</obj-entity>

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testTableTypesMap.map.xml-result
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testTableTypesMap.map.xml-result
@@ -36,6 +36,5 @@
            <skipPrimaryKeyLoading>false</skipPrimaryKeyLoading>
            <skipRelationshipsLoading>false</skipRelationshipsLoading>
            <useJava7Types>false</useJava7Types>
-           <usePrimitives>true</usePrimitives>
     </dbImport>
 </data-map>

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/action/CreateObjEntityAction.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/action/CreateObjEntityAction.java
@@ -112,7 +112,7 @@ public class CreateObjEntityAction extends CayenneAction {
 
         // TODO: Modeler-controlled defaults for all the hardcoded boolean flags here.
         EntityMergeSupport merger = new EntityMergeSupport(new DefaultObjectNameGenerator(NoStemStemmer.getInstance()),
-                NamePatternMatcher.EXCLUDE_ALL, true, true, false);
+                NamePatternMatcher.EXCLUDE_ALL, true, false);
         merger.setNameGenerator(new DbEntitySyncAction.PreserveRelationshipNameGenerator());
         merger.addEntityMergeListener(DeleteRuleUpdater.getEntityMergeListener());
         merger.synchronizeWithDbEntity(entity);

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/db/load/DbLoaderContext.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/db/load/DbLoaderContext.java
@@ -116,7 +116,6 @@ public class DbLoaderContext {
     }
 
     private void fillReverseEngineeringFromView(ReverseEngineering reverseEngineering, DbImportView view) {
-        reverseEngineering.setUsePrimitives(view.isUsePrimitives());
         reverseEngineering.setUseJava7Types(view.isUseJava7Typed());
         reverseEngineering.setForceDataMapCatalog(view.isForceDataMapCatalog());
         reverseEngineering.setForceDataMapSchema(view.isForceDataMapSchema());
@@ -179,7 +178,6 @@ public class DbLoaderContext {
         config.setNamingStrategy(reverseEngineering.getNamingStrategy());
         config.setDefaultPackage(reverseEngineering.getDefaultPackage());
         config.setStripFromTableNames(reverseEngineering.getStripFromTableNames());
-        config.setUsePrimitives(reverseEngineering.isUsePrimitives());
         config.setUseJava7Types(reverseEngineering.isUseJava7Types());
         config.setForceDataMapCatalog(reverseEngineering.isForceDataMapCatalog());
         config.setForceDataMapSchema(reverseEngineering.isForceDataMapSchema());

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/objentity/EntitySyncController.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/objentity/EntitySyncController.java
@@ -70,7 +70,7 @@ public class EntitySyncController extends CayenneController {
         }
 
         // TODO: Modeler-controlled defaults for all the hardcoded boolean flags here.
-        EntityMergeSupport merger = new EntityMergeSupport(namingStrategy, NamePatternMatcher.EXCLUDE_ALL, true, true, false);
+        EntityMergeSupport merger = new EntityMergeSupport(namingStrategy, NamePatternMatcher.EXCLUDE_ALL, true, false);
 
         // see if we need to remove meaningful attributes...
         for (ObjEntity entity : entities) {
@@ -110,7 +110,7 @@ public class EntitySyncController extends CayenneController {
         view.setVisible(true);
 
         // TODO: Modeler-controlled defaults for all the hardcoded flags here.
-        return cancel[0] ? null : new EntityMergeSupport(namingStrategy, NamePatternMatcher.EXCLUDE_ALL, removeFKs[0], true, false);
+        return cancel[0] ? null : new EntityMergeSupport(namingStrategy, NamePatternMatcher.EXCLUDE_ALL, removeFKs[0], false);
     }
 
     @Override

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/dbimport/DbImportView.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/dbimport/DbImportView.java
@@ -241,10 +241,6 @@ public class DbImportView extends JPanel {
         return configPanel.getForceDataMapSchema().isSelected();
     }
 
-    public boolean isUsePrimitives() {
-        return configPanel.getUsePrimitives().isSelected();
-    }
-
     public boolean isUseJava7Typed() {
         return configPanel.getUseJava7Types().isSelected();
     }

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/dbimport/ReverseEngineeringConfigPanel.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/dbimport/ReverseEngineeringConfigPanel.java
@@ -52,7 +52,6 @@ public class ReverseEngineeringConfigPanel extends JPanel {
     private JCheckBox skipPrimaryKeyLoading;
     private JCheckBox forceDataMapCatalog;
     private JCheckBox forceDataMapSchema;
-    private JCheckBox usePrimitives;
     private JCheckBox useJava7Types;
 
     private TextAdapter tableTypes;
@@ -80,7 +79,6 @@ public class ReverseEngineeringConfigPanel extends JPanel {
         panelBuilder.append("Skip primary key loading:", skipPrimaryKeyLoading);
         panelBuilder.append("Force datamap catalog:", forceDataMapCatalog);
         panelBuilder.append("Force datamap schema:", forceDataMapSchema);
-        panelBuilder.append("Use Java primitive types:", usePrimitives);
         panelBuilder.append("Use java.util.Date type:", useJava7Types);
         panelBuilder.append("Naming strategy:", strategyCombo);
         panelBuilder.append("Table types:", tableTypes.getComponent());
@@ -93,7 +91,6 @@ public class ReverseEngineeringConfigPanel extends JPanel {
         skipPrimaryKeyLoading.setSelected(reverseEngineering.getSkipPrimaryKeyLoading());
         forceDataMapCatalog.setSelected(reverseEngineering.isForceDataMapCatalog());
         forceDataMapSchema.setSelected(reverseEngineering.isForceDataMapSchema());
-        usePrimitives.setSelected(reverseEngineering.isUsePrimitives());
         useJava7Types.setSelected(reverseEngineering.isUseJava7Types());
     }
 
@@ -189,8 +186,6 @@ public class ReverseEngineeringConfigPanel extends JPanel {
         useJava7Types = new JCheckBox();
         useJava7Types.setToolTipText("<html>Use <b>java.util.Date</b> for all columns with <i>DATE/TIME/TIMESTAMP</i> types.<br>" +
                 "By default <b>java.time.*</b> types will be used.</html>");
-        usePrimitives = new JCheckBox();
-        usePrimitives.setToolTipText("<html>Use primitive types (e.g. int) or Object types (e.g. java.lang.Integer)</html>");
     }
 
     private void initListeners() {
@@ -214,12 +209,6 @@ public class ReverseEngineeringConfigPanel extends JPanel {
         });
         forceDataMapSchema.addActionListener(e -> {
             getReverseEngineeringBySelectedMap().setForceDataMapSchema(forceDataMapSchema.isSelected());
-            if(!dbImportView.isInitFromModel()) {
-                projectController.setDirty(true);
-            }
-        });
-        usePrimitives.addActionListener(e -> {
-            getReverseEngineeringBySelectedMap().setUsePrimitives(usePrimitives.isSelected());
             if(!dbImportView.isInitFromModel()) {
                 projectController.setDirty(true);
             }
@@ -279,10 +268,6 @@ public class ReverseEngineeringConfigPanel extends JPanel {
 
     JCheckBox getForceDataMapSchema() {
         return forceDataMapSchema;
-    }
-
-    JCheckBox getUsePrimitives() {
-        return usePrimitives;
     }
 
     JCheckBox getUseJava7Types() {


### PR DESCRIPTION
This PR deprecates "use primitive" parameter in the dbimport config and removes corresponding checkbox from the Modeler.
Primitive types are used where applicable based on attribute nullability. That should be more intuitive.

