### PR TITLE
Fix get declared fields dependent test

### DIFF
--- a/cayenne-server/src/main/java/org/apache/cayenne/reflect/PojoMapper.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/reflect/PojoMapper.java
@@ -23,6 +23,8 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
 import java.util.function.Function;
+import java.util.Arrays;
+import java.util.Comparator;
 
 import org.apache.cayenne.CayenneRuntimeException;
 
@@ -48,6 +50,8 @@ public class PojoMapper<T> implements Function<Object[], T> {
         }
 
         Field[] declaredFields = type.getDeclaredFields();
+        java.util.Arrays.sort(declaredFields, Comparator.comparing(Field::getName));
+        
         this.setters = new MethodHandle[declaredFields.length];
         int i = 0;
         for(Field field : declaredFields) {


### PR DESCRIPTION
# Description
Test `org.apache.cayenne.reflect.PojoMapperTest.testObjectCreation` will fail under [NonDex](https://github.com/TestingResearchIllinois/NonDex) which detects flakiness under non-deterministic environment. 

To reproduce:
```
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex \
    -pl cayenne-server \
    -Dtest=org.apache.cayenne.reflect.PojoMapperTest#testObjectCreation
```

# Issue
In `testObjectCreation`, the object creation depends on the following logic:
```java
Field[] declaredFields = type.getDeclaredFields();
this.setters = new MethodHandle[declaredFields.length];
int i = 0;
for(Field field : declaredFields) {
        ...
        setters[i++] = lookup.unreflectSetter(field);
}
```

However, according to the documentation of [getDeclaredFields](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--), the function does not guarantee the order of fields and may be different on different JVM. 

Simply applying sorting on the fields could guarantee correctness in the testing environment. 