### PR TITLE
CAY-2708 Gradle build plugin fails

### DIFF
--- a/cayenne-gradle-plugin/build.gradle
+++ b/cayenne-gradle-plugin/build.gradle
@@ -48,13 +48,13 @@ def classpathFile = file('build/classpath.txt')
 if (classpathFile.file) {
     String[] paths = classpathFile.text.split(';')
     dependencies {
-        add 'compile', files(paths)
+        add 'implementation', files(paths)
     }
 }
 
 dependencies {
-    compile gradleApi()
-    compile localGroovy()
+    implementation gradleApi()
+    implementation localGroovy()
 }
 
 // Create file with cayenne-gradle-plugin version

--- a/cayenne-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/cayenne-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/cayenne-gradle-plugin/pom.xml
+++ b/cayenne-gradle-plugin/pom.xml
@@ -137,6 +137,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/BaseCayenneTask.java
+++ b/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/BaseCayenneTask.java
@@ -56,6 +56,10 @@ public class BaseCayenneTask extends DefaultTask {
         setMap(mapFile);
     }
 
+    public String getMapFileName() {
+        return mapFileName;
+    }
+
     @Internal
     public File getDataMapFile() {
         if (map != null) {

--- a/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/CgenTask.java
+++ b/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/CgenTask.java
@@ -431,6 +431,22 @@ public class CgenTask extends BaseCayenneTask {
         this.excludeEmbeddables = excludeEmbeddables;
     }
 
+    public Boolean getCreatePKProperties() {
+        return createPKProperties;
+    }
+
+    public String getExternalToolConfig() {
+        return externalToolConfig;
+    }
+
+    public String getQueryTemplate() {
+        return queryTemplate;
+    }
+
+    public String getQuerySuperTemplate() {
+        return querySuperTemplate;
+    }
+
     /**
      * @param excludeEmbeddables pattern to use for embeddable exclusion
      * @since 4.1

--- a/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/DbGenerateTask.java
+++ b/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/DbGenerateTask.java
@@ -58,23 +58,18 @@ public class DbGenerateTask extends BaseCayenneTask {
     private DataSourceConfig dataSource = new DataSourceConfig();
 
     @Input
-    @Optional
     private boolean dropTables;
 
     @Input
-    @Optional
     private boolean dropPK;
 
     @Input
-    @Optional
     private boolean createTables = true;
 
     @Input
-    @Optional
     private boolean createPK = true;
 
     @Input
-    @Optional
     private boolean createFK = true;
 
     @InputFile

--- a/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/DbImportTask.java
+++ b/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/DbImportTask.java
@@ -188,6 +188,10 @@ public class DbImportTask extends BaseCayenneTask {
         setAdapter(adapter);
     }
 
+    public ReverseEngineering getReverseEngineering() {
+        return reverseEngineering;
+    }
+
     @OutputFile
     @Optional
     public File getCayenneProject() {

--- a/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/DbImportTask.java
+++ b/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/DbImportTask.java
@@ -48,6 +48,7 @@ import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.TaskExecutionException;
+import org.apache.cayenne.di.spi.DefaultClassLoaderManager;
 
 /**
  * @since 4.0
@@ -79,7 +80,7 @@ public class DbImportTask extends BaseCayenneTask {
         dataSource.validate();
 
         final Injector injector = DIBootstrap.createInjector(new DbSyncModule(), new ToolsModule(getLogger()), new DbImportModule(),
-                binder -> binder.bind(ClassLoaderManager.class).toInstance(new GradlePluginClassLoaderManager(getProject())));
+                binder -> binder.bind(ClassLoaderManager.class).toInstance(new DefaultClassLoaderManager()));
 
         final DbImportConfiguration config = createConfig();
 

--- a/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/GradlePluginClassLoaderManager.java
+++ b/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/GradlePluginClassLoaderManager.java
@@ -36,7 +36,15 @@ import org.gradle.api.artifacts.DependencySet;
  * Gradle class loader manager to update class loader urls with project dependencies.
  *
  * @since 4.1
+ *
+ * @deprecated
+ * Class supports only compile gradle configuration, which is removed in gradle 7.0
+ * replaced with org.apache.cayenne.di.spi.DefaultClassLoaderManager
+ *
+ * Class will be removed in next updates
+ * @since 4.2.M4
  */
+@Deprecated
 public class GradlePluginClassLoaderManager implements ClassLoaderManager {
 
     private Project project;

--- a/cayenne-gradle-plugin/src/test/java/org/apache/cayenne/tools/GradlePluginIT.java
+++ b/cayenne-gradle-plugin/src/test/java/org/apache/cayenne/tools/GradlePluginIT.java
@@ -56,7 +56,9 @@ public class GradlePluginIT extends BaseTaskIT {
 
         // Old gradle versions will fail on new JDK
         int javaMajorVersion = getJavaMajorVersion(System.getProperty("java.version"));
-        if(javaMajorVersion >= 11) {
+        if(javaMajorVersion >= 16) {
+            versions = new String[]{"7.0"};
+        } else if(javaMajorVersion >= 11) {
             versions = new String[]{"4.8"};
         } else if (javaMajorVersion < 9) {
             versions = new String[]{"4.3", "4.0", "3.5", "3.3", "3.0", "2.12", "2.8"};

--- a/cayenne-gradle-plugin/src/test/java/org/apache/cayenne/tools/GradlePluginIT.java
+++ b/cayenne-gradle-plugin/src/test/java/org/apache/cayenne/tools/GradlePluginIT.java
@@ -61,7 +61,7 @@ public class GradlePluginIT extends BaseTaskIT {
         } else if(javaMajorVersion >= 11) {
             versions = new String[]{"4.8"};
         } else if (javaMajorVersion < 9) {
-            versions = new String[]{"4.3", "4.0", "3.5", "3.3", "3.0", "2.12", "2.8"};
+            versions = new String[]{"4.3", "4.0", "3.5"};
         } else {
             versions = new String[]{"4.3.1", "4.3"};
         }

--- a/cayenne-gradle-plugin/src/test/resources/org/apache/cayenne/tools/dbimport-with-project-dependency.gradle
+++ b/cayenne-gradle-plugin/src/test/resources/org/apache/cayenne/tools/dbimport-with-project-dependency.gradle
@@ -35,7 +35,11 @@ cdbimport {
 }
 
 dependencies {
-    compile 'mysql:mysql-connector-java:6.0.5'
+    implementation 'mysql:mysql-connector-java:6.0.5'
+}
+
+configurations {
+    project.configurations.getByName("implementation").setCanBeResolved(true)
 }
 
 repositories {


### PR DESCRIPTION
- Replace 4.8.1 Gradle version with 7.0 in path to binary file. 
    
    _(cayenne-gradle-plugin/gradle/wrapper/gradle-wrapper.properties)_
- Replace 'compile' configuration with 'implementation' in build.gradle and test Gradle files due to 'compile' configuration is not supported yet. Where it is needed, resolvable=true property was set to 'implementation' in test files.

    _(cayenne-gradle-plugin/build.gradle, cayenne-gradle-plugin/src/test/resources/org/apache/cayenne/tools/dbimport-with-project-dependency.gradle)_
- Gradle Api 7.0 requires getters and the lack of Optional annotation for fields marked with Input annotation, so these methods were added.

    _(cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/CgenTask.java, cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/CgenTask.java)_
- Add maven-compiler-plugin to pom.xml to be able to compile with maven current module.

    _(cayenne-gradle-plugin/pom.xml)_
- GradlePluginClassLoaderManager recognize only 'compile' configuration in test Gradle files. This class was marked as deprecated and replaced with DefaultClassLoaderManager.

    _(cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/DbImportTask.java)_
- Add 7.0 version of Gradle to test of Gradle versions compatibility. For the versions in [11,16) Gradle 4.8 still in use. Remove support of version 3.3 and less in tests.

    _(cayenne-gradle-plugin/src/test/java/org/apache/cayenne/tools/DbGenerateTaskIT.java)_
- Document deprecated class and commented annotations.

    _(cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/GradlePluginClassLoaderManager.java, cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/DbGenerateTask.java)_