### PR TITLE
CAY-2687 Modeler Migrate Repeatedly Asks to Set Column Type for MySQL…

### DIFF
--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/DbAttributeMerger.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/DbAttributeMerger.java
@@ -133,7 +133,7 @@ class DbAttributeMerger extends AbstractMerger<DbEntity, DbAttribute> {
                 (imported.getType() == Types.DECIMAL || imported.getType() == Types.NUMERIC)) {
                 return false;
             }
-            return true;
+            return getTokenFactory().needUpdateSpecificType(original, imported);
         }
 
         if(original.getMaxLength() != imported.getMaxLength()) {

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/factory/DefaultMergerTokenFactory.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/factory/DefaultMergerTokenFactory.java
@@ -215,4 +215,9 @@ public class DefaultMergerTokenFactory implements MergerTokenFactory {
     public MergerToken createSetGeneratedFlagToModel(DbEntity entity, DbAttribute column, boolean isGenerated) {
         return new SetGeneratedFlagToModel(entity, column, isGenerated);
     }
+
+    @Override
+    public boolean needUpdateSpecificType(DbAttribute columnOriginal, DbAttribute columnNew) {
+        return true;
+    }
 }

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/factory/MergerTokenFactory.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/factory/MergerTokenFactory.java
@@ -98,4 +98,6 @@ public interface MergerTokenFactory {
     MergerToken createSetGeneratedFlagToDb(DbEntity entity, DbAttribute column, boolean isGenerated);
 
     MergerToken createSetGeneratedFlagToModel(DbEntity entity, DbAttribute column, boolean isGenerated);
+
+    boolean needUpdateSpecificType(DbAttribute columnOriginal, DbAttribute columnNew);
 }

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/factory/MySQLMergerTokenFactory.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/factory/MySQLMergerTokenFactory.java
@@ -31,6 +31,7 @@ import org.apache.cayenne.map.DbAttribute;
 import org.apache.cayenne.map.DbEntity;
 import org.apache.cayenne.map.DbRelationship;
 
+import java.sql.Types;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -180,5 +181,14 @@ public class MySQLMergerTokenFactory extends DefaultMergerTokenFactory {
                 return false;
             }
         };
