### PR TITLE
CAY-2711 JDK 17 compatibility

### DIFF
--- a/cayenne-protostuff/pom.xml
+++ b/cayenne-protostuff/pom.xml
@@ -88,6 +88,38 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>jdk9-test-open-modules</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>
+                                --add-opens java.base/java.lang=ALL-UNNAMED
+                                --add-opens java.base/java.util=ALL-UNNAMED
+                            </argLine>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <argLine>
+                                --add-opens java.base/java.lang=ALL-UNNAMED
+                                --add-opens java.base/java.util=ALL-UNNAMED
+                            </argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <!-- This ensures LICENSE and NOTICE inclusion in all jars -->


### PR DESCRIPTION
Tests in protostuff module will warn when using jdk 9 and later and will fail when using jdk 17 and later.
It happened because of an unnamed module.
It was resolved by adding a profile in pom.xml for java version 9 and later.