### PR TITLE
CAY-2694 Precision issues with reverse / forward engineering of time …

### DIFF
--- a/cayenne-server/src/main/java/org/apache/cayenne/access/PrefetchProcessorJointNode.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/PrefetchProcessorJointNode.java
@@ -197,7 +197,9 @@ class PrefetchProcessorJointNode extends PrefetchProcessorNode {
 
             public boolean visitAttribute(AttributeProperty property) {
                 String target = property.getAttribute().getDbAttributePath();
-                appendColumn(targetSource, target, prefix + target);
+                if(!property.getAttribute().isLazy()) {
+                    appendColumn(targetSource, target, prefix + target);
+                }
                 return true;
             }
 

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/jdbc/SQLTemplateAction.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/jdbc/SQLTemplateAction.java
@@ -41,6 +41,7 @@ import org.apache.cayenne.access.types.ExtendedType;
 import org.apache.cayenne.access.types.ExtendedTypeMap;
 import org.apache.cayenne.dba.DbAdapter;
 import org.apache.cayenne.dba.TypesMapping;
+import org.apache.cayenne.dba.frontbase.FrontBaseAdapter;
 import org.apache.cayenne.map.DbAttribute;
 import org.apache.cayenne.map.DbEntity;
 import org.apache.cayenne.map.DefaultScalarResultSegment;
@@ -188,6 +189,9 @@ public class SQLTemplateAction implements SQLAction {
 		boolean iteratedResult = callback.isIteratedResult();
 		int generatedKeys = query.isReturnGeneratedKeys() ? Statement.RETURN_GENERATED_KEYS : Statement.NO_GENERATED_KEYS;
 		PreparedStatement statement = connection.prepareStatement(compiled.getSql(), generatedKeys);
+		if (statement == null && this.dbAdapter instanceof FrontBaseAdapter) {
+			statement = connection.prepareStatement(compiled.getSql());
+		}
 		try {
 			bind(statement, compiled.getBindings());
 

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/jdbc/SQLTemplateAction.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/jdbc/SQLTemplateAction.java
@@ -41,7 +41,6 @@ import org.apache.cayenne.access.types.ExtendedType;
 import org.apache.cayenne.access.types.ExtendedTypeMap;
 import org.apache.cayenne.dba.DbAdapter;
 import org.apache.cayenne.dba.TypesMapping;
-import org.apache.cayenne.dba.frontbase.FrontBaseAdapter;
 import org.apache.cayenne.map.DbAttribute;
 import org.apache.cayenne.map.DbEntity;
 import org.apache.cayenne.map.DefaultScalarResultSegment;
@@ -189,9 +188,7 @@ public class SQLTemplateAction implements SQLAction {
 		boolean iteratedResult = callback.isIteratedResult();
 		int generatedKeys = query.isReturnGeneratedKeys() ? Statement.RETURN_GENERATED_KEYS : Statement.NO_GENERATED_KEYS;
 		PreparedStatement statement = connection.prepareStatement(compiled.getSql(), generatedKeys);
-		if (statement == null && this.dbAdapter instanceof FrontBaseAdapter) {
-			statement = connection.prepareStatement(compiled.getSql());
-		}
+
 		try {
 			bind(statement, compiled.getBindings());
 

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/JdbcAdapter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/JdbcAdapter.java
@@ -509,6 +509,10 @@ public class JdbcAdapter implements DbAdapter {
         attr.setType(type);
         attr.setMandatory(!allowNulls);
 
+        if(type == Types.TIME || type == Types.TIMESTAMP) {
+            size = -1;
+        }
+
         if (size >= 0) {
             attr.setMaxLength(size);
         }

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/TypesMapping.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/TypesMapping.java
@@ -316,7 +316,7 @@ public class TypesMapping {
 	 * Returns true if supplied type is a decimal type.
 	 */
 	public static boolean isDecimal(int type) {
-		return type == DECIMAL || type == DOUBLE || type == FLOAT || type == REAL || type == NUMERIC;
+		return type == DECIMAL || type == DOUBLE || type == FLOAT || type == REAL || type == NUMERIC || type == TIME || type == TIMESTAMP;
 	}
 
 	/**

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/frontbase/FrontBaseActionBuilder.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/frontbase/FrontBaseActionBuilder.java
@@ -1,0 +1,45 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.dba.frontbase;
+
+import org.apache.cayenne.access.DataNode;
+import org.apache.cayenne.dba.JdbcActionBuilder;
+import org.apache.cayenne.query.SQLAction;
+import org.apache.cayenne.query.SQLTemplate;
+
+/**
+ * An action builder for FrontBaseActionBuilder.
+ *
+ * @since 4.2
+ */
+public class FrontBaseActionBuilder extends JdbcActionBuilder {
+    /**
+     * @param dataNode
+     * @since 4.2
+     */
+    public FrontBaseActionBuilder(DataNode dataNode) {
+        super(dataNode);
+    }
+
+    @Override
+    public SQLAction sqlAction(SQLTemplate query) {
+        return new FrontBaseTemplateAction(query, dataNode);
+    }
+}

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/frontbase/FrontBaseAdapter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/frontbase/FrontBaseAdapter.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.cayenne.CayenneRuntimeException;
+import org.apache.cayenne.access.DataNode;
 import org.apache.cayenne.access.sqlbuilder.sqltree.SQLTreeProcessor;
 import org.apache.cayenne.access.types.ExtendedType;
 import org.apache.cayenne.access.types.ExtendedTypeFactory;
@@ -40,6 +41,8 @@ import org.apache.cayenne.dba.TypesMapping;
 import org.apache.cayenne.di.Inject;
 import org.apache.cayenne.map.DbAttribute;
 import org.apache.cayenne.map.DbEntity;
+import org.apache.cayenne.query.Query;
+import org.apache.cayenne.query.SQLAction;
 import org.apache.cayenne.resource.ResourceLocator;
 
 /**
@@ -214,5 +217,15 @@ public class FrontBaseAdapter extends JdbcAdapter {
 	@Override
 	protected PkGenerator createPkGenerator() {
 		return new FrontBasePkGenerator(this);
+	}
+
+	/**
+	 * Uses FrontBaseActionBuilder to create the right action.
+	 *
+	 * @since 4.2
+	 */
+	@Override
+	public SQLAction getAction(Query query, DataNode node) {
+		return query.createSQLAction(new FrontBaseActionBuilder(node));
 	}
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/frontbase/FrontBaseTemplateAction.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/frontbase/FrontBaseTemplateAction.java
@@ -1,0 +1,107 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.dba.frontbase;
+
+import org.apache.cayenne.access.DataNode;
+import org.apache.cayenne.access.OperationObserver;
+import org.apache.cayenne.access.jdbc.SQLStatement;
+import org.apache.cayenne.access.jdbc.SQLTemplateAction;
+import org.apache.cayenne.query.SQLTemplate;
+
+import java.sql.*;
+import java.util.Collection;
+
+/**
+ * @since 4.2
+ */
+public class FrontBaseTemplateAction extends SQLTemplateAction {
+    /**
+     * @param query
+     * @param dataNode
+     * @since 4.2
+     */
+    public FrontBaseTemplateAction(SQLTemplate query, DataNode dataNode) {
+        super(query, dataNode);
+    }
+
+    @Override
+    protected void execute(Connection connection, OperationObserver callback, SQLStatement compiled,
+                 Collection<Number> updateCounts) throws SQLException, Exception {
+
+        long t1 = System.currentTimeMillis();
+        boolean iteratedResult = callback.isIteratedResult();
+        PreparedStatement statement = connection.prepareStatement(compiled.getSql());
+
+        try {
+            bind(statement, compiled.getBindings());
+
+            // process a mix of results
+            boolean isResultSet = statement.execute();
+
+            if(query.isReturnGeneratedKeys()) {
+                ResultSet generatedKeysResultSet = statement.getGeneratedKeys();
+                if (generatedKeysResultSet != null) {
+                    processSelectResult(compiled, connection, statement, generatedKeysResultSet, callback, t1);
+                }
+            }
+
+            boolean firstIteration = true;
+            while (true) {
+                if (firstIteration) {
+                    firstIteration = false;
+                } else {
+                    isResultSet = statement.getMoreResults();
+                }
+
+                if (isResultSet) {
+
+                    ResultSet resultSet = statement.getResultSet();
+                    if (resultSet != null) {
+
+                        try {
+                            processSelectResult(compiled, connection, statement, resultSet, callback, t1);
+                        } finally {
+                            if (!iteratedResult) {
+                                resultSet.close();
+                            }
+                        }
+
+                        // ignore possible following update counts and bail early on iterated results
+                        if (iteratedResult) {
+                            break;
+                        }
+                    }
+                } else {
+                    int updateCount = statement.getUpdateCount();
+                    if (updateCount == -1) {
+                        break;
+                    }
+
+                    updateCounts.add(updateCount);
+                    dataNode.getJdbcEventLogger().logUpdateCount(updateCount);
+                }
+            }
+        } finally {
+            if (!iteratedResult) {
+                statement.close();
+            }
+        }
+    }
+}

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/mysql/MySQLAdapter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/mysql/MySQLAdapter.java
@@ -213,6 +213,16 @@ public class MySQLAdapter extends JdbcAdapter {
 			type = Types.LONGVARCHAR;
 		}
 
+		if(type == Types.TIME || type == Types.TIMESTAMP) {
+			if (size == 8 || size == 19) {
+				precision = 0;
+			} else if (size > 9 && size < 16) {
+				precision = size - 9;
+			} else if (size > 20 && size < 27) {
+				precision = size - 20;
+			}
+		}
+
 		return super.buildAttribute(name, typeName, type, size, precision, allowNulls);
 	}
 
@@ -326,19 +336,23 @@ public class MySQLAdapter extends JdbcAdapter {
 
 			int scale = TypesMapping.isDecimal(column.getType()) ? column.getScale() : -1;
 
-			// sanity check
-			if (scale > len) {
-				scale = -1;
-			}
-
-			if (len > 0) {
-				sqlBuffer.append('(').append(len);
-
-				if (scale >= 0) {
-					sqlBuffer.append(", ").append(scale);
+			if ((column.getType() == Types.TIME || column.getType() == Types.TIMESTAMP) && scale >= 0) {
+				sqlBuffer.append('(').append(scale).append(')');
+			} else {
+				// sanity check
+				if (scale > len) {
+					scale = -1;
 				}
 
-				sqlBuffer.append(')');
+				if (len > 0) {
+					sqlBuffer.append('(').append(len);
+
+					if (scale >= 0) {
+						sqlBuffer.append(", ").append(scale);
+					}
+
+					sqlBuffer.append(')');
+				}
 			}
 		}
 

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/postgres/PostgresAdapter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/postgres/PostgresAdapter.java
@@ -230,6 +230,8 @@ public class PostgresAdapter extends JdbcAdapter {
 
 		buf.append(context.quotedName(at)).append(' ').append(type).append(sizeAndPrecision(this, at))
 				.append(at.isMandatory() ? " NOT" : "").append(" NULL");
+
+		addPrecisionIfTypeTimeOrTimestamp(buf, at);
 	}
 
 	@Override
@@ -277,4 +279,14 @@ public class PostgresAdapter extends JdbcAdapter {
 		return SYSTEM_SCHEMAS;
 	}
 
+	public void addPrecisionIfTypeTimeOrTimestamp(StringBuilder buf, DbAttribute at) {
+		if (at.getType() == Types.TIME || at.getType() == Types.TIMESTAMP) {
+			String stringSqlNameByType = TypesMapping.getSqlNameByType(at.getType()).toLowerCase();
+			int index = buf.lastIndexOf(stringSqlNameByType);
+			if (at.getScale() >= 0) {
+				String string = "(" + at.getScale() + ")";
+				buf.insert(index + stringSqlNameByType.length(), string);
+			}
+		}
+	}
 }

--- a/cayenne-server/src/test/java/org/apache/cayenne/access/Cay2641IT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/access/Cay2641IT.java
@@ -39,14 +39,13 @@ import org.junit.Test;
 import java.sql.Types;
 import java.util.List;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @since 4.2
  */
 @UseServerRuntime(CayenneProjects.CAY_2641)
-public class Cay2641 extends ServerCase {
+public class Cay2641IT extends ServerCase {
 
     @Inject
     private ObjectContext context;
@@ -80,7 +79,7 @@ public class Cay2641 extends ServerCase {
         assertFalse(sql.contains("t0.NAME"));
 
         String string = "SELECT t0.SURNAME, t0.ID FROM ArtistLazy t0";
-        assertTrue(sql.equals(string));
+        assertEquals(sql, string);
 
         ColumnSelect<String> select = ObjectSelect.columnQuery(ArtistLazy.class, ArtistLazy.NAME);
         translator = new DefaultSelectTranslator(select, adapter, context.getEntityResolver());
@@ -97,7 +96,7 @@ public class Cay2641 extends ServerCase {
         assertTrue(object instanceof Fault);
 
         object = artists.get(0).readPropertyDirectly("surname");
-        assertTrue(object.equals("artist2"));
+        assertEquals("artist2", object);
     }
 
     @Test
@@ -109,7 +108,7 @@ public class Cay2641 extends ServerCase {
 
         artist.getName();
         object = artist.readPropertyDirectly("name");
-        assertTrue(object.equals("artist1"));
+        assertEquals("artist1", object);
     }
 
     @Test
@@ -119,31 +118,33 @@ public class Cay2641 extends ServerCase {
         String sql = translator.getSql();
         assertFalse(sql.contains("t0.NAME"));
 
-        String string = "SELECT DISTINCT t0.ARTIST_ID, t0.ID, t1.ID, t1.SURNAME FROM PaintingLazy t0 LEFT JOIN ArtistLazy t1 ON t0.ARTIST_ID = t1.ID";
-        assertTrue(sql.equals(string));
+        String string = "SELECT t0.ARTIST_ID, t0.ID, t1.ID, t1.SURNAME FROM PaintingLazy t0 LEFT JOIN ArtistLazy t1 ON t0.ARTIST_ID = t1.ID";
+        assertEquals(sql, string);
     }
 
     @Test
     public void testPrefetchLazyTypeAttributes() {
-        List<PaintingLazy> paintingLazyList = ObjectSelect.query(PaintingLazy.class).prefetch(PaintingLazy.ARTIST.joint()).select(context);
+        List<PaintingLazy> paintingLazyList = ObjectSelect.query(PaintingLazy.class)
+                .prefetch(PaintingLazy.ARTIST.joint())
+                .select(context);
 
         Object object = paintingLazyList.get(0).readPropertyDirectly("name");
         assertTrue(object instanceof Fault);
 
         object = paintingLazyList.get(0).getName();
         assertTrue(object instanceof String);
-        assertTrue(object.equals("painting1"));
+        assertEquals("painting1", object);
 
         ArtistLazy artist = (ArtistLazy) paintingLazyList.get(0).readPropertyDirectly("artist");
         object = artist.readPropertyDirectly("name");
         assertTrue(object instanceof Fault);
 
         object = artist.readPropertyDirectly("surname");
-        assertTrue(object.equals("artist2"));
+        assertEquals("artist2", object);
 
         object = artist.getName();
         assertTrue(object instanceof String);
-        assertTrue(object.equals("artist1"));
+        assertEquals("artist1", object);
     }
 
     @Test
@@ -156,7 +157,7 @@ public class Cay2641 extends ServerCase {
 
         object = artistLazies.get(0).readPropertyDirectly("surname");
         assertTrue(object instanceof String);
-        assertTrue(object.equals("artist2"));
+        assertEquals("artist2", object);
     }
 
     @Test

--- a/cayenne-server/src/test/java/org/apache/cayenne/dba/mysql/MySQLAdapterIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/dba/mysql/MySQLAdapterIT.java
@@ -28,6 +28,9 @@ import org.apache.cayenne.unit.di.server.ServerCase;
 import org.apache.cayenne.unit.di.server.UseServerRuntime;
 import org.junit.Test;
 
+import java.sql.Types;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @UseServerRuntime(CayenneProjects.TESTMAP_PROJECT)
@@ -66,5 +69,53 @@ public class MySQLAdapterIT extends ServerCase {
         assertTrue(b2.indexOf("PK1") > 0);
         assertTrue(b2.indexOf("PK2") > 0);
         assertTrue(b2.indexOf("PK1") > b2.indexOf("PK2"));
+    }
+
+    @Test
+    public void testCreateTableAppendColumnWithTimeAndTimestamp() {
+        MySQLAdapter adapter = objectFactory.newInstance(
+                MySQLAdapter.class,
+                MySQLAdapter.class.getName());
+
+        DbEntity e = new DbEntity("Test");
+        DbAttribute dblPrec1 = new DbAttribute("dbl1");
+        dblPrec1.setType(Types.TIMESTAMP);
+        dblPrec1.setScale(3);
+        e.addAttribute(dblPrec1);
+
+        DbAttribute dblPrec2 = new DbAttribute("dbl2");
+        dblPrec2.setType(Types.TIME);
+        dblPrec2.setScale(6);
+        e.addAttribute(dblPrec2);
+
+        String sql = adapter.createTable(e);
+
+        // CAY-2694.
+        assertTrue(sql.indexOf("TIME(6)") > 0);
+        assertTrue(sql.indexOf("DATETIME(3)") > 0);
+        assertEquals("CREATE TABLE Test (dbl1 DATETIME(3) NULL, dbl2 TIME(6) NULL) ENGINE=InnoDB", sql);
+    }
+
+    @Test
+    public void testCreateTableAppendColumnWithTimeAndTimestampWihoutScale() {
+        MySQLAdapter adapter = objectFactory.newInstance(
+                MySQLAdapter.class,
+                MySQLAdapter.class.getName());
+
+        DbEntity e = new DbEntity("Test");
+        DbAttribute dblPrec1 = new DbAttribute("dbl1");
+        dblPrec1.setType(Types.TIMESTAMP);
+        e.addAttribute(dblPrec1);
+
+        DbAttribute dblPrec2 = new DbAttribute("dbl2");
+        dblPrec2.setType(Types.TIME);
+        e.addAttribute(dblPrec2);
+
+        String sql = adapter.createTable(e);
+
+        // CAY-2694.
+        assertTrue(sql.indexOf("TIME") > 0);
+        assertTrue(sql.indexOf("DATETIME") > 0);
+        assertEquals("CREATE TABLE Test (dbl1 DATETIME NULL, dbl2 TIME NULL) ENGINE=InnoDB", sql);
     }
 }

--- a/cayenne-server/src/test/java/org/apache/cayenne/dba/postgres/PostgresAdapterIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/dba/postgres/PostgresAdapterIT.java
@@ -59,4 +59,54 @@ public class PostgresAdapterIT extends ServerCase {
         assertEquals("CREATE TABLE Test (dbl1 float(22) NULL)", sql);
     }
 
+    @Test
+    public void testCreateTableWithTimeAndTimestampAttributeWithScale() {
+        PostgresAdapter adapter = objectFactory.newInstance(
+                PostgresAdapter.class,
+                PostgresAdapter.class.getName());
+        DbEntity e = new DbEntity("Test");
+        DbAttribute dblPrec = new DbAttribute("dbl1");
+        dblPrec.setType(Types.TIMESTAMP);
+        dblPrec.setMaxLength(-1);
+        dblPrec.setScale(3);
+        e.addAttribute(dblPrec);
+
+        DbAttribute dblPrec2 = new DbAttribute("dbl2");
+        dblPrec2.setType(Types.TIME);
+        dblPrec2.setMaxLength(-1);
+        dblPrec2.setScale(6);
+        e.addAttribute(dblPrec2);
+
+        String sql = adapter.createTable(e);
+
+        // CAY-2694.
+        assertTrue(sql.indexOf("time(6)") > 0);
+        assertTrue(sql.indexOf("timestamp(3) with time zone") > 0);
+        assertEquals("CREATE TABLE Test (dbl1 timestamp(3) with time zone NULL, dbl2 time(6) NULL)", sql);
+    }
+
+    @Test
+    public void testCreateTableWithTimeAndTimestampAttributeWithoutScale() {
+        PostgresAdapter adapter = objectFactory.newInstance(
+                PostgresAdapter.class,
+                PostgresAdapter.class.getName());
+        DbEntity e = new DbEntity("Test");
+        DbAttribute dblPrec = new DbAttribute("dbl1");
+        dblPrec.setType(Types.TIMESTAMP);
+        dblPrec.setMaxLength(-1);
+        e.addAttribute(dblPrec);
+
+        DbAttribute dblPrec2 = new DbAttribute("dbl2");
+        dblPrec2.setType(Types.TIME);
+        dblPrec2.setMaxLength(-1);
+        e.addAttribute(dblPrec2);
+
+        String sql = adapter.createTable(e);
+
+        // CAY-2694.
+        assertTrue(sql.indexOf("time") > 0);
+        assertTrue(sql.indexOf("timestamp with time zone") > 0);
+        assertEquals("CREATE TABLE Test (dbl1 timestamp with time zone NULL, dbl2 time NULL)", sql);
+
+    }
 }

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testDbAttributeChange.map.xml-result
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testDbAttributeChange.map.xml-result
@@ -36,7 +36,7 @@
         <db-attribute name="COL2" type="CHAR" length="20"/>
         <db-attribute name="COL3" type="DECIMAL" length="10" scale="2"/>
         <db-attribute name="COL4" type="VARCHAR" length="50"/>
-        <db-attribute name="COL5" type="TIME" length="8"/>
+        <db-attribute name="COL5" type="TIME"/>
         <db-attribute name="ID" type="INTEGER" isPrimaryKey="true" isMandatory="true" length="10"/>
     </db-entity>
     <obj-entity name="Child" className="Child" dbEntityName="CHILD">

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testJava7Types.map.xml-result
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testJava7Types.map.xml-result
@@ -27,8 +27,8 @@
     <db-entity name="CHILD" schema="SCHEMA_01">
         <db-attribute name="ID" type="INTEGER" isPrimaryKey="true" isMandatory="true" length="10"/>
         <db-attribute name="date" type="DATE" length="10" />
-        <db-attribute name="time" type="TIME" length="8" />
-        <db-attribute name="timestamp" type="TIMESTAMP" length="29" />
+        <db-attribute name="time" type="TIME" />
+        <db-attribute name="timestamp" type="TIMESTAMP" scale="9" />
     </db-entity>
 
     <obj-entity name="Child" className="Child" dbEntityName="CHILD">

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testJava8Types.map.xml-result
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testJava8Types.map.xml-result
@@ -27,8 +27,8 @@
     <db-entity name="CHILD" schema="SCHEMA_01">
         <db-attribute name="ID" type="INTEGER" isPrimaryKey="true" isMandatory="true" length="10"/>
         <db-attribute name="date" type="DATE" length="10" />
-        <db-attribute name="time" type="TIME" length="8" />
-        <db-attribute name="timestamp" type="TIMESTAMP" length="29" />
+        <db-attribute name="time" type="TIME" />
+        <db-attribute name="timestamp" type="TIMESTAMP" scale="9" />
     </db-entity>
 
     <obj-entity name="Child" className="Child" dbEntityName="CHILD">


### PR DESCRIPTION
…types on MySQL

The precision fixed for MySQL and Postgres.
Reverse Engineering: "maxlength" ignored and "scale" matching the precision of the column.
Forward Engineering: "maxlength" ignored and "scale" matching the precision of the column.