### PR TITLE
CAY-2708 gradle build plugin fails on java 16

### DIFF
--- a/cayenne-gradle-plugin/build.gradle
+++ b/cayenne-gradle-plugin/build.gradle
@@ -44,17 +44,17 @@ def getProjectVersion() {
     }
 }
 
-def classpathFile = file('build/classpath.txt')
+def classpathFile = file('build/classpath2.txt')
 if (classpathFile.file) {
     String[] paths = classpathFile.text.split(';')
     dependencies {
-        add 'compile', files(paths)
+        add 'implementation', files(paths)
     }
 }
 
 dependencies {
-    compile gradleApi()
-    compile localGroovy()
+    implementation gradleApi()
+    implementation localGroovy()
 }
 
 // Create file with cayenne-gradle-plugin version

--- a/cayenne-gradle-plugin/build.gradle
+++ b/cayenne-gradle-plugin/build.gradle
@@ -44,7 +44,7 @@ def getProjectVersion() {
     }
 }
 
-def classpathFile = file('build/classpath2.txt')
+def classpathFile = file('build/classpath.txt')
 if (classpathFile.file) {
     String[] paths = classpathFile.text.split(';')
     dependencies {

--- a/cayenne-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/cayenne-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/cayenne-gradle-plugin/pom.xml
+++ b/cayenne-gradle-plugin/pom.xml
@@ -137,6 +137,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/BaseCayenneTask.java
+++ b/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/BaseCayenneTask.java
@@ -56,6 +56,10 @@ public class BaseCayenneTask extends DefaultTask {
         setMap(mapFile);
     }
 
+    public String getMapFileName() {
+        return mapFileName;
+    }
+
     @Internal
     public File getDataMapFile() {
         if (map != null) {

--- a/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/CgenTask.java
+++ b/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/CgenTask.java
@@ -431,6 +431,22 @@ public class CgenTask extends BaseCayenneTask {
         this.excludeEmbeddables = excludeEmbeddables;
     }
 
+    public Boolean getCreatePKProperties() {
+        return createPKProperties;
+    }
+
+    public String getExternalToolConfig() {
+        return externalToolConfig;
+    }
+
+    public String getQueryTemplate() {
+        return queryTemplate;
+    }
+
+    public String getQuerySuperTemplate() {
+        return querySuperTemplate;
+    }
+
     /**
      * @param excludeEmbeddables pattern to use for embeddable exclusion
      * @since 4.1

--- a/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/DbGenerateTask.java
+++ b/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/DbGenerateTask.java
@@ -58,23 +58,23 @@ public class DbGenerateTask extends BaseCayenneTask {
     private DataSourceConfig dataSource = new DataSourceConfig();
 
     @Input
-    @Optional
+    //@Optional
     private boolean dropTables;
 
     @Input
-    @Optional
+    //@Optional
     private boolean dropPK;
 
     @Input
-    @Optional
+    //@Optional
     private boolean createTables = true;
 
     @Input
-    @Optional
+    //@Optional
     private boolean createPK = true;
 
     @Input
-    @Optional
+    //@Optional
     private boolean createFK = true;
 
     @InputFile

--- a/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/DbGenerateTask.java
+++ b/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/DbGenerateTask.java
@@ -47,6 +47,8 @@ import javax.sql.DataSource;
 
 /**
  * @since 4.0
+ *
+ * Gradle 7.0 can't recognize @Optional for some fields
  */
 public class DbGenerateTask extends BaseCayenneTask {
 

--- a/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/DbImportTask.java
+++ b/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/DbImportTask.java
@@ -48,6 +48,7 @@ import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.TaskExecutionException;
+import org.apache.cayenne.di.spi.DefaultClassLoaderManager;
 
 /**
  * @since 4.0
@@ -79,7 +80,7 @@ public class DbImportTask extends BaseCayenneTask {
         dataSource.validate();
 
         final Injector injector = DIBootstrap.createInjector(new DbSyncModule(), new ToolsModule(getLogger()), new DbImportModule(),
-                binder -> binder.bind(ClassLoaderManager.class).toInstance(new GradlePluginClassLoaderManager(getProject())));
+                binder -> binder.bind(ClassLoaderManager.class).toInstance(new DefaultClassLoaderManager()));
 
         final DbImportConfiguration config = createConfig();
 
@@ -187,7 +188,6 @@ public class DbImportTask extends BaseCayenneTask {
     public void adapter(final String adapter) {
         setAdapter(adapter);
     }
-
 
     public ReverseEngineering getReverseEngineering() {
         return reverseEngineering;

--- a/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/DbImportTask.java
+++ b/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/DbImportTask.java
@@ -188,6 +188,11 @@ public class DbImportTask extends BaseCayenneTask {
         setAdapter(adapter);
     }
 
+
+    public ReverseEngineering getReverseEngineering() {
+        return reverseEngineering;
+    }
+
     @OutputFile
     @Optional
     public File getCayenneProject() {

--- a/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/GradlePluginClassLoaderManager.java
+++ b/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/GradlePluginClassLoaderManager.java
@@ -40,9 +40,10 @@ import org.gradle.api.artifacts.DependencySet;
  * @deprecated
  * Class supports only compile gradle configuration, which is removed in gradle 7.0
  * replaced with org.apache.cayenne.di.spi.DefaultClassLoaderManager
+ * Will be removed
  * @since 4.2.M4
  */
-@Deprecated(since = "4.2.M4",forRemoval = true)
+@Deprecated
 public class GradlePluginClassLoaderManager implements ClassLoaderManager {
 
     private Project project;

--- a/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/GradlePluginClassLoaderManager.java
+++ b/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/GradlePluginClassLoaderManager.java
@@ -75,7 +75,7 @@ public class GradlePluginClassLoaderManager implements ClassLoaderManager {
             return classLoader;
         }
 
-        Configuration configuration = configurations.getByName("compile");
+        Configuration configuration = configurations.getByName("implementation");
         DependencySet dependencies = configuration.getDependencies();
         if(dependencies == null || dependencies.isEmpty()) {
             return classLoader;

--- a/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/GradlePluginClassLoaderManager.java
+++ b/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/GradlePluginClassLoaderManager.java
@@ -36,7 +36,13 @@ import org.gradle.api.artifacts.DependencySet;
  * Gradle class loader manager to update class loader urls with project dependencies.
  *
  * @since 4.1
+ *
+ * @deprecated
+ * Class supports only compile gradle configuration, which is removed in gradle 7.0
+ * replaced with org.apache.cayenne.di.spi.DefaultClassLoaderManager
+ * @since 4.2.M4
  */
+@Deprecated(since = "4.2.M4",forRemoval = true)
 public class GradlePluginClassLoaderManager implements ClassLoaderManager {
 
     private Project project;
@@ -75,7 +81,7 @@ public class GradlePluginClassLoaderManager implements ClassLoaderManager {
             return classLoader;
         }
 
-        Configuration configuration = configurations.getByName("implementation");
+        Configuration configuration = configurations.getByName("compile");
         DependencySet dependencies = configuration.getDependencies();
         if(dependencies == null || dependencies.isEmpty()) {
             return classLoader;

--- a/cayenne-gradle-plugin/src/test/java/org/apache/cayenne/tools/DbGenerateTaskIT.java
+++ b/cayenne-gradle-plugin/src/test/java/org/apache/cayenne/tools/DbGenerateTaskIT.java
@@ -59,7 +59,7 @@ public class DbGenerateTaskIT extends BaseTaskIT {
                 "cdbgen",
                 "-PdbUrl=" + dbUrl,
                 "-PdataMap=test_datamap.map.xml",
-                "--info"
+                "--debug"
         );
 
         BuildResult result = runner.build();

--- a/cayenne-gradle-plugin/src/test/java/org/apache/cayenne/tools/GradlePluginIT.java
+++ b/cayenne-gradle-plugin/src/test/java/org/apache/cayenne/tools/GradlePluginIT.java
@@ -56,7 +56,9 @@ public class GradlePluginIT extends BaseTaskIT {
 
         // Old gradle versions will fail on new JDK
         int javaMajorVersion = getJavaMajorVersion(System.getProperty("java.version"));
-        if(javaMajorVersion >= 11) {
+        if(javaMajorVersion >= 16) {
+            versions = new String[]{"7.0"};
+        } else if(javaMajorVersion >= 11) {
             versions = new String[]{"4.8"};
         } else if (javaMajorVersion < 9) {
             versions = new String[]{"4.3", "4.0", "3.5", "3.3", "3.0", "2.12", "2.8"};

--- a/cayenne-gradle-plugin/src/test/resources/org/apache/cayenne/tools/dbimport-with-project-dependency.gradle
+++ b/cayenne-gradle-plugin/src/test/resources/org/apache/cayenne/tools/dbimport-with-project-dependency.gradle
@@ -20,7 +20,9 @@
 plugins {
     id 'org.apache.cayenne'
 }
-apply plugin:'java'
+
+
+apply plugin: 'java'
 cdbimport {
     map 'datamap.map.xml'
 
@@ -36,6 +38,10 @@ cdbimport {
 
 dependencies {
     implementation 'mysql:mysql-connector-java:6.0.5'
+}
+
+configurations {
+    project.configurations.getByName("implementation").setCanBeResolved(true)
 }
 
 repositories {

--- a/cayenne-gradle-plugin/src/test/resources/org/apache/cayenne/tools/dbimport-with-project-dependency.gradle
+++ b/cayenne-gradle-plugin/src/test/resources/org/apache/cayenne/tools/dbimport-with-project-dependency.gradle
@@ -35,7 +35,7 @@ cdbimport {
 }
 
 dependencies {
-    compile 'mysql:mysql-connector-java:6.0.5'
+    implementation 'mysql:mysql-connector-java:6.0.5'
 }
 
 repositories {


### PR DESCRIPTION
- Replace 4.8.1 Gradle version with 7.0 in path to binary file. 
    
    _(cayenne-gradle-plugin/gradle/wrapper/gradle-wrapper.properties)_
- Replace 'compile' configuration with 'implementation' in build.gradle and test Gradle files due to 'compile' configuration is not supported yet. Where it is needed, resolvable=true property was set to 'implementation' in test files.

    _(cayenne-gradle-plugin/build.gradle, cayenne-gradle-plugin/src/test/resources/org/apache/cayenne/tools/dbimport-with-project-dependency.gradle)_
- Gradle Api 7.0 requires getters and the lack of Optional annotation for fields marked with Input annotation, so these methods were added.

    _(cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/CgenTask.java, cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/CgenTask.java)_
- Add maven-compiler-plugin to pom.xml to be able to compile with maven current module.

    _(cayenne-gradle-plugin/pom.xml)_
- GradlePluginClassLoaderManager recognize only 'compile' configuration in test Gradle files. This class was marked as deprecated and replaced with DefaultClassLoaderManager.

    _(cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/DbImportTask.java)_
- Add 7.0 version of Gradle to test of Gradle versions compatibility. For the versions in [11,16) Gradle 4.8 still in use.

    _(cayenne-gradle-plugin/src/test/java/org/apache/cayenne/tools/GradlePluginIT.java)_
- Change somewhere logging level to debug to track more information.

    _(cayenne-gradle-plugin/src/test/java/org/apache/cayenne/tools/DbGenerateTaskIT.java)_
- Document deprecated class and commented annotations.

    _(cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/GradlePluginClassLoaderManager.java, cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/DbGenerateTask.java)_