### PR TITLE
Added support for Json type in sqlServe and Oracle

### DIFF
--- a/cayenne-server/src/main/java/org/apache/cayenne/access/translator/select/BaseSQLTreeProcessor.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/translator/select/BaseSQLTreeProcessor.java
@@ -34,7 +34,7 @@ import org.apache.cayenne.access.sqlbuilder.sqltree.ValueNode;
 /**
  * @since 4.2
  */
-public class BaseSQLTreeProcessor extends SimpleNodeTreeVisitor implements SQLTreeProcessor {
+public class BaseSQLTreeProcessor extends TypeAwareSQLTreeProcessor implements SQLTreeProcessor {
 
     @Override
     public Node process(Node node) {

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/oracle/OracleAdapter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/oracle/OracleAdapter.java
@@ -35,12 +35,7 @@ import org.apache.cayenne.access.DataNode;
 import org.apache.cayenne.access.sqlbuilder.sqltree.SQLTreeProcessor;
 import org.apache.cayenne.access.translator.ParameterBinding;
 import org.apache.cayenne.access.translator.ejbql.EJBQLTranslatorFactory;
-import org.apache.cayenne.access.types.ByteType;
-import org.apache.cayenne.access.types.ExtendedType;
-import org.apache.cayenne.access.types.ExtendedTypeFactory;
-import org.apache.cayenne.access.types.ExtendedTypeMap;
-import org.apache.cayenne.access.types.ShortType;
-import org.apache.cayenne.access.types.ValueObjectTypeRegistry;
+import org.apache.cayenne.access.types.*;
 import org.apache.cayenne.configuration.Constants;
 import org.apache.cayenne.configuration.RuntimeProperties;
 import org.apache.cayenne.dba.JdbcAdapter;
@@ -200,7 +195,8 @@ public class OracleAdapter extends JdbcAdapter {
 		super.configureExtendedTypes(map);
 
 		// create specially configured CharType handler
-		map.registerType(new OracleCharType());
+		CharType charType = new OracleCharType();
+		map.registerType(charType);
 
 		// create specially configured ByteArrayType handler
 		map.registerType(new OracleByteArrayType());
@@ -212,6 +208,7 @@ public class OracleAdapter extends JdbcAdapter {
 		map.registerType(new ShortType(true));
 		map.registerType(new ByteType(true));
 		map.registerType(new OracleBooleanType());
+		map.registerType(new JsonType(charType, true));
 	}
 
 	/**

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/oracle/OracleSQLTreeProcessor.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/oracle/OracleSQLTreeProcessor.java
@@ -25,17 +25,7 @@ import java.util.List;
 import org.apache.cayenne.access.sqlbuilder.ExpressionNodeBuilder;
 import org.apache.cayenne.access.sqlbuilder.QuotingAppendable;
 import org.apache.cayenne.access.sqlbuilder.SelectBuilder;
-import org.apache.cayenne.access.sqlbuilder.sqltree.ColumnNode;
-import org.apache.cayenne.access.sqlbuilder.sqltree.EmptyNode;
-import org.apache.cayenne.access.sqlbuilder.sqltree.FunctionNode;
-import org.apache.cayenne.access.sqlbuilder.sqltree.InNode;
-import org.apache.cayenne.access.sqlbuilder.sqltree.LimitOffsetNode;
-import org.apache.cayenne.access.sqlbuilder.sqltree.Node;
-import org.apache.cayenne.access.sqlbuilder.sqltree.NodeType;
-import org.apache.cayenne.access.sqlbuilder.sqltree.OpExpressionNode;
-import org.apache.cayenne.access.sqlbuilder.sqltree.TextNode;
-import org.apache.cayenne.access.sqlbuilder.sqltree.ValueNode;
-import org.apache.cayenne.access.sqlbuilder.sqltree.TrimmingColumnNode;
+import org.apache.cayenne.access.sqlbuilder.sqltree.*;
 import org.apache.cayenne.access.translator.select.BaseSQLTreeProcessor;
 import org.apache.cayenne.util.ArrayUtil;
 

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/sybase/SybaseAdapter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/sybase/SybaseAdapter.java
@@ -26,14 +26,7 @@ import java.util.List;
 import org.apache.cayenne.access.sqlbuilder.sqltree.SQLTreeProcessor;
 import org.apache.cayenne.access.translator.ParameterBinding;
 import org.apache.cayenne.access.translator.ejbql.EJBQLTranslatorFactory;
-import org.apache.cayenne.access.types.ByteArrayType;
-import org.apache.cayenne.access.types.ByteType;
-import org.apache.cayenne.access.types.CharType;
-import org.apache.cayenne.access.types.ExtendedType;
-import org.apache.cayenne.access.types.ExtendedTypeFactory;
-import org.apache.cayenne.access.types.ExtendedTypeMap;
-import org.apache.cayenne.access.types.ShortType;
-import org.apache.cayenne.access.types.ValueObjectTypeRegistry;
+import org.apache.cayenne.access.types.*;
 import org.apache.cayenne.configuration.Constants;
 import org.apache.cayenne.configuration.RuntimeProperties;
 import org.apache.cayenne.dba.DefaultQuotingStrategy;
@@ -100,7 +93,8 @@ public class SybaseAdapter extends JdbcAdapter {
         super.configureExtendedTypes(map);
 
         // create specially configured CharType handler
-        map.registerType(new CharType(true, false));
+        CharType charType = new CharType(true, false);
+        map.registerType(charType);
 
         // create specially configured ByteArrayType handler
         map.registerType(new ByteArrayType(true, false));
@@ -109,6 +103,7 @@ public class SybaseAdapter extends JdbcAdapter {
         // java.lang.Byte
         map.registerType(new ShortType(true));
         map.registerType(new ByteType(true));
+        map.registerType(new JsonType(charType, true));
     }
 
     /**


### PR DESCRIPTION
A json string can be stored in the database table.
JsonType added to ExtendedTypeMap in OracleAdapter and SybaseAdapter.
SQLServerTreeProcessor and OracleSQLTreeProcessor extends from TypeAwareSQLTreeProcessor. Added three types Json, GeoJson, Wkt to byNodeTypeProcessors.

In SQL Server:
Create a column with the NVARCHAR type in the table. Then we import the database in the modeler. Automatically the obj-attribute type will be String. In the obj-attribute, specify the type org.apache.cayenne.value.Json.
In Oracle SQL:
Create a column with the CLOB type in the table. Then we import the database in the modeler. Automatically the obj-attribute type will be String. In the obj-attribute, specify the type org.apache.cayenne.value.Json.