### PR TITLE
CAY-2630 Prefetched relationships not preserving pending changes

### DIFF
--- a/cayenne-server/src/main/java/org/apache/cayenne/access/JoinedIdParentAttachmentStrategy.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/JoinedIdParentAttachmentStrategy.java
@@ -32,16 +32,14 @@ import org.apache.cayenne.reflect.ClassDescriptor;
  * A ParentAttachmentStrategy that extracts parent ObjectId from the joined columns in the
  * child snapshot.
  */
-class JoinedIdParentAttachementStrategy implements ParentAttachmentStrategy {
+class JoinedIdParentAttachmentStrategy implements ParentAttachmentStrategy {
 
-    private String relatedIdPrefix;
-    private Collection<ObjEntity> sourceEntities;
-    private PrefetchProcessorNode node;
-    private GraphManager graphManager;
+    private final String relatedIdPrefix;
+    private final Collection<ObjEntity> sourceEntities;
+    private final PrefetchProcessorNode node;
+    private final GraphManager graphManager;
 
-    JoinedIdParentAttachementStrategy(GraphManager graphManager,
-            PrefetchProcessorNode node) {
-
+    JoinedIdParentAttachmentStrategy(GraphManager graphManager, PrefetchProcessorNode node) {
         ClassDescriptor parentDescriptor = ((PrefetchProcessorNode) node.getParent())
                 .getResolver()
                 .getDescriptor();

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/PrefetchProcessorNode.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/PrefetchProcessorNode.java
@@ -24,7 +24,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.cayenne.*;
+import org.apache.cayenne.CayenneRuntimeException;
+import org.apache.cayenne.DataRow;
+import org.apache.cayenne.Fault;
+import org.apache.cayenne.PersistenceState;
+import org.apache.cayenne.Persistent;
+import org.apache.cayenne.ValueHolder;
 import org.apache.cayenne.query.PrefetchTreeNode;
 import org.apache.cayenne.reflect.ArcProperty;
 import org.apache.cayenne.reflect.ToOneProperty;
@@ -70,26 +75,23 @@ class PrefetchProcessorNode extends PrefetchTreeNode {
      */
     void linkToParent(Persistent object, Persistent parent) {
         if (parent != null && parent.getPersistenceState() != PersistenceState.HOLLOW) {
-
-            // if a relationship is to-one (i.e. flattened to-one), can connect right
-            // away.... write directly to prevent changing persistence state.
+            // if a relationship is to-one (i.e. flattened to-one), can connect right away....
+            // write directly to prevent changing persistence state.
             if (incoming instanceof ToOneProperty) {
-                incoming.writePropertyDirectly(parent, null, object);
+                ObjectDiff diff = ((DataContext)parent.getObjectContext())
+                        .getObjectStore().getChangesByObjectId().get(parent.getObjectId());
+                // check that there are no pending changes for that property
+                if (diff == null || !diff.containsArcSnapshot(incoming.getName())) {
+                    incoming.writePropertyDirectly(parent, null, object);
+                }
             } else {
-                List<Persistent> peers = partitionByParent.get(parent);
-
-                // wrap in a list even if relationship is to-one... will unwrap at the end
-                // of the processing cycle.
-                if (peers == null) {
-                    peers = new ArrayList<>();
-                    partitionByParent.put(parent, peers);
-                } else if (peers.contains(object)) {
+                List<Persistent> peers = partitionByParent.computeIfAbsent(parent, p -> new ArrayList<>());
+                if (peers.contains(object)) {
                     // checking for duplicates is needed in case of nested joint prefetches
                     // when there is more than one row with the same combination of adjacent
                     // parent and child...
                     return;
                 }
-
                 peers.add(object);
             }
         }
@@ -112,8 +114,8 @@ class PrefetchProcessorNode extends PrefetchTreeNode {
                     connectToFaultedParents();
                 }
             } else {
-                // optional to-one ... need to fill in unresolved relationships with
-                // null...
+                // optional to-one ...
+                // need to fill in unresolved relationships with null...
                 if (parentObjectsExist) {
                     clearNullRelationships(parent.getObjects());
                 }
@@ -146,8 +148,8 @@ class PrefetchProcessorNode extends PrefetchTreeNode {
             @SuppressWarnings("unchecked")
             ValueHolder<List<?>> toManyList = (ValueHolder<List<?>>) incoming.readProperty(object);
 
-            // TODO, Andrus 11/15/2005 - if list is modified, shouldn't we attempt to
-            // merge the changes instead of overwriting?
+            // TODO, Andrus 11/15/2005 -
+            //       if list is modified, shouldn't we attempt to merge the changes instead of overwriting?
             toManyList.setValueDirectly(related != null ? related : new ArrayList<>(1));
         } else {
             // this should've been handled elsewhere

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/PrefetchProcessorTreeBuilder.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/PrefetchProcessorTreeBuilder.java
@@ -181,10 +181,11 @@ final class PrefetchProcessorTreeBuilder implements PrefetchProcessor {
         node.setIncoming(arc);
 
         if (node.getParent() != null && !node.isJointPrefetch()) {
-            node.setResolver(new HierarchicalObjectResolverNode(node, context, descriptor, queryMetadata
-                    .isRefreshingObjects(), seen));
+            node.setResolver(new HierarchicalObjectResolverNode(node, context, descriptor,
+                    queryMetadata.isRefreshingObjects(), seen));
         } else {
-            node.setResolver(new PrefetchObjectResolver(context, descriptor, queryMetadata.isRefreshingObjects(), seen));
+            node.setResolver(new PrefetchObjectResolver(context, descriptor,
+                    queryMetadata.isRefreshingObjects(), seen));
         }
 
         if (node.getParent() == null || node.getParent().isPhantom()) {
@@ -192,7 +193,7 @@ final class PrefetchProcessorTreeBuilder implements PrefetchProcessor {
         } else if (node.isJointPrefetch()) {
             node.setParentAttachmentStrategy(new StackLookupParentAttachmentStrategy(node));
         } else if (node.getIncoming().getRelationship().isSourceIndependentFromTargetChange()) {
-            node.setParentAttachmentStrategy(new JoinedIdParentAttachementStrategy(context.getGraphManager(), node));
+            node.setParentAttachmentStrategy(new JoinedIdParentAttachmentStrategy(context.getGraphManager(), node));
         } else {
             node.setParentAttachmentStrategy(new ResultScanParentAttachmentStrategy(node));
         }

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/StackLookupParentAttachmentStrategy.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/StackLookupParentAttachmentStrategy.java
@@ -23,7 +23,7 @@ import org.apache.cayenne.Persistent;
 
 class StackLookupParentAttachmentStrategy implements ParentAttachmentStrategy {
 
-    private PrefetchProcessorNode node;
+    private final PrefetchProcessorNode node;
 
     StackLookupParentAttachmentStrategy(PrefetchProcessorNode node) {
         this.node = node;

--- a/cayenne-server/src/test/java/org/apache/cayenne/access/JointPrefetchIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/access/JointPrefetchIT.java
@@ -42,7 +42,6 @@ import org.apache.cayenne.unit.di.server.CayenneProjects;
 import org.apache.cayenne.unit.di.server.ServerCase;
 import org.apache.cayenne.unit.di.server.UseServerRuntime;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.sql.Date;
@@ -441,41 +440,40 @@ public class JointPrefetchIT extends ServerCase {
             assertEquals("G1", g1.readProperty("galleryName"));
         });
     }
-    
+
     @Test
-    @Ignore("Waiting for a fix, see CAY-2630")
     public void testJointPrefetchPreservesPendingToOneArcDiff() throws Exception {
         createJointPrefetchDataSet();
 
-    	Artist artist = ObjectSelect.query(Artist.class)
-        		.where(Artist.ARTIST_NAME.eq("artist1"))
-        		.selectFirst(context);
-    	
-    	Painting painting = ObjectSelect.query(Painting.class)
-    		.where(Painting.PAINTING_TITLE.eq("P_artist21"))
-    		.selectFirst(context);
-        
-    	// create pending arc diff
-    	painting.setToArtist(artist); 
-    	
-    	// refresh the painting (should preserve pending arc diff)
-    	ObjectSelect.query(Painting.class)
-			.where(Painting.PAINTING_TITLE.eq("P_artist21"))
-			.selectFirst(context);
-    	assertEquals(artist, painting.getToArtist());
+        Artist artist = ObjectSelect.query(Artist.class)
+                .where(Artist.ARTIST_NAME.eq("artist1"))
+                .selectFirst(context);
 
-    	// refresh the artist (should preserve pending arc diff)
-    	ObjectSelect.query(Artist.class)
-			.where(Artist.ARTIST_NAME.eq("artist1"))
-			.selectFirst(context);
-    	assertEquals(artist, painting.getToArtist());
+        Painting painting = ObjectSelect.query(Painting.class)
+                .where(Painting.PAINTING_TITLE.eq("P_artist21"))
+                .selectFirst(context);
 
-    	// refresh them both together (should preserve pending arc diff)
-    	ObjectSelect.query(Painting.class)
-    		.where(Painting.PAINTING_TITLE.eq("P_artist21"))
-    		.prefetch(Painting.TO_ARTIST.joint())
-    		.selectFirst(context);
+        // create pending arc diff
+        painting.setToArtist(artist);
 
-    	assertEquals(artist, painting.getToArtist());
+        // refresh the painting (should preserve pending arc diff)
+        ObjectSelect.query(Painting.class)
+                .where(Painting.PAINTING_TITLE.eq("P_artist21"))
+                .selectFirst(context);
+        assertEquals(artist, painting.getToArtist());
+
+        // refresh the artist (should preserve pending arc diff)
+        ObjectSelect.query(Artist.class)
+                .where(Artist.ARTIST_NAME.eq("artist1"))
+                .selectFirst(context);
+        assertEquals(artist, painting.getToArtist());
+
+        // refresh them both together (should preserve pending arc diff)
+        ObjectSelect.query(Painting.class)
+                .where(Painting.PAINTING_TITLE.eq("P_artist21"))
+                .prefetch(Painting.TO_ARTIST.joint())
+                .selectFirst(context);
+
+        assertEquals(artist, painting.getToArtist());
     }
 }

--- a/cayenne-server/src/test/java/org/apache/cayenne/util/DeepMergeOperationIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/util/DeepMergeOperationIT.java
@@ -25,7 +25,6 @@ import org.apache.cayenne.access.DataContext;
 import org.apache.cayenne.di.Inject;
 import org.apache.cayenne.testdo.testmap.Artist;
 import org.apache.cayenne.unit.di.DataChannelInterceptor;
-import org.apache.cayenne.unit.di.UnitTestClosure;
 import org.apache.cayenne.unit.di.server.CayenneProjects;
 import org.apache.cayenne.unit.di.server.ServerCase;
 import org.apache.cayenne.unit.di.server.UseServerRuntime;
@@ -56,14 +55,11 @@ public class DeepMergeOperationIT extends ServerCase {
 
         final DeepMergeOperation op = new DeepMergeOperation(context1);
 
-        queryInterceptor.runWithQueriesBlocked(new UnitTestClosure() {
-
-            public void execute() {
-                Artist a2 = (Artist) op.merge(a);
-                assertNotNull(a2);
-                assertEquals(PersistenceState.COMMITTED, a2.getPersistenceState());
-                assertEquals(a.getArtistName(), a2.getArtistName());
-            }
+        queryInterceptor.runWithQueriesBlocked(() -> {
+            Artist a2 = op.merge(a);
+            assertNotNull(a2);
+            assertEquals(PersistenceState.COMMITTED, a2.getPersistenceState());
+            assertEquals(a.getArtistName(), a2.getArtistName());
         });
     }
 
@@ -78,15 +74,12 @@ public class DeepMergeOperationIT extends ServerCase {
         a1.setArtistName("BBB");
         final DeepMergeOperation op = new DeepMergeOperation(context1);
 
-        queryInterceptor.runWithQueriesBlocked(new UnitTestClosure() {
-
-            public void execute() {
-                Artist a2 = (Artist) op.merge(a);
-                assertNotNull(a2);
-                assertEquals(PersistenceState.MODIFIED, a2.getPersistenceState());
-                assertSame(a1, a2);
-                assertEquals("BBB", a2.getArtistName());
-            }
+        queryInterceptor.runWithQueriesBlocked(() -> {
+            Artist a2 = op.merge(a);
+            assertNotNull(a2);
+            assertEquals(PersistenceState.MODIFIED, a2.getPersistenceState());
+            assertSame(a1, a2);
+            assertEquals("BBB", a2.getArtistName());
         });
     }
 


### PR DESCRIPTION
This PR changes the logic of prefetch attachment to the parent object. After these changes prefetch won't override related objects if there is a pending diff for that relationship in the context.

This could lead to incompatibility for any code relying on the old behaviour. 

