### PR TITLE
Fix H2 clob streaming

### DIFF
--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/h2/H2Adapter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/h2/H2Adapter.java
@@ -21,6 +21,7 @@ package org.apache.cayenne.dba.h2;
 
 import org.apache.cayenne.access.types.ExtendedType;
 import org.apache.cayenne.access.types.ExtendedTypeFactory;
+import org.apache.cayenne.access.types.ExtendedTypeMap;
 import org.apache.cayenne.access.types.ValueObjectTypeRegistry;
 import org.apache.cayenne.configuration.Constants;
 import org.apache.cayenne.configuration.RuntimeProperties;
@@ -64,6 +65,19 @@ public class H2Adapter extends JdbcAdapter {
         if (column.isGenerated()) {
             sqlBuffer.append(" AUTO_INCREMENT");
         }
+    }
+
+    /**
+     * Installs appropriate ExtendedTypes as converters for passing values
+     * between JDBC and Java layers.
+     * @since 4.1.2
+     */
+    @Override
+    protected void configureExtendedTypes(ExtendedTypeMap map) {
+        super.configureExtendedTypes(map);
+
+        // create specially configured CharType handler
+        map.registerType(new H2CharType());
     }
 
     @Override

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/h2/H2CharType.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/h2/H2CharType.java
@@ -1,0 +1,38 @@
+package org.apache.cayenne.dba.h2;
+
+import org.apache.cayenne.access.types.CharType;
+
+import java.sql.Clob;
+import java.sql.PreparedStatement;
+import java.sql.Types;
+
+/**
+ * H2 specific char type handling - used to handle the correct setting of clobs
+ *
+ * @since 4.1.2
+ */
+public class H2CharType extends CharType {
+
+    public H2CharType() {
+        super(true, true);
+    }
+
+    @Override
+    public void setJdbcObject(PreparedStatement st, String val, int pos, int type, int precision) throws Exception {
+
+        if (type == Types.CLOB) {
+
+            if (isUsingClobs()) {
+
+                Clob clob = st.getConnection().createClob();
+                clob.setString(1, val);
+                st.setClob(pos, clob);
+
+            } else {
+                st.setString(pos, val);
+            }
+        } else {
+            st.setObject(pos, val);
+        }
+    }
+}


### PR DESCRIPTION
In Cayenne 4.1.1 (and probably other versions) when using CLOB's with H2 v2.0.202 an error occurs when attempting to save.
 
This is due to a change in behaviour in H2 (likely from 1.x) where a CLOB now needs to be saved as a stream.
 
When the statement.setString(pos, value) gets executed in Cayenne an exception is thrown from H2 as you now need to set a stream as follows:
 
    Clob clob = st.getConnection().createClob();
    clob.setString(1, val);
    st.setClob(pos, clob);

This PR is to implement that behaviour into H2 clob handling.
