### PR TITLE
CAY-2637 allow forcing custom connection for transaction

### DIFF
--- a/cayenne-server/src/main/java/org/apache/cayenne/tx/BaseTransaction.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/tx/BaseTransaction.java
@@ -22,11 +22,7 @@ package org.apache.cayenne.tx;
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.Map;
+import java.util.*;
 
 import org.apache.cayenne.CayenneRuntimeException;
 
@@ -204,7 +200,10 @@ public abstract class BaseTransaction implements Transaction {
         Connection c = getExistingConnection(connectionName);
 
         if (c == null || c.isClosed()) {
-            c = dataSource.getConnection();
+            if(descriptor.getCustomConnectionSupplier() != null)
+                c = descriptor.getCustomConnectionSupplier().get();
+            else
+                c = dataSource.getConnection();
             addConnection(connectionName, c);
         }
 
@@ -219,18 +218,17 @@ public abstract class BaseTransaction implements Transaction {
 
     protected Connection addConnection(String connectionName, Connection connection) {
 
-        if(descriptor.getIsolation() != TransactionDescriptor.ISOLATION_DEFAULT) {
-            try {
-                defaultIsolationLevel = connection.getTransactionIsolation();
-                connection.setTransactionIsolation(descriptor.getIsolation());
-            } catch (SQLException ex) {
-                throw new CayenneRuntimeException("Unable to set required isolation level: " + descriptor.getIsolation(), ex);
-            }
-        }
+        setIsolationLevelFrom(connection);
 
-        TransactionConnectionDecorator wrapper = new TransactionConnectionDecorator(connection);
+        TransactionConnectionDecorator wrapper = null;
 
         if (listeners != null) {
+            for (TransactionListener listener : listeners) {
+                connection = listener.decorateConnection(this, connection);
+            }
+
+            wrapper = new TransactionConnectionDecorator(connection);
+
             for (TransactionListener listener : listeners) {
                 listener.willAddConnection(this, connectionName, wrapper);
             }
@@ -241,11 +239,25 @@ public abstract class BaseTransaction implements Transaction {
             connections = new HashMap<>();
         }
 
+        if (wrapper == null)
+            wrapper = new TransactionConnectionDecorator(connection);
+
         if (connections.put(connectionName, wrapper) != wrapper) {
             connectionAdded(connection);
         }
 
         return wrapper;
+    }
+
+    private void setIsolationLevelFrom(Connection connection) {
+        if (descriptor.getIsolation() != TransactionDescriptor.ISOLATION_DEFAULT) {
+            try {
+                defaultIsolationLevel = connection.getTransactionIsolation();
+                connection.setTransactionIsolation(descriptor.getIsolation());
+            } catch (SQLException ex) {
+                throw new CayenneRuntimeException("Unable to set required isolation level: " + descriptor.getIsolation(), ex);
+            }
+        }
     }
 
     protected void connectionAdded(Connection connection) {
@@ -278,7 +290,7 @@ public abstract class BaseTransaction implements Transaction {
                 // ignore for now
             } finally {
                 // restore connection default isolation level ...
-                if(defaultIsolationLevel != -1) {
+                if (defaultIsolationLevel != -1) {
                     try {
                         c.setTransactionIsolation(defaultIsolationLevel);
                     } catch (SQLException ignore) {

--- a/cayenne-server/src/main/java/org/apache/cayenne/tx/TransactionDescriptor.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/tx/TransactionDescriptor.java
@@ -19,8 +19,10 @@
 
 package org.apache.cayenne.tx;
 
+import java.sql.Connection;
+import java.util.function.Supplier;
+
 /**
- *
  * Descriptor that provide desired transaction isolation level and propagation logic.
  *
  * @since 4.1
@@ -32,47 +34,53 @@ public class TransactionDescriptor {
      */
     public static final int ISOLATION_DEFAULT = -1;
 
-    private final int isolation;
+    private int isolation;
 
-    private final TransactionPropagation propagation;
+    private TransactionPropagation propagation;
+
+    private Supplier<Connection> customConnectionSupplier;
+
+    private TransactionDescriptor() {
+    }
 
     /**
-     * @param isolation one of the following <code>Connection</code> constants:
-     *        <code>Connection.TRANSACTION_READ_UNCOMMITTED</code>,
-     *        <code>Connection.TRANSACTION_READ_COMMITTED</code>,
-     *        <code>Connection.TRANSACTION_REPEATABLE_READ</code>,
-     *        <code>Connection.TRANSACTION_SERIALIZABLE</code>, or
-     *        <code>TransactionDescriptor.ISOLATION_DEFAULT</code>
-     *
+     * @param isolation   one of the following <code>Connection</code> constants:
+     *                    <code>Connection.TRANSACTION_READ_UNCOMMITTED</code>,
+     *                    <code>Connection.TRANSACTION_READ_COMMITTED</code>,
+     *                    <code>Connection.TRANSACTION_REPEATABLE_READ</code>,
+     *                    <code>Connection.TRANSACTION_SERIALIZABLE</code>, or
+     *                    <code>TransactionDescriptor.ISOLATION_DEFAULT</code>
      * @param propagation transaction propagation behaviour
-     *
      * @see TransactionPropagation
+     * @deprecated since 4.2.M4. Use builder instead
      */
+    @Deprecated
     public TransactionDescriptor(int isolation, TransactionPropagation propagation) {
         this.isolation = isolation;
         this.propagation = propagation;
     }
 
     /**
-     *
      * Create transaction descriptor with desired isolation level and <code>NESTED</code> propagation
      *
      * @param isolation one of the following <code>Connection</code> constants:
-     *        <code>Connection.TRANSACTION_READ_UNCOMMITTED</code>,
-     *        <code>Connection.TRANSACTION_READ_COMMITTED</code>,
-     *        <code>Connection.TRANSACTION_REPEATABLE_READ</code>,
-     *        <code>Connection.TRANSACTION_SERIALIZABLE</code>, or
-     *        <code>TransactionDescriptor.ISOLATION_DEFAULT</code>
+     *                  <code>Connection.TRANSACTION_READ_UNCOMMITTED</code>,
+     *                  <code>Connection.TRANSACTION_READ_COMMITTED</code>,
+     *                  <code>Connection.TRANSACTION_REPEATABLE_READ</code>,
+     *                  <code>Connection.TRANSACTION_SERIALIZABLE</code>, or
+     *                  <code>TransactionDescriptor.ISOLATION_DEFAULT</code>
      */
+    @Deprecated
     public TransactionDescriptor(int isolation) {
         this(isolation, TransactionPropagation.NESTED);
     }
 
     /**
-     *
      * @param propagation transaction propagation behaviour
      * @see TransactionPropagation
+     * @deprecated since 4.2.M4. Use builder instead
      */
+    @Deprecated
     public TransactionDescriptor(TransactionPropagation propagation) {
         this(ISOLATION_DEFAULT, propagation);
     }
@@ -90,4 +98,66 @@ public class TransactionDescriptor {
     public TransactionPropagation getPropagation() {
         return propagation;
     }
+
+    /**
+     * @return custom connection supplier, passed by user
+     */
+    public Supplier<Connection> getCustomConnectionSupplier() {
+        return customConnectionSupplier;
+    }
+
+    /**
+     * Builder class for TransactionDescriptor.
+     *
+     * @since 4.2.M4
+     */
+    public static class Builder {
+        private final TransactionDescriptor transactionDescriptor = new TransactionDescriptor();
+
+        /**
+         * @param isolation one of the following <code>Connection</code> constants:
+         *                  <code>Connection.TRANSACTION_READ_UNCOMMITTED</code>,
+         *                  <code>Connection.TRANSACTION_READ_COMMITTED</code>,
+         *                  <code>Connection.TRANSACTION_REPEATABLE_READ</code>,
+         *                  <code>Connection.TRANSACTION_SERIALIZABLE</code>, or
+         *                  <code>TransactionDescriptor.ISOLATION_DEFAULT</code>
+         */
+        public Builder isolation(int isolation) {
+            transactionDescriptor.isolation = isolation;
+            return this;
+        }
+
+        /**
+         * @param connection custom connection
+         * @see Connection
+         */
+        public Builder connectionSupplier(Connection connection) {
+            transactionDescriptor.customConnectionSupplier = () -> connection;
+            return this;
+        }
+
+        /**
+         * @param connectionSupplier custom connection supplier
+         * @see Connection
+         * @see Supplier
+         */
+        public Builder connectionSupplier(Supplier<Connection> connectionSupplier){
+            transactionDescriptor.customConnectionSupplier = connectionSupplier;
+            return this;
+        }
+
+        /**
+         * @param propagation transaction propagation behaviour
+         * @see TransactionPropagation
+         */
+        public Builder propagation(TransactionPropagation propagation) {
+            transactionDescriptor.propagation = propagation;
+            return this;
+        }
+
+        public TransactionDescriptor build() {
+            return transactionDescriptor;
+        }
+    }
+
 }

--- a/cayenne-server/src/main/java/org/apache/cayenne/tx/TransactionDescriptor.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/tx/TransactionDescriptor.java
@@ -52,7 +52,7 @@ public class TransactionDescriptor {
      *                    <code>TransactionDescriptor.ISOLATION_DEFAULT</code>
      * @param propagation transaction propagation behaviour
      * @see TransactionPropagation
-     * @deprecated since 4.2.M4. Use builder instead
+     * @deprecated since 4.2. Use builder instead
      */
     @Deprecated
     public TransactionDescriptor(int isolation, TransactionPropagation propagation) {
@@ -78,7 +78,7 @@ public class TransactionDescriptor {
     /**
      * @param propagation transaction propagation behaviour
      * @see TransactionPropagation
-     * @deprecated since 4.2.M4. Use builder instead
+     * @deprecated since 4.2. Use builder instead
      */
     @Deprecated
     public TransactionDescriptor(TransactionPropagation propagation) {
@@ -106,13 +106,18 @@ public class TransactionDescriptor {
         return customConnectionSupplier;
     }
 
+    public static Builder builder(){
+        return new Builder();
+    }
+
     /**
      * Builder class for TransactionDescriptor.
-     *
-     * @since 4.2.M4
+     * @since 4.2
      */
     public static class Builder {
         private final TransactionDescriptor transactionDescriptor = new TransactionDescriptor();
+
+        private Builder(){}
 
         /**
          * @param isolation one of the following <code>Connection</code> constants:

--- a/cayenne-server/src/main/java/org/apache/cayenne/tx/TransactionListener.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/tx/TransactionListener.java
@@ -33,4 +33,8 @@ public interface TransactionListener {
     void willRollback(Transaction tx);
 
     void willAddConnection(Transaction tx, String connectionName, Connection connection);
+
+    default Connection decorateConnection(Transaction tx, Connection connection){
+        return connection;
+    }
 }

--- a/cayenne-server/src/test/java/org/apache/cayenne/tx/DefaultTransactionManagerIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/tx/DefaultTransactionManagerIT.java
@@ -86,7 +86,7 @@ public class DefaultTransactionManagerIT {
                         assertSame(tx, BaseTransaction.getThreadTransaction());
                         return expectedResult;
                     },
-                    new TransactionDescriptor.Builder()
+                    TransactionDescriptor.builder()
                             .propagation(TransactionPropagation.NESTED)
                             .build()
             );
@@ -111,7 +111,7 @@ public class DefaultTransactionManagerIT {
                         assertSame(tx, BaseTransaction.getThreadTransaction());
                         return expectedResult;
                     },
-                    new TransactionDescriptor.Builder()
+                    TransactionDescriptor.builder()
                             .propagation(TransactionPropagation.MANDATORY)
                             .build()
             );
@@ -137,7 +137,7 @@ public class DefaultTransactionManagerIT {
                         assertSame(tx, BaseTransaction.getThreadTransaction());
                         return expectedResult;
                     },
-                    new TransactionDescriptor.Builder()
+                    TransactionDescriptor.builder()
                             .propagation(TransactionPropagation.MANDATORY)
                             .build()
             );
@@ -169,7 +169,7 @@ public class DefaultTransactionManagerIT {
                         assertSame(tx2, BaseTransaction.getThreadTransaction());
                         return expectedResult;
                     },
-                    new TransactionDescriptor.Builder()
+                    TransactionDescriptor.builder()
                             .propagation(TransactionPropagation.REQUIRES_NEW)
                             .build()
             );

--- a/cayenne-server/src/test/java/org/apache/cayenne/tx/DefaultTransactionManagerIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/tx/DefaultTransactionManagerIT.java
@@ -83,10 +83,12 @@ public class DefaultTransactionManagerIT {
         try {
             final Object expectedResult = new Object();
             Object result = txManager.performInTransaction(() -> {
-                    assertSame(tx, BaseTransaction.getThreadTransaction());
-                    return expectedResult;
-                },
-                new TransactionDescriptor(TransactionPropagation.NESTED)
+                        assertSame(tx, BaseTransaction.getThreadTransaction());
+                        return expectedResult;
+                    },
+                    new TransactionDescriptor.Builder()
+                            .propagation(TransactionPropagation.NESTED)
+                            .build()
             );
             assertSame(expectedResult, result);
         } finally {
@@ -109,7 +111,9 @@ public class DefaultTransactionManagerIT {
                         assertSame(tx, BaseTransaction.getThreadTransaction());
                         return expectedResult;
                     },
-                    new TransactionDescriptor(TransactionPropagation.MANDATORY)
+                    new TransactionDescriptor.Builder()
+                            .propagation(TransactionPropagation.MANDATORY)
+                            .build()
             );
             assertSame(expectedResult, result);
         } finally {
@@ -133,7 +137,9 @@ public class DefaultTransactionManagerIT {
                         assertSame(tx, BaseTransaction.getThreadTransaction());
                         return expectedResult;
                     },
-                    new TransactionDescriptor(TransactionPropagation.MANDATORY)
+                    new TransactionDescriptor.Builder()
+                            .propagation(TransactionPropagation.MANDATORY)
+                            .build()
             );
             assertSame(expectedResult, result);
         } finally {
@@ -163,7 +169,9 @@ public class DefaultTransactionManagerIT {
                         assertSame(tx2, BaseTransaction.getThreadTransaction());
                         return expectedResult;
                     },
-                    new TransactionDescriptor(TransactionPropagation.REQUIRES_NEW)
+                    new TransactionDescriptor.Builder()
+                            .propagation(TransactionPropagation.REQUIRES_NEW)
+                            .build()
             );
             assertSame(expectedResult, result);
             assertSame(tx1, BaseTransaction.getThreadTransaction());

--- a/cayenne-server/src/test/java/org/apache/cayenne/tx/TransactionCustomConnectionIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/tx/TransactionCustomConnectionIT.java
@@ -1,0 +1,226 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.tx;
+
+import org.apache.cayenne.access.DataContext;
+import org.apache.cayenne.configuration.server.ServerRuntime;
+import org.apache.cayenne.di.Inject;
+import org.apache.cayenne.log.JdbcEventLogger;
+import org.apache.cayenne.query.ObjectSelect;
+import org.apache.cayenne.testdo.testmap.Artist;
+import org.apache.cayenne.unit.di.server.CayenneProjects;
+import org.apache.cayenne.unit.di.server.ServerCase;
+import org.apache.cayenne.unit.di.server.UseServerRuntime;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Check if connection can be decorated with listeners and that default connection of TransactionDescriptor
+ * has major priority
+ *
+ * @see BaseTransaction,TransactionDescriptor
+ * @since 4.2
+ */
+@UseServerRuntime(CayenneProjects.TESTMAP_PROJECT)
+public class TransactionCustomConnectionIT extends ServerCase {
+
+    private final Logger logger = LoggerFactory.getLogger(TransactionIsolationIT.class);
+
+    @Inject
+    DataContext context;
+
+    @Inject
+    ServerRuntime runtime;
+
+    @Inject
+    private JdbcEventLogger jdbcEventLogger;
+
+    TransactionManager manager;
+    private static boolean firstReadonlyCondition;
+
+    @Before
+    public void initTransactionManager() {
+        // no binding in test container, get it from runtime
+        manager = runtime.getInjector().getInstance(TransactionManager.class);
+    }
+
+    /**
+     * Test depends on decoration of readonly property of the connection, but not every driver supports readonly setting.
+     * So this test calculated for drivers with current support, but if it is not supported, this test mustn't fail
+     * because it checks if readonly wasn't changed by setter and changes firstReadonlyCondition flag value
+     * if it is true to avoid fails. In that case test is useless, but it's behavior in other cases can submit
+     * right behavior of methods
+     */
+    @Test
+    public void testConnectionDecorationWithListeners() {
+        Transaction t = new CayenneTransaction(jdbcEventLogger);
+        //add listeners which will check if connection object will be changed after every decorate call
+        List<TransactionListener> listeners = addAndGetListenersWithCustomReadonlyTo(t);
+        BaseTransaction.bindThreadTransaction(t);
+        try {
+            ObjectSelect.query(Artist.class).select(context);
+
+            //check if the last listener set readonly property to false
+            t.getConnections().forEach((key, connection) -> {
+                try {
+                    assertEquals(connection.isReadOnly(), firstReadonlyCondition);
+                } catch (SQLException throwables) {
+                    throwables.printStackTrace();
+                }
+            });
+
+            //check if every decoration from listener was called
+            for (TransactionListener transactionListener : listeners) {
+                verify(transactionListener).decorateConnection(any(), any());
+            }
+        } finally {
+            BaseTransaction.bindThreadTransaction(null);
+            t.commit();
+        }
+    }
+
+    private List<TransactionListener> addAndGetListenersWithCustomReadonlyTo(Transaction t) {
+        Class<?>[] classes = new Class[]{ListenerWithFirstReadonlyDecorator.class, ListenerWithSecondReadonlyDecorator.class};
+        List<TransactionListener> listeners = new ArrayList<>();
+        for (Class<?> aClass : classes) {
+            TransactionListener listener = (TransactionListener) mock(aClass);
+            listeners.add(listener);
+            when(listener.decorateConnection(any(), any())).thenCallRealMethod();
+            t.addListener(listener);
+        }
+        return listeners;
+    }
+
+    //listener, which will check if readonly property of connection is false and set it to true
+    class ListenerWithFirstReadonlyDecorator implements TransactionListener {
+
+        @Override
+        public void willCommit(Transaction tx) {
+
+        }
+
+        @Override
+        public void willRollback(Transaction tx) {
+
+        }
+
+        @Override
+        public void willAddConnection(Transaction tx, String connectionName, Connection connection) {
+
+        }
+
+        @Override
+        public Connection decorateConnection(Transaction tx, Connection connection) {
+            try {
+                firstReadonlyCondition = connection.isReadOnly();
+                connection.setReadOnly(!firstReadonlyCondition);
+
+                if (connection.isReadOnly() == firstReadonlyCondition) {
+                    firstReadonlyCondition = !connection.isReadOnly();
+                }
+            } catch (SQLException throwables) {
+                throwables.printStackTrace();
+            }
+            return connection;
+        }
+    }
+
+    //listener, which will check if readonly property of connection is true and set it to false
+    class ListenerWithSecondReadonlyDecorator implements TransactionListener {
+
+        @Override
+        public void willCommit(Transaction tx) {
+
+        }
+
+        @Override
+        public void willRollback(Transaction tx) {
+
+        }
+
+        @Override
+        public void willAddConnection(Transaction tx, String connectionName, Connection connection) {
+
+        }
+
+        @Override
+        public Connection decorateConnection(Transaction tx, Connection connection) {
+            try {
+                assertEquals(!firstReadonlyCondition, connection.isReadOnly());
+                connection.setReadOnly(!connection.isReadOnly());
+                if (connection.isReadOnly() == !firstReadonlyCondition) {
+                    firstReadonlyCondition = !firstReadonlyCondition;
+                }
+            } catch (SQLException throwables) {
+                throwables.printStackTrace();
+            }
+            return connection;
+        }
+    }
+
+    @Test
+    public void testDefaultConnectionInDescriptor() {
+        Transaction t = new CayenneTransaction(jdbcEventLogger);
+        BaseTransaction.bindThreadTransaction(t);
+        try {
+            ObjectSelect.query(Artist.class).select(context);
+            Connection connection = t.getConnections().values().stream().findFirst().get();
+
+            try {
+                connection.setAutoCommit(true);
+            } catch (SQLException throwables) {
+                throwables.printStackTrace();
+            }
+
+            TransactionDescriptor mockDescriptor = mock(TransactionDescriptor.class);
+            when(mockDescriptor.getCustomConnectionSupplier()).thenReturn(() -> connection);
+            when(mockDescriptor.getPropagation()).thenReturn(TransactionPropagation.REQUIRES_NEW);
+            when(mockDescriptor.getIsolation()).thenReturn(Connection.TRANSACTION_SERIALIZABLE);
+
+            performInTransaction(mockDescriptor);
+            verify(mockDescriptor, times(2)).getCustomConnectionSupplier();
+        } finally {
+            BaseTransaction.bindThreadTransaction(null);
+            t.commit();
+        }
+
+    }
+
+    private void performInTransaction(TransactionDescriptor descriptor) {
+        Artist artist = context.newObject(Artist.class);
+        artist.setArtistName("test");
+        manager.performInTransaction(() -> {
+            artist.setArtistName("test3");
+            context.commitChanges();
+            return null;
+        }, descriptor);
+    }
+}

--- a/cayenne-server/src/test/java/org/apache/cayenne/tx/TransactionIsolationIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/tx/TransactionIsolationIT.java
@@ -74,10 +74,10 @@ public class TransactionIsolationIT extends ServerCase {
             return;
         }
 
-        TransactionDescriptor descriptor = new TransactionDescriptor(
-                Connection.TRANSACTION_SERIALIZABLE,
-                TransactionPropagation.REQUIRES_NEW
-        );
+        TransactionDescriptor descriptor = new TransactionDescriptor.Builder()
+                .propagation(TransactionPropagation.REQUIRES_NEW)
+                .isolation(Connection.TRANSACTION_SERIALIZABLE)
+                .build();
 
         CountDownLatch startSignal = new CountDownLatch(1);
         CountDownLatch resumeSerializableTransaction = new CountDownLatch(1);

--- a/cayenne-server/src/test/java/org/apache/cayenne/tx/TransactionIsolationIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/tx/TransactionIsolationIT.java
@@ -74,7 +74,7 @@ public class TransactionIsolationIT extends ServerCase {
             return;
         }
 
-        TransactionDescriptor descriptor = new TransactionDescriptor.Builder()
+        TransactionDescriptor descriptor = TransactionDescriptor.builder()
                 .propagation(TransactionPropagation.REQUIRES_NEW)
                 .isolation(Connection.TRANSACTION_SERIALIZABLE)
                 .build();

--- a/cayenne-server/src/test/java/org/apache/cayenne/tx/TransactionPropagationRollbackIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/tx/TransactionPropagationRollbackIT.java
@@ -69,10 +69,10 @@ public class TransactionPropagationRollbackIT extends ServerCase {
      */
     @Test
     public void testPropagationRequiresNew() {
-        TransactionDescriptor descriptor = new TransactionDescriptor(
-                Connection.TRANSACTION_SERIALIZABLE, // ensure that transaction not visible to each other
-                TransactionPropagation.REQUIRES_NEW  // require new transaction for every operation
-        );
+        TransactionDescriptor descriptor = new TransactionDescriptor.Builder()
+                .propagation(TransactionPropagation.REQUIRES_NEW)
+                .isolation(Connection.TRANSACTION_SERIALIZABLE)
+                .build();
 
         performInTransaction(descriptor);
 
@@ -89,10 +89,10 @@ public class TransactionPropagationRollbackIT extends ServerCase {
     @Test
     public void testPropagationNested() {
 
-        TransactionDescriptor descriptor = new TransactionDescriptor(
-                Connection.TRANSACTION_SERIALIZABLE, // ensure that transaction not visible to each other
-                TransactionPropagation.NESTED        // allow joining to existing transaction
-        );
+        TransactionDescriptor descriptor = new TransactionDescriptor.Builder()
+                .isolation(Connection.TRANSACTION_SERIALIZABLE)
+                .propagation(TransactionPropagation.NESTED)
+                .build();
 
         performInTransaction(descriptor);
 
@@ -109,10 +109,10 @@ public class TransactionPropagationRollbackIT extends ServerCase {
     @Test
     public void testPropagationMandatory() {
 
-        TransactionDescriptor descriptor = new TransactionDescriptor(
-                Connection.TRANSACTION_SERIALIZABLE, // ensure that transaction not visible to each other
-                TransactionPropagation.MANDATORY     // requires existing transaction to join
-        );
+        TransactionDescriptor descriptor = new TransactionDescriptor.Builder()
+                .isolation(Connection.TRANSACTION_SERIALIZABLE)
+                .propagation(TransactionPropagation.MANDATORY)
+                .build();
 
         performInTransaction(descriptor);
 

--- a/cayenne-server/src/test/java/org/apache/cayenne/tx/TransactionPropagationRollbackIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/tx/TransactionPropagationRollbackIT.java
@@ -69,7 +69,7 @@ public class TransactionPropagationRollbackIT extends ServerCase {
      */
     @Test
     public void testPropagationRequiresNew() {
-        TransactionDescriptor descriptor = new TransactionDescriptor.Builder()
+        TransactionDescriptor descriptor = TransactionDescriptor.builder()
                 .propagation(TransactionPropagation.REQUIRES_NEW)
                 .isolation(Connection.TRANSACTION_SERIALIZABLE)
                 .build();
@@ -89,7 +89,7 @@ public class TransactionPropagationRollbackIT extends ServerCase {
     @Test
     public void testPropagationNested() {
 
-        TransactionDescriptor descriptor = new TransactionDescriptor.Builder()
+        TransactionDescriptor descriptor = TransactionDescriptor.builder()
                 .isolation(Connection.TRANSACTION_SERIALIZABLE)
                 .propagation(TransactionPropagation.NESTED)
                 .build();
@@ -109,7 +109,7 @@ public class TransactionPropagationRollbackIT extends ServerCase {
     @Test
     public void testPropagationMandatory() {
 
-        TransactionDescriptor descriptor = new TransactionDescriptor.Builder()
+        TransactionDescriptor descriptor = TransactionDescriptor.builder()
                 .isolation(Connection.TRANSACTION_SERIALIZABLE)
                 .propagation(TransactionPropagation.MANDATORY)
                 .build();


### PR DESCRIPTION
- add connection supplier to TransactionDescriptor, if it presents, BaseTransaction provides only that connection
- add builder for TransactionDescriptor, mark constructors as deprecated and replace them in tests
- add ability to decorate connection from listeners with default method
- fix bugs in tests related to default methods in interfaces were not allowed
- add integration tests for added abilities