### PR TITLE
Fix concurrent map flakiness

### DIFF
--- a/cayenne-server/src/test/java/org/apache/cayenne/util/WeakValueMapTest.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/util/WeakValueMapTest.java
@@ -216,9 +216,7 @@ public class WeakValueMapTest {
         assertEquals(4, map.size());
 
         for(Map.Entry<String, Integer> entry : map.entrySet()) {
-            if("key_2".equals(entry.getKey())) {
-                map.remove("key_2");
-            }
+            map.remove(entry.getKey());
         }
     }
 

--- a/cayenne-server/src/test/java/org/apache/cayenne/util/WeakValueMapTest.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/util/WeakValueMapTest.java
@@ -215,10 +215,10 @@ public class WeakValueMapTest {
         map.put("key_4", 321);
         assertEquals(4, map.size());
 
-        for(Map.Entry<String, Integer> entry : map.entrySet()) {
-            map.remove(entry.getKey());
+        for (String key : map.keySet()) {
+            map.remove(key);
         }
-    }
+}
 
     @Test(expected = UnsupportedOperationException.class)
     public void testUnsupportedEntryIteratorRemoval() {


### PR DESCRIPTION
# Description
Test `org.apache.cayenne.util.WeakValueMapTest.testConcurrentModification` will fail under [NonDex](https://github.com/TestingResearchIllinois/NonDex) which detects flakiness under non-deterministic environment. 

To reproduce:
```
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex \
    -pl cayenne-server \
    -Dtest=org.apache.cayenne.util.WeakValueMapTest#testConcurrentModification
```

# Issue
The test code follows the logic below:
```java
Map<String, Integer> map = new WeakValueMap<>(3);
for(Map.Entry<String, Integer> entry : map.entrySet()) {
    if("key_2".equals(entry.getKey())) 
        map.remove("key_2");
}
```

While [WeakValueMap uses HashMap internally](https://github.com/apache/cayenne/blob/master/cayenne-server/src/main/java/org/apache/cayenne/util/ReferenceMap.java#L76), it is not guaranteed for `map.entrySet` to iterate over the entries under some orders.

The code is expected to thrown `ConcurrentModificationException` during execution. Under some edge cases, eg: `key_2` is traversed and removed last, the test will fail to throw and cause an issue. 