### PR TITLE
CAY-2694 Precision issues with reverse / forward engineering of time …

### DIFF
--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/JdbcAdapter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/JdbcAdapter.java
@@ -509,6 +509,10 @@ public class JdbcAdapter implements DbAdapter {
         attr.setType(type);
         attr.setMandatory(!allowNulls);
 
+        if (type == Types.TIME || type == Types.TIMESTAMP) {
+            size = -1;
+        }
+
         if (size >= 0) {
             attr.setMaxLength(size);
         }

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/TypesMapping.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/TypesMapping.java
@@ -316,7 +316,7 @@ public class TypesMapping {
 	 * Returns true if supplied type is a decimal type.
 	 */
 	public static boolean isDecimal(int type) {
-		return type == DECIMAL || type == DOUBLE || type == FLOAT || type == REAL || type == NUMERIC;
+		return type == DECIMAL || type == DOUBLE || type == FLOAT || type == REAL || type == NUMERIC || type == TIME || type == TIMESTAMP;
 	}
 
 	/**

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/mysql/MySQLAdapter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/mysql/MySQLAdapter.java
@@ -213,6 +213,16 @@ public class MySQLAdapter extends JdbcAdapter {
 			type = Types.LONGVARCHAR;
 		}
 
+		if(type == Types.TIME || type == Types.TIMESTAMP) {
+			if (size == 8 || size == 19) {
+				precision = 0;
+			} else if (size > 9 && size < 16) {
+				precision = size - 9;
+			} else if (size > 20 && size < 27) {
+				precision = size - 20;
+			}
+		}
+
 		return super.buildAttribute(name, typeName, type, size, precision, allowNulls);
 	}
 
@@ -326,19 +336,23 @@ public class MySQLAdapter extends JdbcAdapter {
 
 			int scale = TypesMapping.isDecimal(column.getType()) ? column.getScale() : -1;
 
-			// sanity check
-			if (scale > len) {
-				scale = -1;
-			}
-
-			if (len > 0) {
-				sqlBuffer.append('(').append(len);
-
-				if (scale >= 0) {
-					sqlBuffer.append(", ").append(scale);
+			if ((column.getType() == Types.TIME || column.getType() == Types.TIMESTAMP) && scale >= 0) {
+				sqlBuffer.append('(').append(scale).append(')');
+			} else {
+				// sanity check
+				if (scale > len) {
+					scale = -1;
 				}
 
-				sqlBuffer.append(')');
+				if (len > 0) {
+					sqlBuffer.append('(').append(len);
+
+					if (scale >= 0) {
+						sqlBuffer.append(", ").append(scale);
+					}
+
+					sqlBuffer.append(')');
+				}
 			}
 		}
 

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/postgres/PostgresAdapter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/postgres/PostgresAdapter.java
@@ -230,6 +230,8 @@ public class PostgresAdapter extends JdbcAdapter {
 
 		buf.append(context.quotedName(at)).append(' ').append(type).append(sizeAndPrecision(this, at))
 				.append(at.isMandatory() ? " NOT" : "").append(" NULL");
+
+		addPrecisionIfTypeTimeOrTimestamp(buf, at);
 	}
 
 	@Override
@@ -277,4 +279,14 @@ public class PostgresAdapter extends JdbcAdapter {
 		return SYSTEM_SCHEMAS;
 	}
 
+	public void addPrecisionIfTypeTimeOrTimestamp(StringBuilder buf, DbAttribute at) {
+		if (at.getType() == Types.TIME || at.getType() == Types.TIMESTAMP) {
+			String stringSqlNameByType = TypesMapping.getSqlNameByType(at.getType()).toLowerCase();
+			int index = buf.lastIndexOf(stringSqlNameByType);
+			if (at.getScale() >= 0) {
+				String string = "(" + at.getScale() + ")";
+				buf.insert(index + stringSqlNameByType.length(), string);
+			}
+		}
+	}
 }

--- a/cayenne-server/src/test/java/org/apache/cayenne/dba/mysql/MySQLAdapterIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/dba/mysql/MySQLAdapterIT.java
@@ -28,6 +28,9 @@ import org.apache.cayenne.unit.di.server.ServerCase;
 import org.apache.cayenne.unit.di.server.UseServerRuntime;
 import org.junit.Test;
 
+import java.sql.Types;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @UseServerRuntime(CayenneProjects.TESTMAP_PROJECT)
@@ -66,5 +69,53 @@ public class MySQLAdapterIT extends ServerCase {
         assertTrue(b2.indexOf("PK1") > 0);
         assertTrue(b2.indexOf("PK2") > 0);
         assertTrue(b2.indexOf("PK1") > b2.indexOf("PK2"));
+    }
+
+    @Test
+    public void testCreateTableAppendColumnWithTimeAndTimestamp() {
+        MySQLAdapter adapter = objectFactory.newInstance(
+                MySQLAdapter.class,
+                MySQLAdapter.class.getName());
+
+        DbEntity e = new DbEntity("Test");
+        DbAttribute dblPrec1 = new DbAttribute("dbl1");
+        dblPrec1.setType(Types.TIMESTAMP);
+        dblPrec1.setScale(3);
+        e.addAttribute(dblPrec1);
+
+        DbAttribute dblPrec2 = new DbAttribute("dbl2");
+        dblPrec2.setType(Types.TIME);
+        dblPrec2.setScale(6);
+        e.addAttribute(dblPrec2);
+
+        String sql = adapter.createTable(e);
+
+        // CAY-2694.
+        assertTrue(sql.indexOf("TIME(6)") > 0);
+        assertTrue(sql.indexOf("DATETIME(3)") > 0);
+        assertEquals("CREATE TABLE Test (dbl1 DATETIME(3) NULL, dbl2 TIME(6) NULL) ENGINE=InnoDB", sql);
+    }
+
+    @Test
+    public void testCreateTableAppendColumnWithTimeAndTimestampWihoutScale() {
+        MySQLAdapter adapter = objectFactory.newInstance(
+                MySQLAdapter.class,
+                MySQLAdapter.class.getName());
+
+        DbEntity e = new DbEntity("Test");
+        DbAttribute dblPrec1 = new DbAttribute("dbl1");
+        dblPrec1.setType(Types.TIMESTAMP);
+        e.addAttribute(dblPrec1);
+
+        DbAttribute dblPrec2 = new DbAttribute("dbl2");
+        dblPrec2.setType(Types.TIME);
+        e.addAttribute(dblPrec2);
+
+        String sql = adapter.createTable(e);
+
+        // CAY-2694.
+        assertTrue(sql.indexOf("TIME") > 0);
+        assertTrue(sql.indexOf("DATETIME") > 0);
+        assertEquals("CREATE TABLE Test (dbl1 DATETIME NULL, dbl2 TIME NULL) ENGINE=InnoDB", sql);
     }
 }

--- a/cayenne-server/src/test/java/org/apache/cayenne/dba/postgres/PostgresAdapterIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/dba/postgres/PostgresAdapterIT.java
@@ -59,4 +59,54 @@ public class PostgresAdapterIT extends ServerCase {
         assertEquals("CREATE TABLE Test (dbl1 float(22) NULL)", sql);
     }
 
+    @Test
+    public void testCreateTableWithTimeAndTimestampAttributeWithScale() {
+        PostgresAdapter adapter = objectFactory.newInstance(
+                PostgresAdapter.class,
+                PostgresAdapter.class.getName());
+        DbEntity e = new DbEntity("Test");
+        DbAttribute dblPrec = new DbAttribute("dbl1");
+        dblPrec.setType(Types.TIMESTAMP);
+        dblPrec.setMaxLength(-1);
+        dblPrec.setScale(3);
+        e.addAttribute(dblPrec);
+
+        DbAttribute dblPrec2 = new DbAttribute("dbl2");
+        dblPrec2.setType(Types.TIME);
+        dblPrec2.setMaxLength(-1);
+        dblPrec2.setScale(6);
+        e.addAttribute(dblPrec2);
+
+        String sql = adapter.createTable(e);
+
+        // CAY-2694.
+        assertTrue(sql.indexOf("time(6)") > 0);
+        assertTrue(sql.indexOf("timestamp(3) with time zone") > 0);
+        assertEquals("CREATE TABLE Test (dbl1 timestamp(3) with time zone NULL, dbl2 time(6) NULL)", sql);
+    }
+
+    @Test
+    public void testCreateTableWithTimeAndTimestampAttributeWithoutScale() {
+        PostgresAdapter adapter = objectFactory.newInstance(
+                PostgresAdapter.class,
+                PostgresAdapter.class.getName());
+        DbEntity e = new DbEntity("Test");
+        DbAttribute dblPrec = new DbAttribute("dbl1");
+        dblPrec.setType(Types.TIMESTAMP);
+        dblPrec.setMaxLength(-1);
+        e.addAttribute(dblPrec);
+
+        DbAttribute dblPrec2 = new DbAttribute("dbl2");
+        dblPrec2.setType(Types.TIME);
+        dblPrec2.setMaxLength(-1);
+        e.addAttribute(dblPrec2);
+
+        String sql = adapter.createTable(e);
+
+        // CAY-2694.
+        assertTrue(sql.indexOf("time") > 0);
+        assertTrue(sql.indexOf("timestamp with time zone") > 0);
+        assertEquals("CREATE TABLE Test (dbl1 timestamp with time zone NULL, dbl2 time NULL)", sql);
+
+    }
 }

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testDbAttributeChange.map.xml-result
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testDbAttributeChange.map.xml-result
@@ -36,7 +36,7 @@
         <db-attribute name="COL2" type="CHAR" length="20"/>
         <db-attribute name="COL3" type="DECIMAL" length="10" scale="2"/>
         <db-attribute name="COL4" type="VARCHAR" length="50"/>
-        <db-attribute name="COL5" type="TIME" length="8"/>
+        <db-attribute name="COL5" type="TIME"/>
         <db-attribute name="ID" type="INTEGER" isPrimaryKey="true" isMandatory="true" length="10"/>
     </db-entity>
     <obj-entity name="Child" className="Child" dbEntityName="CHILD">

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testJava7Types.map.xml-result
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testJava7Types.map.xml-result
@@ -27,8 +27,8 @@
     <db-entity name="CHILD" schema="SCHEMA_01">
         <db-attribute name="ID" type="INTEGER" isPrimaryKey="true" isMandatory="true" length="10"/>
         <db-attribute name="date" type="DATE" length="10" />
-        <db-attribute name="time" type="TIME" length="8" />
-        <db-attribute name="timestamp" type="TIMESTAMP" length="29" />
+        <db-attribute name="time" type="TIME" />
+        <db-attribute name="timestamp" type="TIMESTAMP" scale="9" />
     </db-entity>
 
     <obj-entity name="Child" className="Child" dbEntityName="CHILD">

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testJava8Types.map.xml-result
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testJava8Types.map.xml-result
@@ -27,8 +27,8 @@
     <db-entity name="CHILD" schema="SCHEMA_01">
         <db-attribute name="ID" type="INTEGER" isPrimaryKey="true" isMandatory="true" length="10"/>
         <db-attribute name="date" type="DATE" length="10" />
-        <db-attribute name="time" type="TIME" length="8" />
-        <db-attribute name="timestamp" type="TIMESTAMP" length="29" />
+        <db-attribute name="time" type="TIME" />
+        <db-attribute name="timestamp" type="TIMESTAMP" scale="9" />
     </db-entity>
 
     <obj-entity name="Child" className="Child" dbEntityName="CHILD">


### PR DESCRIPTION
…types on MySQL

The precision fixed for MySQL and Postgres.
Reverse Engineering: "maxlength" ignored and "scale" matching the precision of the column.
Forward Engineering: "maxlength" ignored and "scale" matching the precision of the column.