### PR TITLE
CAY-2587 SQLServer Limit Offset convertation

### DIFF
--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/AutoAdapter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/AutoAdapter.java
@@ -60,6 +60,8 @@ public class AutoAdapter implements DbAdapter {
 	 */
 	volatile DbAdapter adapter;
 
+	protected Integer version;
+
 	/**
 	 * Creates an {@link AutoAdapter} based on a delegate adapter obtained via
 	 * "adapterProvider".
@@ -269,5 +271,10 @@ public class AutoAdapter implements DbAdapter {
 	@Override
 	public List<String> getSystemSchemas() {
 		return getAdapter().getSystemSchemas();
+	}
+
+	@Override
+	public Integer getVersion() {
+		return version;
 	}
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/AutoAdapter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/AutoAdapter.java
@@ -60,8 +60,6 @@ public class AutoAdapter implements DbAdapter {
 	 */
 	volatile DbAdapter adapter;
 
-	protected Integer version;
-
 	/**
 	 * Creates an {@link AutoAdapter} based on a delegate adapter obtained via
 	 * "adapterProvider".
@@ -273,8 +271,4 @@ public class AutoAdapter implements DbAdapter {
 		return getAdapter().getSystemSchemas();
 	}
 
-	@Override
-	public Integer getVersion() {
-		return version;
-	}
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/DbAdapter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/DbAdapter.java
@@ -255,4 +255,6 @@ public interface DbAdapter {
 	 * @return list of system schemas
 	 */
 	List<String> getSystemSchemas();
+
+	Integer getVersion();
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/DbAdapter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/DbAdapter.java
@@ -256,5 +256,4 @@ public interface DbAdapter {
 	 */
 	List<String> getSystemSchemas();
 
-	Integer getVersion();
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/JdbcAdapter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/JdbcAdapter.java
@@ -78,8 +78,6 @@ public class JdbcAdapter implements DbAdapter {
     protected ResourceLocator resourceLocator;
     protected boolean caseInsensitiveCollations;
 
-    protected Integer version;
-
     /**
      * @since 3.1
      * @deprecated since 4.0 BatchQueryBuilderfactory is attached to the DataNode.
@@ -655,12 +653,4 @@ public class JdbcAdapter implements DbAdapter {
         return this;
     }
 
-    @Override
-    public Integer getVersion() {
-        return version;
-    }
-
-    public void setVersion(Integer version) {
-        this.version = version;
-    }
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/JdbcAdapter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/JdbcAdapter.java
@@ -78,6 +78,8 @@ public class JdbcAdapter implements DbAdapter {
     protected ResourceLocator resourceLocator;
     protected boolean caseInsensitiveCollations;
 
+    protected Integer version;
+
     /**
      * @since 3.1
      * @deprecated since 4.0 BatchQueryBuilderfactory is attached to the DataNode.
@@ -653,4 +655,12 @@ public class JdbcAdapter implements DbAdapter {
         return this;
     }
 
+    @Override
+    public Integer getVersion() {
+        return version;
+    }
+
+    public void setVersion(Integer version) {
+        this.version = version;
+    }
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/sqlserver/SQLServerActionBuilder.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/sqlserver/SQLServerActionBuilder.java
@@ -29,6 +29,13 @@ import org.apache.cayenne.query.*;
 public class SQLServerActionBuilder extends JdbcActionBuilder {
 
 	/**
+	 * Stores the major version of the database.
+	 *
+	 * @since 4.2
+	 */
+	private Integer version;
+
+	/**
 	 * @since 4.0
 	 */
 	public SQLServerActionBuilder(DataNode dataNode) {
@@ -57,7 +64,8 @@ public class SQLServerActionBuilder extends JdbcActionBuilder {
 	 */
 	@Override
 	public <T> SQLAction objectSelectAction(SelectQuery<T> query) {
-		if (query.getOrderings() == null || query.getOrderings().size() == 0) {
+		if (query.getOrderings() == null || query.getOrderings().size() == 0 ||
+				version == null || version < 12) {
 			return new SQLServerSelectAction(query, dataNode, true);
 		}
 
@@ -69,10 +77,19 @@ public class SQLServerActionBuilder extends JdbcActionBuilder {
 	 */
 	@Override
 	public <T> SQLAction objectSelectAction(FluentSelect<T> query) {
-		if (query.getOrderings() == null || query.getOrderings().size() == 0) {
+		if (query.getOrderings() == null || query.getOrderings().size() == 0 ||
+				version == null || version < 12) {
 			return new SQLServerSelectAction(query, dataNode, true);
 		}
 
 		return new SQLServerSelectAction(query, dataNode, false);
+	}
+
+	public Integer getVersion() {
+		return version;
+	}
+
+	public void setVersion(Integer version) {
+		this.version = version;
 	}
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/sqlserver/SQLServerActionBuilder.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/sqlserver/SQLServerActionBuilder.java
@@ -21,9 +21,7 @@ package org.apache.cayenne.dba.sqlserver;
 
 import org.apache.cayenne.access.DataNode;
 import org.apache.cayenne.dba.JdbcActionBuilder;
-import org.apache.cayenne.query.BatchQuery;
-import org.apache.cayenne.query.ProcedureQuery;
-import org.apache.cayenne.query.SQLAction;
+import org.apache.cayenne.query.*;
 
 /**
  * @since 1.2
@@ -52,5 +50,29 @@ public class SQLServerActionBuilder extends JdbcActionBuilder {
 	@Override
 	public SQLAction procedureAction(ProcedureQuery query) {
 		return new SQLServerProcedureAction(query, dataNode);
+	}
+
+	/**
+	 * @since 4.2
+	 */
+	@Override
+	public <T> SQLAction objectSelectAction(SelectQuery<T> query) {
+		if (query.getOrderings() == null || query.getOrderings().size() == 0) {
+			return new SQLServerSelectAction(query, dataNode, true);
+		}
+
+		return new SQLServerSelectAction(query, dataNode, false);
+	}
+
+	/**
+	 * @since 4.2
+	 */
+	@Override
+	public <T> SQLAction objectSelectAction(FluentSelect<T> query) {
+		if (query.getOrderings() == null || query.getOrderings().size() == 0) {
+			return new SQLServerSelectAction(query, dataNode, true);
+		}
+
+		return new SQLServerSelectAction(query, dataNode, false);
 	}
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/sqlserver/SQLServerAdapter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/sqlserver/SQLServerAdapter.java
@@ -75,6 +75,15 @@ import org.apache.cayenne.resource.ResourceLocator;
 public class SQLServerAdapter extends SybaseAdapter {
 
 	/**
+	 * Stores the major version of the database.
+	 * Database versions 12 and higher support the use of LIMIT,
+	 * lower versions use TOP N
+	 *
+	 * @since 4.2
+	 */
+	protected Integer version;
+
+	/**
 	 * @deprecated since 4.2 unused
 	 */
 	@Deprecated
@@ -110,7 +119,7 @@ public class SQLServerAdapter extends SybaseAdapter {
 	@Override
 	public SQLTreeProcessor getSqlTreeProcessor() {
 		SQLServerTreeProcessor sqlServerTreeProcessor = new SQLServerTreeProcessor();
-		sqlServerTreeProcessor.setVersion(this.getVersion());
+		sqlServerTreeProcessor.setVersion(getVersion());
 		return sqlServerTreeProcessor;
 	}
 
@@ -129,4 +138,11 @@ public class SQLServerAdapter extends SybaseAdapter {
 		return SYSTEM_SCHEMAS;
 	}
 
+	public Integer getVersion() {
+		return version;
+	}
+
+	public void setVersion(Integer version) {
+		this.version = version;
+	}
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/sqlserver/SQLServerAdapter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/sqlserver/SQLServerAdapter.java
@@ -81,7 +81,7 @@ public class SQLServerAdapter extends SybaseAdapter {
 	 *
 	 * @since 4.2
 	 */
-	protected Integer version;
+	private Integer version;
 
 	/**
 	 * @deprecated since 4.2 unused
@@ -130,7 +130,9 @@ public class SQLServerAdapter extends SybaseAdapter {
 	 */
 	@Override
 	public SQLAction getAction(Query query, DataNode node) {
-		return query.createSQLAction(new SQLServerActionBuilder(node));
+		SQLServerActionBuilder sqlServerActionBuilder = new SQLServerActionBuilder(node);
+		sqlServerActionBuilder.setVersion(this.version);
+		return query.createSQLAction(sqlServerActionBuilder);
 	}
 
 	@Override

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/sqlserver/SQLServerAdapter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/sqlserver/SQLServerAdapter.java
@@ -109,7 +109,9 @@ public class SQLServerAdapter extends SybaseAdapter {
 	 */
 	@Override
 	public SQLTreeProcessor getSqlTreeProcessor() {
-		return new SQLServerTreeProcessor();
+		SQLServerTreeProcessor sqlServerTreeProcessor = new SQLServerTreeProcessor();
+		sqlServerTreeProcessor.setVersion(this.getVersion());
+		return sqlServerTreeProcessor;
 	}
 
 	/**

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/sqlserver/SQLServerSelectAction.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/sqlserver/SQLServerSelectAction.java
@@ -17,37 +17,34 @@
  *    under the License.
  */
 
-package org.apache.cayenne.dba.sqlserver.sqltree;
+package org.apache.cayenne.dba.sqlserver;
 
-import org.apache.cayenne.access.sqlbuilder.QuotingAppendable;
-import org.apache.cayenne.access.sqlbuilder.sqltree.LimitOffsetNode;
-import org.apache.cayenne.access.sqlbuilder.sqltree.Node;
+import org.apache.cayenne.access.DataNode;
+import org.apache.cayenne.access.jdbc.SelectAction;
+import org.apache.cayenne.query.Select;
 
 /**
  * @since 4.2
  */
-public class SQLServerLimitOffsetNode extends LimitOffsetNode {
+public class SQLServerSelectAction extends SelectAction {
 
-    public SQLServerLimitOffsetNode(int limit, int offset) {
-        super(limit, offset);
+    /**
+     * When using TOP N instead of LIMIT. The offset will be manual.
+     *
+     */
+    private Boolean isManualOffset;
+
+    public SQLServerSelectAction(Select<?> query, DataNode dataNode, Boolean isManualOffset) {
+        super(query, dataNode);
+
+        this.isManualOffset = isManualOffset;
     }
 
     @Override
-    public QuotingAppendable append(QuotingAppendable buffer) {
-        // OFFSET X ROWS FETCH NEXT Y ROWS ONLY
-        if(limit == 0 && offset == 0) {
-            return buffer;
+    protected int getInMemoryOffset(int queryOffset) {
+        if (isManualOffset) {
+            return super.getInMemoryOffset(queryOffset);
         }
-        buffer.append(" OFFSET ").append(offset).append(" ROWS");
-        if (limit > 0) {
-            return buffer.append(" FETCH NEXT ").append(limit).append(" ROWS ONLY");
-        }
-        return buffer;
+        return 0;
     }
-
-    @Override
-    public Node copy() {
-        return new SQLServerLimitOffsetNode(limit, offset);
-    }
-
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/sqlserver/SQLServerSniffer.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/sqlserver/SQLServerSniffer.java
@@ -50,6 +50,7 @@ public class SQLServerSniffer implements DbAdapterDetector {
         SQLServerAdapter adapter = objectFactory.newInstance(
                 SQLServerAdapter.class,
                 SQLServerAdapter.class.getName());
+        adapter.setVersion(md.getDatabaseMajorVersion());
 
         // detect whether generated keys are supported
         boolean generatedKeys = false;

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/sqlserver/SQLServerTreeProcessor.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/sqlserver/SQLServerTreeProcessor.java
@@ -38,10 +38,10 @@ public class SQLServerTreeProcessor extends SybaseSQLTreeProcessor {
 
     @Override
     protected void onLimitOffsetNode(Node parent, LimitOffsetNode child, int index) {
-        if (version >= 12) {
+        if (version == null || version >= 12) {
             for (int i = 0; i < parent.getChildrenCount(); i++) {
                 if (parent.getChild(i) instanceof OrderByNode) {
-                    replaceChild(parent, index,  new SQLServerLimitOffsetNode(child.getLimit(), child.getOffset()));
+                    replaceChild(parent, index,  new SQLServerLimitOffsetNode(child.getLimit(), child.getOffset()), false);
                     return;
                 }
             }

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/sqlserver/SQLServerTreeProcessor.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/sqlserver/SQLServerTreeProcessor.java
@@ -38,7 +38,7 @@ public class SQLServerTreeProcessor extends SybaseSQLTreeProcessor {
 
     @Override
     protected void onLimitOffsetNode(Node parent, LimitOffsetNode child, int index) {
-        if (version == null || version >= 12) {
+        if (version != null && version >= 12) {
             for (int i = 0; i < parent.getChildrenCount(); i++) {
                 if (parent.getChild(i) instanceof OrderByNode) {
                     replaceChild(parent, index,  new SQLServerLimitOffsetNode(child.getLimit(), child.getOffset()), false);

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/sqlserver/SQLServerTreeProcessor.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/sqlserver/SQLServerTreeProcessor.java
@@ -19,9 +19,9 @@
 
 package org.apache.cayenne.dba.sqlserver;
 
-import org.apache.cayenne.access.sqlbuilder.sqltree.ColumnNode;
-import org.apache.cayenne.access.sqlbuilder.sqltree.Node;
+import org.apache.cayenne.access.sqlbuilder.sqltree.*;
 import org.apache.cayenne.dba.sqlserver.sqltree.SQLServerColumnNode;
+import org.apache.cayenne.dba.sqlserver.sqltree.SQLServerLimitOffsetNode;
 import org.apache.cayenne.dba.sybase.SybaseSQLTreeProcessor;
 
 /**
@@ -29,8 +29,32 @@ import org.apache.cayenne.dba.sybase.SybaseSQLTreeProcessor;
  */
 public class SQLServerTreeProcessor extends SybaseSQLTreeProcessor {
 
+    private Integer version;
+
     @Override
     protected void onColumnNode(Node parent, ColumnNode child, int index) {
         replaceChild(parent, index,  new SQLServerColumnNode(child));
+    }
+
+    @Override
+    protected void onLimitOffsetNode(Node parent, LimitOffsetNode child, int index) {
+        if (version >= 12) {
+            for (int i = 0; i < parent.getChildrenCount(); i++) {
+                if (parent.getChild(i) instanceof OrderByNode) {
+                    replaceChild(parent, index,  new SQLServerLimitOffsetNode(child.getLimit(), child.getOffset()));
+                    return;
+                }
+            }
+        }
+
+        super.onLimitOffsetNode(parent, child, index);
+    }
+
+    public Integer getVersion() {
+        return version;
+    }
+
+    public void setVersion(Integer version) {
+        this.version = version;
     }
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/sqlserver/sqltree/SQLServerLimitOffsetNode.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/sqlserver/sqltree/SQLServerLimitOffsetNode.java
@@ -1,0 +1,31 @@
+package org.apache.cayenne.dba.sqlserver.sqltree;
+
+import org.apache.cayenne.access.sqlbuilder.QuotingAppendable;
+import org.apache.cayenne.access.sqlbuilder.sqltree.LimitOffsetNode;
+import org.apache.cayenne.access.sqlbuilder.sqltree.Node;
+
+/**
+ * @since 4.2
+ */
+public class SQLServerLimitOffsetNode extends LimitOffsetNode {
+
+    public SQLServerLimitOffsetNode(int limit, int offset) {
+        // Per SQLServer documentation: "To retrieve all rows from a certain offset up to the end of the result set,
+        // you can use some large number for the second parameter."
+        super(limit == 0 && offset > 0 ? Integer.MAX_VALUE : limit, offset);
+    }
+
+    @Override
+    public QuotingAppendable append(QuotingAppendable buffer) {
+        if(limit == 0 && offset == 0) {
+            return buffer;
+        }
+        return buffer.append(" OFFSET ").append(offset).append(" ROWS FETCH NEXT ").append(limit).append(" ROWS ONLY ");
+    }
+
+    @Override
+    public Node copy() {
+        return new SQLServerLimitOffsetNode(limit, offset);
+    }
+
+}


### PR DESCRIPTION
Now cayenne query for SQLServer Limit/Offset converts to 'top (Limit+Offset)'.
I think we should convert it to:
OFFSET n ROWS
FETCH NEXT k ROWS ONLY;
If MS SQL Server 2008 and older is used, the query is converted to top (Limit+Offset)'. OFFSET can only be used with 'orderBy'.