+    }
+
+    @Override
+    public boolean needUpdateSpecificType(DbAttribute columnOriginal, DbAttribute columnNew) {
+        if ( (columnOriginal.getType() == Types.BOOLEAN && columnNew.getType() == Types.BIT) ||
+                (columnOriginal.getType() == Types.BLOB && columnNew.getType() == Types.LONGVARBINARY)) {
+            return false;
+        }
+        return true;
     }
 }

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/CheckTypeTest.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/CheckTypeTest.java
@@ -1,0 +1,161 @@
+package org.apache.cayenne.dbsync.merge;
+
+import org.apache.cayenne.dbsync.merge.factory.MergerTokenFactory;
+import org.apache.cayenne.dbsync.merge.factory.MySQLMergerTokenFactory;
+import org.apache.cayenne.dbsync.merge.factory.PostgresMergerTokenFactory;
+import org.apache.cayenne.dbsync.merge.token.MergerToken;
+import org.apache.cayenne.map.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Types;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+public class CheckTypeTest {
+
+    DbEntity dbEntity;
+
+    DbAttribute original;
+
+    DbAttribute imported;
+
+    MergerTokenFactory mergerTokenFactory;
+
+    MergerDiffPair<DbAttribute> diffPair;
+
+    DbAttributeMerger dbAttributeMerger;
+
+    @Before
+    public void setUp(){
+        dbEntity = new DbEntity("NEW_TABLE");
+
+        original = new DbAttribute("NAME");
+        original.setEntity(dbEntity);
+        dbEntity.addAttribute(original);
+
+        imported = new DbAttribute("NAME");
+        imported.setEntity(dbEntity);
+
+        mergerTokenFactory = new MySQLMergerTokenFactory();
+        diffPair = new MergerDiffPair(original, imported);
+        dbAttributeMerger = new DbAttributeMerger(mergerTokenFactory, null);
+    }
+
+    @Test
+    public void testCheckBooleanBitTypeMySQL() {
+
+        original.setType(Types.BOOLEAN);
+        imported.setType(Types.BIT);
+
+        Collection<MergerToken> mergerTokens = dbAttributeMerger.createTokensForSame(diffPair);
+        assertEquals(0, mergerTokens.size());
+    }
+
+    @Test
+    public void testCheckBlobLongvarbinaryTypeMySQL() {
+
+        original.setType(Types.BLOB);
+        imported.setType(Types.LONGVARBINARY);
+
+        Collection<MergerToken> mergerTokens = dbAttributeMerger.createTokensForSame(diffPair);
+        assertEquals(0, mergerTokens.size());
+    }
+
+    @Test
+    public void testCheckBooleanIntegerTypeMySQL() {
+
+        original.setType(Types.BOOLEAN);
+        imported.setType(Types.INTEGER);
+
+        Collection<MergerToken> mergerTokens = dbAttributeMerger.createTokensForSame(diffPair);
+        assertEquals(1, mergerTokens.size());
+
+        MergerToken mergerToken1 = (MergerToken) mergerTokens.toArray()[0];
+        String mergerToken = "NEW_TABLE.NAME type: INTEGER -> BOOLEAN";
+        assertEquals(mergerToken, mergerToken1.getTokenValue());
+    }
+
+    @Test
+    public void testCheckBooleanBitTypePostgres() {
+
+        original.setType(Types.BOOLEAN);
+        imported.setType(Types.BIT);
+
+        mergerTokenFactory = new PostgresMergerTokenFactory();
+
+        dbAttributeMerger = new DbAttributeMerger(mergerTokenFactory, null);
+
+        Collection<MergerToken> mergerTokens = dbAttributeMerger.createTokensForSame(diffPair);
+        assertEquals(1, mergerTokens.size());
+
+        MergerToken mergerToken1 = (MergerToken) mergerTokens.toArray()[0];
+        String mergerToken = "NEW_TABLE.NAME type: BIT -> BOOLEAN";
+        assertEquals(mergerToken, mergerToken1.getTokenValue());
+    }
+
+    @Test
+    public void testCheckNumericDecimalType() {
+
+        original.setType(Types.NUMERIC);
+        imported.setType(Types.DECIMAL);
+
+        Collection<MergerToken> mergerTokens = dbAttributeMerger.createTokensForSame(diffPair);
+        assertEquals(0, mergerTokens.size());
+    }
+
+    @Test
+    public void testCheckMaxLengthType() {
+
+        original.setType(Types.CHAR);
+        original.setMaxLength(1);
+        imported.setType(Types.CHAR);
+        imported.setMaxLength(2);
+
+        Collection<MergerToken> mergerTokens = dbAttributeMerger.createTokensForSame(diffPair);
+        assertEquals(1, mergerTokens.size());
+
+        MergerToken mergerToken1 = (MergerToken) mergerTokens.toArray()[0];
+        String mergerToken = "NEW_TABLE.NAME maxLength: 2 -> 1";
+        assertEquals(mergerToken, mergerToken1.getTokenValue());
+    }
+
+    @Test
+    public void testCheckScaleType() {
+
+        original.setScale(1);
+        imported.setScale(2);
+
+        Collection<MergerToken> mergerTokens = dbAttributeMerger.createTokensForSame(diffPair);
+        assertEquals(1, mergerTokens.size());
+
+        MergerToken mergerToken1 = (MergerToken) mergerTokens.toArray()[0];
+        String mergerToken = "NEW_TABLE.NAME scale: 2 -> 1";
+        assertEquals(mergerToken, mergerToken1.getTokenValue());
+    }
+
+    @Test
+    public void testCheckAttributePrecisionType() {
+
+        original.setAttributePrecision(1);
+        imported.setAttributePrecision(2);
+
+        Collection<MergerToken> mergerTokens = dbAttributeMerger.createTokensForSame(diffPair);
+        assertEquals(1, mergerTokens.size());
+
+        MergerToken mergerToken1 = (MergerToken) mergerTokens.toArray()[0];
+        String mergerToken = "NEW_TABLE.NAME precision: 2 -> 1";
+        assertEquals(mergerToken, mergerToken1.getTokenValue());
+    }
+
+    @Test
+    public void testCheckTypeWithoutChanges() {
+
+        diffPair = new MergerDiffPair(original, imported);
+
+        dbAttributeMerger = new DbAttributeMerger(mergerTokenFactory, null);
+        Collection<MergerToken> mergerTokens = dbAttributeMerger.createTokensForSame(diffPair);
+        assertEquals(0, mergerTokens.size());
+    }
+}


### PR DESCRIPTION
… Database

Appears to be a minor bug that has affected us from versions 4.0 through 4.2.M2.
When migrating schema using modeler we are repeatedly asked to 'Set Column Type' for a range of columns & types - we can migrate these changes time and again only to be asked to do it again on the next run - specific types;
BIT -> BOOLEAN (the database already reflects that this is TINYBIT)
LONGVARBINARY -> BLOB (the database already reflects that this is LONGBLOB)
Screenshot of modeler and part of our schema attached for reference.