### PR TITLE
CAY-2724 Duplicating relationship after editing its name

### DIFF
--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/objentity/ObjRelationshipInfo.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/objentity/ObjRelationshipInfo.java
@@ -38,6 +38,7 @@ import org.apache.cayenne.modeler.util.EntityTreeModel;
 import org.apache.cayenne.modeler.util.EntityTreeRelationshipFilter;
 import org.apache.cayenne.modeler.util.MultiColumnBrowser;
 import org.apache.cayenne.modeler.util.NameGeneratorPreferences;
+import org.apache.cayenne.modeler.util.ProjectUtil;
 import org.apache.cayenne.util.DeleteRuleUpdater;
 import org.apache.cayenne.util.Util;
 
@@ -267,7 +268,7 @@ public class ObjRelationshipInfo extends CayenneController implements TreeSelect
             }
         }
 
-        if (savePath()) {
+        if (configureRelationShip()) {
             mediator.fireObjRelationshipEvent(new RelationshipEvent(Application.getFrame(), getRelationship(),
                     getRelationship().getSourceEntity()));
         }
@@ -513,7 +514,7 @@ public class ObjRelationshipInfo extends CayenneController implements TreeSelect
     /**
      * Stores current state of the model in the internal ObjRelationship.
      */
-    public boolean savePath() {
+    public boolean configureRelationShip() {
         boolean hasChanges = false;
 
         boolean oldToMany = relationship.isToMany();
@@ -522,7 +523,7 @@ public class ObjRelationshipInfo extends CayenneController implements TreeSelect
         String relationshipName = getRelationshipName();
         if (!Util.nullSafeEquals(relationship.getName(), relationshipName)) {
             hasChanges = true;
-            relationship.setName(relationshipName);
+            ProjectUtil.setRelationshipName(relationship.getSourceEntity(),relationship, relationshipName);
         }
 
         if (savedDbRelationships.size() > 0) {

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/util/ProjectUtil.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/util/ProjectUtil.java
@@ -211,13 +211,15 @@ public class ProjectUtil {
     /** Changes the name of the attribute in all places in DataMap. */
     public static void setRelationshipName(Entity entity, Relationship rel, String newName) {
 
-        if (rel == null || rel != entity.getRelationship(rel.getName())) {
-            return;
+        Relationship existingRelationship = entity.getRelationship(newName);
+        if (existingRelationship != null && existingRelationship != rel) {
+            throw new IllegalArgumentException("An attempt to override relationship '" + rel.getName() + "'");
         }
-
-        entity.removeRelationship(rel.getName());
-        rel.setName(newName);
-        entity.addRelationship(rel);
+        if (rel != null) {
+            entity.removeRelationship(rel.getName());
+            rel.setName(newName);
+            entity.addRelationship(rel);
+        }
     }
 
     /**


### PR DESCRIPTION
After relationship name editing is created duplicate of the relationship with the same name.  It happened because of add to map collection relationship entity with a different key. It resolves with checking for uniqueness and removing the same objects in the map before changing the key.