### PR TITLE
CAY-2639 DBImport and DB name case sensitivity. Feature for choosing case-sensitive naming.

### DIFF
--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: cayenne
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: JDK ${{ matrix.java }}, DB ${{ matrix.db-profile }}
+    continue-on-error: true
+    strategy:
+      matrix:
+        java: [8, 11, 16-ea]
+        db-profile: [hsql, h2, derby, mysql-tc, postgres-tc, sqlserver-tc]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - uses: actions/cache@v2
+        with:
+          path: $HOME/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Set up DB ${{ matrix.db-profile }}
+        run: mvn verify -q -DcayenneTestConnection=${{ matrix.db-profile }} -DcayenneLogLevel=ERROR -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
+
+#   deploy:
+#     runs-on: ubuntu-latest
+#     needs: test
+# #    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'apache/cayenne' }}
+# #    env:
+# #      SNAPSHOT_REPO_USERNAME: ${{ secrets.SNAPSHOT_REPO_USERNAME }}
+# #      SNAPSHOT_REPO_PASSWORD: ${{ secrets.SNAPSHOT_REPO_PASSWORD }}
+#     env:
+#       GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
+#       GITHUB_USERNAME: KravchenkoAS
+#     steps:
+#       - name: Checkout repository
+#         uses: actions/checkout@v1
+#       - name: Set up java 8
+#         uses: actions/setup-java@v1
+#         with:
+#           java-version: 8
+#       - name: Deploy
+#         run: mvn deploy -DskipTests --settings .github/workflows/.settings.xml

--- a/cayenne-ant/src/main/java/org/apache/cayenne/tools/DbImporterTask.java
+++ b/cayenne-ant/src/main/java/org/apache/cayenne/tools/DbImporterTask.java
@@ -60,6 +60,7 @@ public class DbImporterTask extends Task {
     public DbImporterTask() {
         this.config = new DbImportConfiguration();
         this.config.setUsePrimitives(true);
+        this.config.setUseCaseSensitiveNaming(false);
         this.config.setUseJava7Types(false);
         this.config.setNamingStrategy(DefaultObjectNameGenerator.class.getName());
 
@@ -245,6 +246,13 @@ public class DbImporterTask extends Task {
 
     public void setUsePrimitives(boolean flag) {
         config.setUsePrimitives(flag);
+    }
+
+    /**
+     * @since 4.2
+     */
+    public void setUseCaseSensitiveNaming(boolean flag) {
+        config.setUseCaseSensitiveNaming(flag);
     }
 
     /**

--- a/cayenne-cgen/src/main/java/org/apache/cayenne/gen/ClassGenerationAction.java
+++ b/cayenne-cgen/src/main/java/org/apache/cayenne/gen/ClassGenerationAction.java
@@ -364,14 +364,20 @@ public class ClassGenerationAction {
 	 * the "encoding" property.
 	 */
 	protected Writer openWriter(TemplateType templateType) throws Exception {
-
-		File outFile = (templateType.isSuperclass()) ? fileForSuperclass() : fileForClass();
+		boolean isSuperclass = templateType.isSuperclass();
+		File outFile = (isSuperclass) ? fileForSuperclass() : fileForClass();
 		if (outFile == null) {
 			return null;
 		}
 
+		if (isSuperclass && outFile.exists() && fileNeedUpdate(outFile, cgenConfiguration.getSuperTemplate())) {
+			if (!outFile.delete()) {
+				logger.warn("File " + outFile.getAbsolutePath() + " can't be deleted.");
+			}
+		}
+
 		if (logger != null) {
-			String label = templateType.isSuperclass() ? "superclass" : "class";
+			String label = isSuperclass ? "superclass" : "class";
 			logger.info("Generating " + label + " file: " + outFile.getCanonicalPath());
 		}
 

--- a/cayenne-cgen/src/test/java/org/apache/cayenne/gen/ClassGenerationActionTest.java
+++ b/cayenne-cgen/src/test/java/org/apache/cayenne/gen/ClassGenerationActionTest.java
@@ -20,6 +20,7 @@
 package org.apache.cayenne.gen;
 
 import java.io.*;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -332,5 +333,31 @@ public class ClassGenerationActionTest extends CgenCase {
 
 		cgenConfiguration.setOverwrite(true);
 		assertNull(action.openWriter(templateType));
+	}
+
+	@Test
+	public void testDeleteFileIfChanged() throws Exception {
+
+		TemplateType templateType = TemplateType.DATAMAP_SUPERCLASS;
+		String rootFolder = tempFolder.getRoot().getAbsolutePath();
+
+		File outFile = new File(rootFolder + "/_TestCLASS2.java");
+		assertTrue(outFile.createNewFile());
+
+		cgenConfiguration.setSuperTemplate(outFile.getAbsolutePath());
+		cgenConfiguration.setRootPath(Paths.get(rootFolder));
+		cgenConfiguration.setRelPath(".");
+		action = new ClassGenerationAction(cgenConfiguration);
+		ObjEntity testEntity1 = new ObjEntity("TEST");
+		testEntity1.setSuperClassName("_TestClass2");
+
+		action.context.put(Artifact.SUPER_PACKAGE_KEY, "");
+		action.context.put(Artifact.SUPER_CLASS_KEY, "_TestClass2");
+		try (Writer out = action.openWriter(templateType);){
+			assertNotNull(out);
+		}
+		outFile = new File(rootFolder + "/_TestClass2.java");
+		assertTrue(outFile.exists());
+		assertEquals(outFile.getAbsolutePath(), rootFolder + File.separator + "_TestClass2.java");
 	}
 }

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/DbSyncModule.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/DbSyncModule.java
@@ -30,6 +30,7 @@ import org.apache.cayenne.dba.openbase.OpenBaseAdapter;
 import org.apache.cayenne.dba.oracle.Oracle8Adapter;
 import org.apache.cayenne.dba.oracle.OracleAdapter;
 import org.apache.cayenne.dba.postgres.PostgresAdapter;
+import org.apache.cayenne.dba.sqlite.SQLiteAdapter;
 import org.apache.cayenne.dba.sqlserver.SQLServerAdapter;
 import org.apache.cayenne.dba.sybase.SybaseAdapter;
 import org.apache.cayenne.dbsync.merge.factory.MergerTokenFactoryProvider;
@@ -46,6 +47,7 @@ import org.apache.cayenne.dbsync.merge.factory.OpenBaseMergerTokenFactory;
 import org.apache.cayenne.dbsync.merge.factory.OracleMergerTokenFactory;
 import org.apache.cayenne.dbsync.merge.factory.PostgresMergerTokenFactory;
 import org.apache.cayenne.dbsync.merge.factory.SQLServerMergerTokenFactory;
+import org.apache.cayenne.dbsync.merge.factory.SQLiteMergerTokenFactory;
 import org.apache.cayenne.dbsync.merge.factory.SybaseMergerTokenFactory;
 import org.apache.cayenne.di.Binder;
 import org.apache.cayenne.di.MapBuilder;
@@ -84,7 +86,8 @@ public class DbSyncModule implements Module {
                 .put(Oracle8Adapter.class.getName(), OracleMergerTokenFactory.class)
                 .put(PostgresAdapter.class.getName(), PostgresMergerTokenFactory.class)
                 .put(SQLServerAdapter.class.getName(), SQLServerMergerTokenFactory.class)
-                .put(SybaseAdapter.class.getName(), SybaseMergerTokenFactory.class);
+                .put(SybaseAdapter.class.getName(), SybaseMergerTokenFactory.class)
+                .put(SQLiteAdapter.class.getName(), SQLiteMergerTokenFactory.class);
 
         binder.bind(MergerTokenFactoryProvider.class).to(MergerTokenFactoryProvider.class);
 

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/AbstractMerger.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/AbstractMerger.java
@@ -21,20 +21,37 @@ package org.apache.cayenne.dbsync.merge;
 
 import org.apache.cayenne.dbsync.merge.factory.MergerTokenFactory;
 import org.apache.cayenne.dbsync.merge.token.MergerToken;
-import org.apache.cayenne.map.DataMap;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Function;
 
 abstract class AbstractMerger<T, M> implements Merger<T> {
 
     private MergerDictionaryDiff<M> diff;
     private MergerTokenFactory tokenFactory;
     private DbEntityDictionary originalDictionary;
+    private Function<String, String> nameConverter;
 
-    AbstractMerger(MergerTokenFactory tokenFactory) {
+    AbstractMerger(MergerTokenFactory tokenFactory, Function<String, String> nameConverter) {
         this.tokenFactory = tokenFactory;
+        this.nameConverter = nameConverter;
+    }
+
+    /**
+     * @since 4.2
+     * Sets function for converting string for naming.
+     */
+    public void setNameConverter(Function<String, String> nameConverter) {
+        this.nameConverter = nameConverter;
+    }
+
+    /**
+     * @since 4.2
+     */
+    public Function<String, String> getNameConverter() {
+        return nameConverter;
     }
 
     @Override

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/ChainMerger.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/ChainMerger.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import org.apache.cayenne.dbsync.merge.factory.MergerTokenFactory;
 import org.apache.cayenne.dbsync.merge.token.MergerToken;
-import org.apache.cayenne.map.DataMap;
 
 class ChainMerger<T, M> extends AbstractMerger<T, M> {
 
@@ -33,7 +32,7 @@ class ChainMerger<T, M> extends AbstractMerger<T, M> {
     private final AbstractMerger<?, T> parentMerger;
 
     ChainMerger(MergerTokenFactory tokenFactory, AbstractMerger<T, M> merger, AbstractMerger<?, T> parentMerger) {
-        super(tokenFactory);
+        super(tokenFactory, merger.getNameConverter());
         this.merger = merger;
         this.parentMerger = parentMerger;
     }

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/DbAttributeMerger.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/DbAttributeMerger.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.Function;
 
 import org.apache.cayenne.dbsync.merge.token.ValueForNullProvider;
 import org.apache.cayenne.dbsync.merge.factory.MergerTokenFactory;
@@ -43,8 +44,8 @@ class DbAttributeMerger extends AbstractMerger<DbEntity, DbAttribute> {
 
     private final ValueForNullProvider valueForNull;
 
-    DbAttributeMerger(MergerTokenFactory tokenFactory, ValueForNullProvider valueForNull) {
-        super(tokenFactory);
+    DbAttributeMerger(MergerTokenFactory tokenFactory, ValueForNullProvider valueForNull, Function<String,String> nameConverter) {
+        super(tokenFactory, nameConverter);
         this.valueForNull = valueForNull;
     }
 
@@ -53,6 +54,7 @@ class DbAttributeMerger extends AbstractMerger<DbEntity, DbAttribute> {
         return new MergerDictionaryDiff.Builder<DbAttribute>()
                 .originalDictionary(new DbAttributeDictionary(original))
                 .importedDictionary(new DbAttributeDictionary(imported))
+                .nameConverter(getNameConverter())
                 .build();
     }
 
@@ -89,7 +91,8 @@ class DbAttributeMerger extends AbstractMerger<DbEntity, DbAttribute> {
      */
     @Override
     Collection<MergerToken> createTokensForMissingOriginal(DbAttribute imported) {
-        DbEntity originalDbEntity = getOriginalDictionary().getByName(imported.getEntity().getName().toUpperCase());
+        String name = getNameConverter().apply(imported.getEntity().getName());
+        DbEntity originalDbEntity = getOriginalDictionary().getByName(name);
         return Collections.singleton(getTokenFactory().createDropColumnToDb(originalDbEntity, imported));
     }
 

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/MergerDictionary.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/MergerDictionary.java
@@ -22,6 +22,7 @@ package org.apache.cayenne.dbsync.merge;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 abstract class MergerDictionary<T> {
 
@@ -30,9 +31,9 @@ abstract class MergerDictionary<T> {
     MergerDictionary() {
     }
 
-    void init() {
+    void init(Function<String, String> nameConverter) {
         for(T entity : getAll()) {
-            String name = getName(entity).toUpperCase();
+            String name = nameConverter.apply(getName(entity));
             dictionary.put(name, entity);
         }
     }

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/MergerDictionaryDiff.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/MergerDictionaryDiff.java
@@ -24,6 +24,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 class MergerDictionaryDiff<T> {
 
@@ -51,6 +52,7 @@ class MergerDictionaryDiff<T> {
         private MergerDictionary<T> originalDictionary;
         private MergerDictionary<T> importedDictionary;
         private Set<String> sameNames = new HashSet<>();
+        private Function<String,String> nameConverter;
 
         Builder() {
             diff = new MergerDictionaryDiff<>();
@@ -66,13 +68,21 @@ class MergerDictionaryDiff<T> {
             return this;
         }
 
+        /**
+         * @since 4.2
+         */
+        Builder<T> nameConverter(Function<String,String> nameConverter) {
+            this.nameConverter = nameConverter;
+            return this;
+        }
+
         MergerDictionaryDiff<T> build() {
             if(originalDictionary == null || importedDictionary == null) {
                 throw new IllegalArgumentException("Dictionaries not set");
             }
 
-            originalDictionary.init();
-            importedDictionary.init();
+            originalDictionary.init(nameConverter);
+            importedDictionary.init(nameConverter);
 
             diff.same = buildSame();
             diff.missing = buildMissing();

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/ProcedureMerger.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/ProcedureMerger.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 import org.apache.cayenne.dbsync.merge.factory.MergerTokenFactory;
 import org.apache.cayenne.dbsync.merge.token.MergerToken;
@@ -41,8 +42,8 @@ public class ProcedureMerger extends AbstractMerger<DataMap, Procedure> {
     private DataMap importedDataMap;
 
     ProcedureMerger(MergerTokenFactory tokenFactory, DataMap original, DataMap imported,
-                   FiltersConfig filtersConfig) {
-        super(tokenFactory);
+                   FiltersConfig filtersConfig, Function<String,String> nameConverter) {
+        super(tokenFactory, nameConverter);
         this.filtersConfig = filtersConfig;
         originalDataMap = original;
         importedDataMap = imported;
@@ -58,6 +59,7 @@ public class ProcedureMerger extends AbstractMerger<DataMap, Procedure> {
         return new MergerDictionaryDiff.Builder<Procedure>()
                 .originalDictionary(new ProcedureDictionary(original, filtersConfig))
                 .importedDictionary(new ProcedureDictionary(imported, filtersConfig))
+                .nameConverter(getNameConverter())
                 .build();
     }
 

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/factory/DefaultMergerTokenFactory.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/factory/DefaultMergerTokenFactory.java
@@ -19,6 +19,7 @@
 package org.apache.cayenne.dbsync.merge.factory;
 
 import java.util.Collection;
+import java.util.function.Function;
 
 import org.apache.cayenne.dbsync.merge.token.MergerToken;
 import org.apache.cayenne.dbsync.merge.token.ValueForNullProvider;
@@ -185,12 +186,14 @@ public class DefaultMergerTokenFactory implements MergerTokenFactory {
             DbEntity entity,
             Collection<DbAttribute> primaryKeyOriginal,
             Collection<DbAttribute> primaryKeyNew,
-            String detectedPrimaryKeyName) {
+            String detectedPrimaryKeyName,
+            Function<String, String> nameConverter) {
         return new SetPrimaryKeyToDb(
                 entity,
                 primaryKeyOriginal,
                 primaryKeyNew,
-                detectedPrimaryKeyName);
+                detectedPrimaryKeyName,
+                nameConverter);
     }
 
     @Override
@@ -198,12 +201,13 @@ public class DefaultMergerTokenFactory implements MergerTokenFactory {
             DbEntity entity,
             Collection<DbAttribute> primaryKeyOriginal,
             Collection<DbAttribute> primaryKeyNew,
-            String detectedPrimaryKeyName) {
+            String detectedPrimaryKeyName, Function<String, String> nameConverter) {
         return new SetPrimaryKeyToModel(
                 entity,
                 primaryKeyOriginal,
                 primaryKeyNew,
-                detectedPrimaryKeyName);
+                detectedPrimaryKeyName,
+                nameConverter);
     }
 
     @Override

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/factory/H2MergerTokenFactory.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/factory/H2MergerTokenFactory.java
@@ -32,6 +32,7 @@ import org.apache.cayenne.map.DbEntity;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * @since 3.0
@@ -69,8 +70,8 @@ public class H2MergerTokenFactory extends DefaultMergerTokenFactory {
 
     @Override
     public MergerToken createSetPrimaryKeyToDb(DbEntity entity, Collection<DbAttribute> primaryKeyOriginal,
-            Collection<DbAttribute> primaryKeyNew, String detectedPrimaryKeyName) {
-        return new SetPrimaryKeyToDb(entity, primaryKeyOriginal, primaryKeyNew, detectedPrimaryKeyName) {
+            Collection<DbAttribute> primaryKeyNew, String detectedPrimaryKeyName, Function<String, String> nameConverter) {
+        return new SetPrimaryKeyToDb(entity, primaryKeyOriginal, primaryKeyNew, detectedPrimaryKeyName, nameConverter) {
 
             @Override
             protected void appendDropOriginalPrimaryKeySQL(DbAdapter adapter, List<String> sqls) {

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/factory/HSQLMergerTokenFactory.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/factory/HSQLMergerTokenFactory.java
@@ -31,6 +31,7 @@ import org.apache.cayenne.map.DbEntity;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 public class HSQLMergerTokenFactory extends DefaultMergerTokenFactory {
 
@@ -68,8 +69,8 @@ public class HSQLMergerTokenFactory extends DefaultMergerTokenFactory {
 
     @Override
     public MergerToken createSetPrimaryKeyToDb(DbEntity entity, Collection<DbAttribute> primaryKeyOriginal,
-            Collection<DbAttribute> primaryKeyNew, String detectedPrimaryKeyName) {
-        return new SetPrimaryKeyToDb(entity, primaryKeyOriginal, primaryKeyNew, detectedPrimaryKeyName) {
+            Collection<DbAttribute> primaryKeyNew, String detectedPrimaryKeyName, Function<String, String> nameConverter) {
+        return new SetPrimaryKeyToDb(entity, primaryKeyOriginal, primaryKeyNew, detectedPrimaryKeyName, nameConverter) {
 
             @Override
             protected void appendDropOriginalPrimaryKeySQL(DbAdapter adapter, List<String> sqls) {

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/factory/MergerTokenFactory.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/factory/MergerTokenFactory.java
@@ -19,6 +19,7 @@
 package org.apache.cayenne.dbsync.merge.factory;
 
 import java.util.Collection;
+import java.util.function.Function;
 
 import org.apache.cayenne.dbsync.merge.token.MergerToken;
 import org.apache.cayenne.dbsync.merge.token.ValueForNullProvider;
@@ -87,13 +88,15 @@ public interface MergerTokenFactory {
             DbEntity entity,
             Collection<DbAttribute> primaryKeyOriginal,
             Collection<DbAttribute> primaryKeyNew,
-            String detectedPrimaryKeyName);
+            String detectedPrimaryKeyName,
+            Function<String, String> nameConverter);
 
     MergerToken createSetPrimaryKeyToModel(
             DbEntity entity,
             Collection<DbAttribute> primaryKeyOriginal,
             Collection<DbAttribute> primaryKeyNew,
-            String detectedPrimaryKeyName);
+            String detectedPrimaryKeyName,
+            Function<String, String> nameConverter);
 
     MergerToken createSetGeneratedFlagToDb(DbEntity entity, DbAttribute column, boolean isGenerated);
 

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/factory/MySQLMergerTokenFactory.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/factory/MySQLMergerTokenFactory.java
@@ -35,6 +35,7 @@ import java.sql.Types;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 public class MySQLMergerTokenFactory extends DefaultMergerTokenFactory {
 
@@ -136,12 +137,14 @@ public class MySQLMergerTokenFactory extends DefaultMergerTokenFactory {
             DbEntity entity,
             Collection<DbAttribute> primaryKeyOriginal,
             Collection<DbAttribute> primaryKeyNew,
-            String detectedPrimaryKeyName) {
+            String detectedPrimaryKeyName,
+            Function<String, String> nameConverter) {
         return new SetPrimaryKeyToDb(
                 entity,
                 primaryKeyOriginal,
                 primaryKeyNew,
-                detectedPrimaryKeyName) {
+                detectedPrimaryKeyName,
+                nameConverter) {
 
             @Override
             protected void appendDropOriginalPrimaryKeySQL(

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/factory/SQLiteMergerTokenFactory.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/factory/SQLiteMergerTokenFactory.java
@@ -1,0 +1,155 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.dbsync.merge.factory;
+
+import org.apache.cayenne.CayenneRuntimeException;
+import org.apache.cayenne.dba.DbAdapter;
+import org.apache.cayenne.dbsync.merge.token.MergerToken;
+import org.apache.cayenne.dbsync.merge.token.ValueForNullProvider;
+import org.apache.cayenne.dbsync.merge.token.db.AddRelationshipToDb;
+import org.apache.cayenne.dbsync.merge.token.db.DropRelationshipToDb;
+import org.apache.cayenne.dbsync.merge.token.db.SetAllowNullToDb;
+import org.apache.cayenne.dbsync.merge.token.db.SetColumnTypeToDb;
+import org.apache.cayenne.dbsync.merge.token.db.SetGeneratedFlagToDb;
+import org.apache.cayenne.dbsync.merge.token.db.SetNotNullToDb;
+import org.apache.cayenne.dbsync.merge.token.db.SetPrimaryKeyToDb;
+import org.apache.cayenne.dbsync.merge.token.db.SetValueForNullToDb;
+import org.apache.cayenne.map.DbAttribute;
+import org.apache.cayenne.map.DbEntity;
+import org.apache.cayenne.map.DbRelationship;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * @since 4.3
+ */
+public class SQLiteMergerTokenFactory extends DefaultMergerTokenFactory {
+
+    @Override
+    public MergerToken createSetColumnTypeToDb(
+            final DbEntity entity,
+            final DbAttribute columnOriginal,
+            final DbAttribute columnNew) {
+        return new SetColumnTypeToDb(entity, columnOriginal, columnNew) {
+
+            @Override
+            public List<String> createSql(DbAdapter adapter) {
+                throw new CayenneRuntimeException("SQLite doesn't support altering column type.");
+            }
+
+        };
+    }
+
+    @Override
+    public MergerToken createSetNotNullToDb(DbEntity entity, DbAttribute column) {
+        return new SetNotNullToDb(entity, column) {
+
+            @Override
+            public List<String> createSql(DbAdapter adapter) {
+                throw new CayenneRuntimeException("SQLite doesn't support adding constrains to existing column.");
+            }
+
+        };
+    }
+
+    @Override
+    public MergerToken createSetAllowNullToDb(DbEntity entity, DbAttribute column) {
+        return new SetAllowNullToDb(entity, column) {
+
+            @Override
+            public List<String> createSql(DbAdapter adapter) {
+                throw new CayenneRuntimeException("SQLite doesn't support changing constrains.");
+            }
+
+        };
+    }
+
+    @Override
+    public MergerToken createSetValueForNullToDb(DbEntity entity, DbAttribute column, ValueForNullProvider valueForNullProvider) {
+        return new SetValueForNullToDb(entity, column, valueForNullProvider){
+
+            @Override
+            public List<String> createSql(DbAdapter adapter) {
+                throw new CayenneRuntimeException("SQLite doesn't support adding constrains to existing column.");
+            }
+
+        };
+    }
+
+    @Override
+    public MergerToken createSetPrimaryKeyToDb(
+            DbEntity entity,
+            Collection<DbAttribute> primaryKeyOriginal,
+            Collection<DbAttribute> primaryKeyNew,
+            String detectedPrimaryKeyName,
+            Function<String, String> nameConverter) {
+        return new SetPrimaryKeyToDb(
+                entity,
+                primaryKeyOriginal,
+                primaryKeyNew,
+                detectedPrimaryKeyName,
+                nameConverter){
+
+            @Override
+            public List<String> createSql(DbAdapter adapter) {
+                throw new CayenneRuntimeException("SQLite doesn't support adding constrains to existing column.");
+            }
+
+        };
+    }
+
+    @Override
+    public MergerToken createSetGeneratedFlagToDb(DbEntity entity, DbAttribute column, boolean isGenerated) {
+        return new SetGeneratedFlagToDb(entity, column, isGenerated){
+
+            @Override
+            public List<String> createSql(DbAdapter adapter) {
+                throw new CayenneRuntimeException("SQLite doesn't support adding constrains to existing column.");
+            }
+
+        };
+    }
+
+    @Override
+    public MergerToken createDropRelationshipToDb(DbEntity entity, DbRelationship rel) {
+        return new DropRelationshipToDb(entity, rel){
+
+            @Override
+            public List<String> createSql(DbAdapter adapter) {
+                throw new CayenneRuntimeException("SQLite doesn't support removing constrains.");
+            }
+
+        };
+    }
+
+    @Override
+    public MergerToken createAddRelationshipToDb(DbEntity entity, DbRelationship rel) {
+        return new AddRelationshipToDb(entity, rel){
+
+            @Override
+            public List<String> createSql(DbAdapter adapter) {
+                throw new CayenneRuntimeException("SQLite doesn't support adding FK to existing column.");
+            }
+
+        };
+    }
+}

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/token/db/DropRelationshipToDb.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/token/db/DropRelationshipToDb.java
@@ -54,7 +54,8 @@ public class DropRelationshipToDb extends AbstractToDbToken.Entity {
 
         QuotingStrategy context = adapter.getQuotingStrategy();
         return Collections.singletonList(
-                "ALTER TABLE " + context.quotedFullyQualifiedName(getEntity()) + " DROP CONSTRAINT " + getFkName());
+                "ALTER TABLE " + context.quotedFullyQualifiedName(getEntity()) + " DROP CONSTRAINT " +
+                        context.quotedIdentifier(getEntity().getDataMap(), getFkName()));
     }
 
     public MergerToken createReverse(MergerTokenFactory factory) {

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/token/model/CreateTableToModel.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/merge/token/model/CreateTableToModel.java
@@ -28,7 +28,8 @@ import org.apache.cayenne.map.DbEntity;
 import org.apache.cayenne.map.ObjEntity;
 
 /**
- * A {@link MergerToken} to add a {@link DbEntity} to a {@link DataMap}
+ * A {@link MergerToken} to add a {@link DbEntity} to a {@link DataMap}.
+ * Token creates a entity without relationships.
  */
 public class CreateTableToModel extends AbstractToModelToken.Entity {
 
@@ -88,7 +89,8 @@ public class CreateTableToModel extends AbstractToModelToken.Entity {
         map.addObjEntity(objEntity);
 
         // presumably there are no other ObjEntities pointing to this DbEntity, so syncing just this one...
-        context.getEntityMergeSupport().synchronizeWithDbEntity(objEntity);
+        // ObjEntity is synchronized without relationships it will be created with token AddRelationshipToModel
+        context.getEntityMergeSupport().synchronizeWithDbEntity(objEntity, false);
 
         context.getDelegate().dbEntityAdded(getEntity());
         context.getDelegate().objEntityAdded(objEntity);

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/naming/DeduplicationVisitor.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/naming/DeduplicationVisitor.java
@@ -36,6 +36,7 @@ import org.apache.cayenne.map.ProcedureParameter;
 import org.apache.cayenne.map.QueryDescriptor;
 
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Predicate;
 
 /**
@@ -92,7 +93,15 @@ class DeduplicationVisitor implements ConfigurationNodeVisitor<String> {
 
     @Override
     public String visitObjEntity(ObjEntity entity) {
-        return resolve(name -> ((DataMap) parent).getObjEntity(name) != null);
+        return resolve(name -> {
+            Set<String> keys= ((DataMap) parent).getObjEntityMap().keySet();
+            for(String key: keys){
+                if (name.equalsIgnoreCase(key)){
+                    return true;
+                }
+            }
+            return false;
+        });
     }
 
     @Override

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/dbimport/DbImportConfiguration.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/dbimport/DbImportConfiguration.java
@@ -55,6 +55,7 @@ public class DbImportConfiguration {
     private String meaningfulPkTables;
     private String adapter;
     private boolean usePrimitives;
+    private boolean useCaseSensitiveNaming;
     private boolean useJava7Types;
     private Logger logger;
     private String namingStrategy;
@@ -146,6 +147,20 @@ public class DbImportConfiguration {
 
     public void setUsePrimitives(boolean usePrimitives) {
         this.usePrimitives = usePrimitives;
+    }
+
+    /**
+     * @since 4.2
+     */
+    public boolean isUseCaseSensitiveNaming() {
+        return useCaseSensitiveNaming;
+    }
+
+    /**
+     * @since 4.2
+     */
+    public void setUseCaseSensitiveNaming(boolean useCaseSensitiveNaming) {
+        this.useCaseSensitiveNaming = useCaseSensitiveNaming;
     }
 
     public boolean isUseJava7Types() {

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/dbimport/DefaultDbImportAction.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/dbimport/DefaultDbImportAction.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.Function;
 
 import org.apache.cayenne.CayenneRuntimeException;
 import org.apache.cayenne.configuration.ConfigurationNode;
@@ -222,6 +223,7 @@ public class DefaultDbImportAction implements DbImportAction {
            .filters(loaderConfig.getFiltersConfig())
            .skipPKTokens(loaderConfig.isSkipPrimaryKeyLoading())
            .skipRelationshipsTokens(loaderConfig.isSkipRelationshipsLoading())
+           .nameConverter(createNameConverter(config.isUseCaseSensitiveNaming()))
            .build()
            .createMergeTokens(targetDataMap, sourceDataMap);
         tokens = log(sort(reverse(mergerTokenFactory, tokens)));
@@ -250,6 +252,7 @@ public class DefaultDbImportAction implements DbImportAction {
         config.setForceDataMapSchema(reverseEngineering.isForceDataMapSchema());
         config.setDefaultPackage(reverseEngineering.getDefaultPackage());
         config.setUsePrimitives(reverseEngineering.isUsePrimitives());
+        config.setUseCaseSensitiveNaming(reverseEngineering.isUseCaseSensitiveNaming());
         config.setUseJava7Types(reverseEngineering.isUseJava7Types());
     }
 
@@ -514,6 +517,13 @@ public class DefaultDbImportAction implements DbImportAction {
         return new DbLoader(adapter, connection,
                 config.getDbLoaderConfig(),
                 config.createLoaderDelegate(),
-                config.createNameGenerator());
+                config.createNameGenerator(),
+                createNameConverter(config.isUseCaseSensitiveNaming()));
+    }
+
+    private Function<String, String> createNameConverter(boolean useCaseSensitiveNaming) {
+        return useCaseSensitiveNaming
+                ? Function.identity()
+                : (String::toUpperCase);
     }
 }

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/dbimport/ReverseEngineering.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/dbimport/ReverseEngineering.java
@@ -104,6 +104,12 @@ public class ReverseEngineering extends SchemaContainer implements Serializable,
     private boolean usePrimitives = true;
 
     /**
+     * <p>If true, would use case sensitive naming.</p>
+     * <p>Default is <b>"false"</b>, i.e. case insensitive naming will be used.</p>
+     */
+    private boolean useCaseSensitiveNaming = false;
+
+    /**
      * Use old Java 7 date types
      */
     private boolean useJava7Types = false;
@@ -138,6 +144,7 @@ public class ReverseEngineering extends SchemaContainer implements Serializable,
         this.setForceDataMapCatalog(original.isForceDataMapCatalog());
         this.setUseJava7Types(original.isUseJava7Types());
         this.setUsePrimitives(original.isUsePrimitives());
+        this.setUseCaseSensitiveNaming(original.isUseCaseSensitiveNaming());
         this.setTableTypes(Arrays.asList(original.getTableTypes()));
         this.setName(original.getName());
         for (Catalog catalog : original.getCatalogs()) {
@@ -223,6 +230,9 @@ public class ReverseEngineering extends SchemaContainer implements Serializable,
         if (usePrimitives) {
             res.append("\n  Use primitives");
         }
+        if (useCaseSensitiveNaming) {
+            res.append("\n  Use case sensitive naming");
+        }
         if (useJava7Types) {
             res.append("\n  Use Java 7 types");
         }
@@ -257,6 +267,13 @@ public class ReverseEngineering extends SchemaContainer implements Serializable,
         return usePrimitives;
     }
 
+    /**
+     * @since 4.2
+     */
+    public boolean isUseCaseSensitiveNaming() {
+        return useCaseSensitiveNaming;
+    }
+
     public boolean isUseJava7Types() {
         return useJava7Types;
     }
@@ -287,6 +304,13 @@ public class ReverseEngineering extends SchemaContainer implements Serializable,
 
     public void setUsePrimitives(boolean usePrimitives) {
         this.usePrimitives = usePrimitives;
+    }
+
+    /**
+     * @since 4.2
+     */
+    public void setUseCaseSensitiveNaming(boolean useCaseSensitiveNaming) {
+        this.useCaseSensitiveNaming = useCaseSensitiveNaming;
     }
 
     public void setUseJava7Types(boolean useJava7Types) {
@@ -323,7 +347,7 @@ public class ReverseEngineering extends SchemaContainer implements Serializable,
                 .simpleTag("stripFromTableNames", this.getStripFromTableNames())
                 .simpleTag("useJava7Types", Boolean.toString(this.isUseJava7Types()))
                 .simpleTag("usePrimitives", Boolean.toString(this.isUsePrimitives()))
+                .simpleTag("useCaseSensitiveNaming", Boolean.toString(this.isUseCaseSensitiveNaming()))
                 .end();
     }
-
 }

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/dbload/DbLoadDataStore.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/dbload/DbLoadDataStore.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Function;
 
 import org.apache.cayenne.map.DataMap;
 import org.apache.cayenne.map.DbEntity;
@@ -43,15 +44,17 @@ public class DbLoadDataStore extends DataMap {
 
     private Map<String, Set<ExportedKey>> exportedKeys = new HashMap<>();
 
-    private Map<String, DbEntity> upperCaseNames = new HashMap<>();
+    private Map<String, DbEntity> names = new HashMap<>();
+    private Function<String, String> nameConverter;
 
-    DbLoadDataStore() {
+    DbLoadDataStore(Function<String, String> nameConverter) {
         super("__generated_by_dbloader__");
+        this.nameConverter = nameConverter;
     }
 
     @Override
     public DbEntity getDbEntity(String dbEntityName) {
-        return upperCaseNames.get(dbEntityName.toUpperCase());
+        return names.get(nameConverter.apply(dbEntityName));
     }
 
     @Override
@@ -60,7 +63,7 @@ public class DbLoadDataStore extends DataMap {
             throw new IllegalArgumentException("Only DetectedDbEntity can be inserted in this map");
         }
         super.addDbEntity(entity);
-        upperCaseNames.put(entity.getName().toUpperCase(), entity);
+        names.put(nameConverter.apply(entity.getName()), entity);
     }
 
     DbEntity addDbEntitySafe(DbEntity entity) {

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/dbload/DbLoader.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/dbload/DbLoader.java
@@ -29,6 +29,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
 
 /**
  * Loads DB schema into a DataMap, creating DbEntities and Procedures. Consists of a list of specialized loaders that
@@ -46,15 +47,16 @@ public class DbLoader {
     private final DbLoaderConfiguration config;
     private final DbLoaderDelegate delegate;
     private final ObjectNameGenerator nameGenerator;
+    private final Function<String, String> nameConverter;
 
     public DbLoader(DbAdapter adapter, Connection connection, DbLoaderConfiguration config,
-                    DbLoaderDelegate delegate, ObjectNameGenerator nameGenerator) {
+                    DbLoaderDelegate delegate, ObjectNameGenerator nameGenerator, Function<String, String> nameConverter) {
         this.adapter = Objects.requireNonNull(adapter);
         this.connection = Objects.requireNonNull(connection);
         this.config = Objects.requireNonNull(config);
         this.nameGenerator = Objects.requireNonNull(nameGenerator);
         this.delegate = delegate == null ? new DefaultDbLoaderDelegate() : delegate;
-
+        this.nameConverter = Objects.requireNonNull(nameConverter);
         createLoaders();
     }
 
@@ -75,7 +77,7 @@ public class DbLoader {
      * @return new DataMap with data loaded from DB
      */
     public DataMap load() throws SQLException {
-        DbLoadDataStore loadedData = new DbLoadDataStore();
+        DbLoadDataStore loadedData = new DbLoadDataStore(nameConverter);
         DatabaseMetaData metaData = connection.getMetaData();
 
         for(AbstractLoader loader : loaders) {

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/filters/FiltersConfigBuilder.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/filters/FiltersConfigBuilder.java
@@ -159,7 +159,7 @@ public final class FiltersConfigBuilder {
     private SortedSet<Pattern> transformExcludeTable(Collection<ExcludeTable> excludeTables) {
         SortedSet<Pattern> res = new TreeSet<>(PatternFilter.PATTERN_COMPARATOR);
         for (ExcludeTable exclude : excludeTables) {
-            res.add(PatternFilter.pattern(exclude.getPattern()));
+            res.add(PatternFilter.pattern(exclude.getPattern(), engineering.isUseCaseSensitiveNaming()));
         }
         return res;
     }
@@ -170,6 +170,7 @@ public final class FiltersConfigBuilder {
             includeTableFilters.add(new IncludeTableFilter(includeTable.getPattern()
                     , transform(includeTable.getIncludeColumns(), includeTable.getExcludeColumns())
                     , transform(Collections.emptyList(), includeTable.getExcludeRelationship())
+                    , engineering.isUseCaseSensitiveNaming()
             ));
         }
 
@@ -177,7 +178,7 @@ public final class FiltersConfigBuilder {
     }
 
     private PatternFilter transform(Collection<? extends PatternParam> include, Collection<? extends PatternParam> exclude) {
-        PatternFilter filter = new PatternFilter();
+        PatternFilter filter = new PatternFilter(engineering.isUseCaseSensitiveNaming());
 
         for (PatternParam patternParam : include) {
             filter.include(patternParam.getPattern());

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/filters/IncludeTableFilter.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/filters/IncludeTableFilter.java
@@ -28,26 +28,29 @@ public class IncludeTableFilter implements Comparable<IncludeTableFilter> {
 
     public final PatternFilter columnsFilter;
 
+    public final boolean useCaseSensitiveNaming;
+
     /**
      * @since 4.1
      */
     public final PatternFilter relationshipFilter;
 
-    public IncludeTableFilter(String pattern) {
-        this(pattern, PatternFilter.INCLUDE_EVERYTHING, PatternFilter.INCLUDE_EVERYTHING);
+    public IncludeTableFilter(String pattern, boolean useCaseSensitiveNaming) {
+        this(pattern, PatternFilter.INCLUDE_EVERYTHING, PatternFilter.INCLUDE_EVERYTHING, useCaseSensitiveNaming);
     }
 
-    public IncludeTableFilter(String pattern, PatternFilter columnsFilter) {
-        this(pattern, columnsFilter, PatternFilter.INCLUDE_EVERYTHING);
+    public IncludeTableFilter(String pattern, PatternFilter columnsFilter, boolean useCaseSensitiveNaming) {
+        this(pattern, columnsFilter, PatternFilter.INCLUDE_EVERYTHING, useCaseSensitiveNaming);
     }
 
     /**
      * @since 4.1
      */
-    public IncludeTableFilter(String pattern, PatternFilter columnsFilter, PatternFilter relationshipFilter) {
-        this.pattern = PatternFilter.pattern(pattern);
+    public IncludeTableFilter(String pattern, PatternFilter columnsFilter, PatternFilter relationshipFilter, boolean useCaseSensitiveNaming) {
+        this.pattern = PatternFilter.pattern(pattern, useCaseSensitiveNaming);
         this.columnsFilter = columnsFilter;
         this.relationshipFilter = relationshipFilter;
+        this.useCaseSensitiveNaming = useCaseSensitiveNaming;
     }
 
     public boolean isIncludeColumn (String name) {

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/filters/PatternFilter.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/filters/PatternFilter.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
  */
 public class PatternFilter {
 
-    public static final PatternFilter INCLUDE_EVERYTHING = new PatternFilter() {
+    public static final PatternFilter INCLUDE_EVERYTHING = new PatternFilter(true) {
 
         @Override
         public boolean isIncluded(String obj) {
@@ -43,7 +43,7 @@ public class PatternFilter {
         }
     };
 
-    public static final PatternFilter INCLUDE_NOTHING = new PatternFilter() {
+    public static final PatternFilter INCLUDE_NOTHING = new PatternFilter(true) {
         @Override
         public boolean isIncluded(String obj) {
             return false;
@@ -65,10 +65,12 @@ public class PatternFilter {
 
     private final SortedSet<Pattern> includes;
     private final SortedSet<Pattern> excludes;
+    private boolean useCaseSensitiveNaming;
 
-    public PatternFilter() {
+    public PatternFilter(boolean useCaseSensitiveNaming) {
         this.includes = new TreeSet<>(PATTERN_COMPARATOR);
         this.excludes = new TreeSet<>(PATTERN_COMPARATOR);
+        this.useCaseSensitiveNaming = useCaseSensitiveNaming;
     }
 
     public SortedSet<Pattern> getIncludes() {
@@ -87,19 +89,21 @@ public class PatternFilter {
         return this;
     }
 
-    public static Pattern pattern(String pattern) {
+    public static Pattern pattern(String pattern, boolean useCaseSensitiveNaming) {
         if (pattern == null) {
             return null;
         }
-        return Pattern.compile(pattern, Pattern.CASE_INSENSITIVE);
+        return useCaseSensitiveNaming
+                ? Pattern.compile(pattern)
+                : Pattern.compile(pattern, Pattern.CASE_INSENSITIVE);
     }
 
     public PatternFilter include(String p) {
-        return include(pattern(p));
+        return include(pattern(p, useCaseSensitiveNaming));
     }
 
     public PatternFilter exclude(String p) {
-        return exclude(pattern(p));
+        return exclude(pattern(p, useCaseSensitiveNaming));
     }
 
     public boolean isIncluded(String obj) {

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/filters/TableFilter.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/filters/TableFilter.java
@@ -93,16 +93,19 @@ public class TableFilter {
         return includes;
     }
 
-    public static TableFilter include(String tablePattern) {
+    public static TableFilter include(String tablePattern, boolean useCaseSensitiveNaming) {
         TreeSet<IncludeTableFilter> includes = new TreeSet<>();
-        includes.add(new IncludeTableFilter(tablePattern == null ? null : tablePattern.replaceAll("%", ".*")));
+        includes.add(new IncludeTableFilter(tablePattern == null ? null : tablePattern.replaceAll("%", ".*"), useCaseSensitiveNaming));
 
         return new TableFilter(includes, new TreeSet<>());
     }
 
+    /**
+     * useCaseSensitiveNaming always is true because method creates filter that includes everything.
+     */
     public static TableFilter everything() {
         TreeSet<IncludeTableFilter> includes = new TreeSet<>();
-        includes.add(new IncludeTableFilter(null));
+        includes.add(new IncludeTableFilter(null, true));
 
         return new TableFilter(includes, new TreeSet<>());
     }

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/xml/ConfigHandler.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/xml/ConfigHandler.java
@@ -52,6 +52,7 @@ class ConfigHandler extends NamespaceAwareNestedTagHandler {
     private static final String STRIP_FROM_TABLE_NAMES_TAG = "stripFromTableNames";
     private static final String USE_JAVA7_TYPES_TAG = "useJava7Types";
     private static final String USE_PRIMITIVES_TAG = "usePrimitives";
+    private static final String USE_CASE_SENSITIVE_NAMING_TAG = "useCaseSensitiveNaming";
     private static final String INCLUDE_TABLE_TAG = "includeTable";
     private static final String EXCLUDE_TABLE_TAG = "excludeTable";
     private static final String INCLUDE_COLUMN_TAG = "includeColumn";
@@ -135,6 +136,9 @@ class ConfigHandler extends NamespaceAwareNestedTagHandler {
             case USE_PRIMITIVES_TAG:
                 createUsePrimitives(data);
                 break;
+            case USE_CASE_SENSITIVE_NAMING_TAG:
+                createUseCaseSensitiveNaming(data);
+                break;
             case EXCLUDE_TABLE_TAG:
                 createExcludeTable(data);
                 break;
@@ -213,6 +217,20 @@ class ConfigHandler extends NamespaceAwareNestedTagHandler {
                 configuration.setUsePrimitives(true);
             } else {
                 configuration.setUsePrimitives(false);
+            }
+        }
+    }
+
+    private void createUseCaseSensitiveNaming(String useCaseSesitiveNaming) {
+        if (useCaseSesitiveNaming.trim().length() == 0) {
+            return;
+        }
+
+        if (configuration != null) {
+            if (useCaseSesitiveNaming.equals(TRUE)) {
+                configuration.setUseCaseSensitiveNaming(true);
+            } else {
+                configuration.setUseCaseSensitiveNaming(false);
             }
         }
     }

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/CheckTypeTest.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/CheckTypeTest.java
@@ -59,7 +59,7 @@ public class CheckTypeTest {
 
         mergerTokenFactory = new MySQLMergerTokenFactory();
         diffPair = new MergerDiffPair<>(original, imported);
-        dbAttributeMerger = new DbAttributeMerger(mergerTokenFactory, null);
+        dbAttributeMerger = new DbAttributeMerger(mergerTokenFactory, null, String::toUpperCase);
     }
 
     @Test
@@ -104,7 +104,7 @@ public class CheckTypeTest {
 
         mergerTokenFactory = new PostgresMergerTokenFactory();
 
-        dbAttributeMerger = new DbAttributeMerger(mergerTokenFactory, null);
+        dbAttributeMerger = new DbAttributeMerger(mergerTokenFactory, null, String::toUpperCase);
 
         Collection<MergerToken> mergerTokens = dbAttributeMerger.createTokensForSame(diffPair);
         assertEquals(1, mergerTokens.size());
@@ -189,7 +189,7 @@ public class CheckTypeTest {
 
         diffPair = new MergerDiffPair<>(original, imported);
 
-        dbAttributeMerger = new DbAttributeMerger(mergerTokenFactory, null);
+        dbAttributeMerger = new DbAttributeMerger(mergerTokenFactory, null,  String::toUpperCase);
         Collection<MergerToken> mergerTokens = dbAttributeMerger.createTokensForSame(diffPair);
         assertEquals(0, mergerTokens.size());
     }

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/DbEntityMergerIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/DbEntityMergerIT.java
@@ -29,6 +29,7 @@ import org.apache.cayenne.map.DbJoin;
 import org.apache.cayenne.map.DbRelationship;
 import org.apache.cayenne.map.ObjEntity;
 import org.apache.cayenne.map.ObjRelationship;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.sql.Types;
@@ -49,6 +50,7 @@ public class DbEntityMergerIT extends MergeCase {
 
     @Test
     public void testCreateTokensForMissingImported() throws Exception {
+        Assume.assumeTrue(accessStackAdapter.supportsFKConstraints());
         dropTableIfPresent("NEW_TABLE");
         dropTableIfPresent("NEW_TABLE2");
         assertTokensAndExecute(0, 0);

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/DbEntityMergerIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/DbEntityMergerIT.java
@@ -1,0 +1,156 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+package org.apache.cayenne.dbsync.merge;
+
+import org.apache.cayenne.access.DataContext;
+import org.apache.cayenne.dbsync.merge.token.MergerToken;
+import org.apache.cayenne.dbsync.merge.token.db.DropRelationshipToDb;
+import org.apache.cayenne.dbsync.merge.token.db.DropTableToDb;
+import org.apache.cayenne.di.Inject;
+import org.apache.cayenne.map.DbAttribute;
+import org.apache.cayenne.map.DbEntity;
+import org.apache.cayenne.map.DbJoin;
+import org.apache.cayenne.map.DbRelationship;
+import org.apache.cayenne.map.ObjEntity;
+import org.apache.cayenne.map.ObjRelationship;
+import org.junit.Test;
+
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class DbEntityMergerIT extends MergeCase {
+
+    @Inject
+    private DataContext context;
+
+    @Test
+    public void testCreateTokensForMissingImported() throws Exception {
+        map.setQuotingSQLIdentifiers(true);
+        dropTableIfPresent("NEW_TABLE");
+        dropTableIfPresent("NEW_TABLE2");
+        assertTokensAndExecute(0, 0);
+
+        DbEntity dbEntity1 = new DbEntity("NEW_TABLE");
+
+        DbAttribute column1 = new DbAttribute("ID", Types.INTEGER, dbEntity1);
+        column1.setMandatory(true);
+        column1.setPrimaryKey(true);
+        dbEntity1.addAttribute(column1);
+
+        DbAttribute column2 = new DbAttribute("NAME", Types.VARCHAR, dbEntity1);
+        column2.setMaxLength(10);
+        column2.setMandatory(false);
+        column2.setPrimaryKey(false);
+        dbEntity1.addAttribute(column2);
+
+
+        DbEntity dbEntity2 = new DbEntity("NEW_TABLE2");
+
+        DbAttribute column3 = new DbAttribute("ID", Types.INTEGER, dbEntity2);
+        column3.setMandatory(false);
+        column3.setPrimaryKey(false);
+        dbEntity2.addAttribute(column3);
+
+        DbAttribute column4 = new DbAttribute("NUMBER", Types.INTEGER, dbEntity2);
+        column3.setMandatory(false);
+        column3.setPrimaryKey(false);
+        column4.setMaxLength(10);
+        dbEntity2.addAttribute(column4);
+
+        // create db relationships
+        DbRelationship rel1To2 = new DbRelationship("rel1To2");
+        rel1To2.setSourceEntity(dbEntity1);
+        rel1To2.setTargetEntityName(dbEntity2);
+        rel1To2.setToMany(true);
+        rel1To2.addJoin(new DbJoin(rel1To2, column1.getName(), column3.getName()));
+        dbEntity1.addRelationship(rel1To2);
+
+        DbRelationship rel2To1 = new DbRelationship("rel2To1");
+        rel2To1.setSourceEntity(dbEntity2);
+        rel2To1.setTargetEntityName(dbEntity1);
+        rel2To1.setToMany(false);
+        rel2To1.addJoin(new DbJoin(rel2To1, column3.getName(), column1.getName()));
+        dbEntity2.addRelationship(rel2To1);
+
+        // for the new entity to the db
+        map.addDbEntity(dbEntity1);
+        map.addDbEntity(dbEntity2);
+        execute(mergerFactory().createCreateTableToDb(dbEntity1));
+        execute(mergerFactory().createCreateTableToDb(dbEntity2));
+        execute(mergerFactory().createDropRelationshipToModel(dbEntity1, rel1To2).createReverse(mergerFactory()));
+        execute(mergerFactory().createDropRelationshipToModel(dbEntity2, rel2To1).createReverse(mergerFactory()));
+        map.removeDbEntity(dbEntity1.getName());
+        map.removeDbEntity(dbEntity2.getName());
+
+        List<MergerToken> tokens = createMergeTokensWithoutEmptyFilter(false);
+        List<MergerToken> reverseTokens = new ArrayList<>();
+        for (MergerToken token : tokens) {
+            if (token instanceof DropRelationshipToDb || token instanceof DropTableToDb) {
+                reverseTokens.add(token.createReverse(mergerFactory()));
+            }
+        }
+
+        Collections.sort(reverseTokens);
+        assertEquals(4, reverseTokens.size());
+        execute(reverseTokens);
+
+        ObjEntity objEntity1 = null;
+        ObjEntity objEntity2 = null;
+        for (ObjEntity candidate : map.getObjEntities()) {
+            if (dbEntity1.getName().equals(candidate.getDbEntityName())) {
+                objEntity1 = candidate;
+                continue;
+            }
+            if (dbEntity2.getName().equals(candidate.getDbEntityName())) {
+                objEntity2 = candidate;
+            }
+        }
+
+        assertNotNull(objEntity1);
+        assertNotNull(objEntity2);
+        Iterator<ObjRelationship> iterator1 = objEntity1.getRelationships().iterator();
+        Iterator<ObjRelationship> iterator2 = objEntity2.getRelationships().iterator();
+        assertTrue(iterator2.hasNext());
+        ObjRelationship objRelationship2 = iterator2.next();
+        assertFalse(objRelationship2.isToMany());
+        assertTrue(iterator1.hasNext());
+        ObjRelationship objRelationship1 = iterator1.next();
+        assertTrue(objRelationship1.isToMany());
+
+        //clear entity
+        map.removeDbEntity(dbEntity1.getName());
+        map.removeDbEntity(dbEntity2.getName());
+        map.removeObjEntity(objEntity1.getName(), true);
+        map.removeObjEntity(objEntity2.getName(), true);
+        dropTableIfPresent("NEW_TABLE2");
+        dropTableIfPresent("NEW_TABLE");
+
+        assertTokensAndExecute(0, 0, true);
+
+        map.setQuotingSQLIdentifiers(false);
+    }
+}

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/EntityMergeSupportIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/EntityMergeSupportIT.java
@@ -109,4 +109,183 @@ public class EntityMergeSupportIT extends MergeCase {
 		map.removeDbEntity(dbEntity2.getName());
 		map.removeDbEntity(dbEntity1.getName());
 	}
+
+	@Test
+	public void testMergingTableWithSameNameInDifferentCapitalization() {
+		DbEntity dbEntity1 = new DbEntity("NEW_TABLE");
+
+		DbAttribute e1col1 = new DbAttribute("ID", Types.INTEGER, dbEntity1);
+		e1col1.setMandatory(true);
+		e1col1.setPrimaryKey(true);
+		dbEntity1.addAttribute(e1col1);
+
+		DbAttribute e1col2 = new DbAttribute("NAME", Types.VARCHAR, dbEntity1);
+		e1col2.setMaxLength(10);
+		e1col2.setMandatory(false);
+		dbEntity1.addAttribute(e1col2);
+
+		map.addDbEntity(dbEntity1);
+
+		DbEntity dbEntity2 = new DbEntity("NEW_TABLE2");
+		DbAttribute e2col1 = new DbAttribute("ID", Types.INTEGER, dbEntity2);
+		e2col1.setMandatory(true);
+		e2col1.setPrimaryKey(true);
+		dbEntity2.addAttribute(e2col1);
+		DbAttribute e2col2 = new DbAttribute("FK", Types.INTEGER, dbEntity2);
+		dbEntity2.addAttribute(e2col2);
+
+		map.addDbEntity(dbEntity2);
+
+		DbEntity dbEntity3 = new DbEntity("NEW_table");
+		DbAttribute e3col1 = new DbAttribute("Id", Types.INTEGER, dbEntity3);
+		e3col1.setMandatory(true);
+		e3col1.setPrimaryKey(true);
+		dbEntity3.addAttribute(e3col1);
+
+		DbAttribute e3col2 = new DbAttribute("FK", Types.INTEGER, dbEntity3);
+		dbEntity3.addAttribute(e3col2);
+
+		map.addDbEntity(dbEntity3);
+
+		// create db relationships
+		DbRelationship rel1To2 = new DbRelationship("rel1To2");
+		rel1To2.setSourceEntity(dbEntity1);
+		rel1To2.setTargetEntityName(dbEntity2);
+		rel1To2.setToMany(true);
+		rel1To2.addJoin(new DbJoin(rel1To2, e1col1.getName(), e2col2.getName()));
+		dbEntity1.addRelationship(rel1To2);
+		DbRelationship rel2To1 = new DbRelationship("rel2To1");
+		rel2To1.setSourceEntity(dbEntity2);
+		rel2To1.setTargetEntityName(dbEntity1);
+		rel2To1.setToMany(false);
+		rel2To1.addJoin(new DbJoin(rel2To1, e2col2.getName(), e1col1.getName()));
+		dbEntity2.addRelationship(rel2To1);
+		assertSame(rel1To2, rel2To1.getReverseRelationship());
+		assertSame(rel2To1, rel1To2.getReverseRelationship());
+
+		// create db relationships
+		DbRelationship rel3To2 = new DbRelationship("rel3To2");
+		rel3To2.setSourceEntity(dbEntity3);
+		rel3To2.setTargetEntityName(dbEntity2);
+		rel3To2.setToMany(true);
+		rel3To2.addJoin(new DbJoin(rel3To2, e1col1.getName(), e2col2.getName()));
+		dbEntity3.addRelationship(rel3To2);
+		DbRelationship rel2To3 = new DbRelationship("rel2To3");
+		rel2To3.setSourceEntity(dbEntity2);
+		rel2To3.setTargetEntityName(dbEntity3);
+		rel2To3.setToMany(false);
+		rel2To3.addJoin(new DbJoin(rel2To3, e2col2.getName(), e1col1.getName()));
+		dbEntity2.addRelationship(rel2To3);
+		assertSame(rel3To2, rel2To3.getReverseRelationship());
+		assertSame(rel2To3, rel3To2.getReverseRelationship());
+
+		ObjEntity objEntity1 = new ObjEntity("NewTable");
+		objEntity1.setDbEntity(dbEntity1);
+		map.addObjEntity(objEntity1);
+
+		ObjEntity objEntity2 = new ObjEntity("NewTable2");
+		objEntity2.setDbEntity(dbEntity2);
+		map.addObjEntity(objEntity2);
+
+
+		ObjEntity objEntity3 = new ObjEntity("NewTable3");
+		objEntity3.setDbEntity(dbEntity3);
+		map.addObjEntity(objEntity3);
+
+		EntityMergeSupport entityMergeSupport = new EntityMergeSupport(
+				new DefaultObjectNameGenerator(NoStemStemmer.getInstance()),
+				NamePatternMatcher.EXCLUDE_ALL,
+				true,
+				true,
+				false);
+		assertTrue(entityMergeSupport.synchronizeWithDbEntities(Arrays.asList(objEntity1, objEntity2, objEntity3)));
+		assertNotNull(objEntity1.getAttribute("name"));
+		assertNotNull(objEntity1.getRelationship("newTable2s"));
+		assertNotNull(objEntity2.getRelationship("newTable"));
+		assertNotNull(objEntity2.getRelationship("newTable1"));
+		assertNotNull(objEntity3.getAttribute("fk"));
+		assertNotNull(objEntity3.getRelationship("newTable2s"));
+
+		assertEquals(objEntity1.getRelationship("newTable2s").getDeleteRule(), DeleteRule.DEFAULT_DELETE_RULE_TO_MANY);
+		assertEquals(objEntity2.getRelationship("newTable").getDeleteRule(), DeleteRule.DEFAULT_DELETE_RULE_TO_ONE);
+		assertEquals(objEntity3.getRelationship("newTable2s").getDeleteRule(), DeleteRule.DEFAULT_DELETE_RULE_TO_MANY);
+		assertEquals(objEntity2.getRelationship("newTable1").getDeleteRule(), DeleteRule.DEFAULT_DELETE_RULE_TO_ONE);
+
+		map.removeObjEntity(objEntity2.getName());
+		map.removeObjEntity(objEntity1.getName());
+		map.removeObjEntity(objEntity3.getName());
+		map.removeDbEntity(dbEntity2.getName());
+		map.removeDbEntity(dbEntity1.getName());
+		map.removeDbEntity(dbEntity3.getName());
+	}
+
+	@Test
+	public void testMergingTableWithSameNameInDifferentCapitalization1() {
+		DbEntity dbEntity1 = new DbEntity("NEW_TABLE");
+
+		DbAttribute e1col1 = new DbAttribute("ID", Types.INTEGER, dbEntity1);
+		e1col1.setMandatory(true);
+		e1col1.setPrimaryKey(true);
+		dbEntity1.addAttribute(e1col1);
+
+		DbAttribute e1col2 = new DbAttribute("NAME", Types.VARCHAR, dbEntity1);
+		e1col2.setMaxLength(10);
+		e1col2.setMandatory(false);
+		dbEntity1.addAttribute(e1col2);
+
+		map.addDbEntity(dbEntity1);
+
+		DbEntity dbEntity2 = new DbEntity("NEW_table");
+		DbAttribute e2col1 = new DbAttribute("ID", Types.INTEGER, dbEntity2);
+		e2col1.setMandatory(true);
+		e2col1.setPrimaryKey(true);
+		dbEntity2.addAttribute(e2col1);
+		DbAttribute e2col2 = new DbAttribute("FK", Types.INTEGER, dbEntity2);
+		dbEntity2.addAttribute(e2col2);
+
+		map.addDbEntity(dbEntity2);
+
+		// create db relationships
+		DbRelationship rel1To2 = new DbRelationship("rel1To2");
+		rel1To2.setSourceEntity(dbEntity1);
+		rel1To2.setTargetEntityName(dbEntity2);
+		rel1To2.setToMany(true);
+		rel1To2.addJoin(new DbJoin(rel1To2, e1col1.getName(), e2col2.getName()));
+		dbEntity1.addRelationship(rel1To2);
+		DbRelationship rel2To1 = new DbRelationship("rel2To1");
+		rel2To1.setSourceEntity(dbEntity2);
+		rel2To1.setTargetEntityName(dbEntity1);
+		rel2To1.setToMany(false);
+		rel2To1.addJoin(new DbJoin(rel2To1, e2col2.getName(), e1col1.getName()));
+		dbEntity2.addRelationship(rel2To1);
+		assertSame(rel1To2, rel2To1.getReverseRelationship());
+		assertSame(rel2To1, rel1To2.getReverseRelationship());
+
+		ObjEntity objEntity1 = new ObjEntity("NewTable");
+		objEntity1.setDbEntity(dbEntity1);
+		map.addObjEntity(objEntity1);
+
+		ObjEntity objEntity2 = new ObjEntity("NewTable2");
+		objEntity2.setDbEntity(dbEntity2);
+		map.addObjEntity(objEntity2);
+
+		EntityMergeSupport entityMergeSupport = new EntityMergeSupport(
+				new DefaultObjectNameGenerator(NoStemStemmer.getInstance()),
+				NamePatternMatcher.EXCLUDE_ALL,
+				true,
+				true,
+				false);
+		assertTrue(entityMergeSupport.synchronizeWithDbEntities(Arrays.asList(objEntity1, objEntity2)));
+		assertNotNull(objEntity1.getAttribute("name"));
+		assertNotNull(objEntity1.getRelationship("newTables"));
+		assertNotNull(objEntity2.getRelationship("newTable"));
+
+		assertEquals(objEntity1.getRelationship("newTables").getDeleteRule(), DeleteRule.DEFAULT_DELETE_RULE_TO_MANY);
+		assertEquals(objEntity2.getRelationship("newTable").getDeleteRule(), DeleteRule.DEFAULT_DELETE_RULE_TO_ONE);
+
+		map.removeObjEntity(objEntity2.getName());
+		map.removeObjEntity(objEntity1.getName());
+		map.removeDbEntity(dbEntity2.getName());
+		map.removeDbEntity(dbEntity1.getName());
+	}
 }

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/MergeCase.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/MergeCase.java
@@ -94,9 +94,9 @@ public abstract class MergeCase extends DbSyncCase {
         // container
         // on every test
         map = runtime.getDataDomain().getDataMap("testmap");
-//        map.setQuotingSQLIdentifiers(true);
+        map.setQuotingSQLIdentifiers(true);
         //to prevent postgresql from creating pk_table
-//        setPrimaryKeyGeneratorDBGenerateForMap(map);
+        setPrimaryKeyGeneratorDBGenerateForMap(map);
         filterDataMap();
 
         List<MergerToken> tokens = createMergeTokens();
@@ -104,7 +104,7 @@ public abstract class MergeCase extends DbSyncCase {
         execute(tokens);
 
         assertTokensAndExecute(0, 0);
-//        map.setQuotingSQLIdentifiers(false);
+        map.setQuotingSQLIdentifiers(false);
     }
 
     protected DataMapMerger.Builder merger() {

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/MergerFactoryIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/MergerFactoryIT.java
@@ -67,6 +67,7 @@ public class MergerFactoryIT extends MergeCase {
 
     @Test
     public void testChangeVarcharSizeToDb() throws Exception {
+        Assume.assumeTrue(accessStackAdapter.supportsColumnTypeReengineering());
         DbEntity dbEntity = map.getDbEntity("PAINTING");
         assertNotNull(dbEntity);
 
@@ -119,6 +120,10 @@ public class MergerFactoryIT extends MergeCase {
         column1.setMaxLength(20);
         column2.setMaxLength(30);
 
+        if (!accessStackAdapter.supportsColumnTypeReengineering()) {
+            assertTokensAndExecute(0, 0);
+            return;
+        }
         // merge to db
         assertTokensAndExecute(2, 0);
 
@@ -184,6 +189,7 @@ public class MergerFactoryIT extends MergeCase {
 
     @Test
     public void testAddForeignKeyWithTable() throws Exception {
+        Assume.assumeTrue(accessStackAdapter.supportsFKConstraints());
         dropTableIfPresent("NEW_TABLE");
 
         assertTokensAndExecute(0, 0);
@@ -243,6 +249,7 @@ r2 =     * Db -Rel 'toNewTableR2' - ARTIST 1 -> * NEW_TABLE" -- Not generated an
 
     @Test
     public void testAddForeignKeyAfterTable() throws Exception {
+        Assume.assumeTrue(accessStackAdapter.supportsFKConstraints());
         dropTableIfPresent("NEW_TABLE");
 
         assertTokensAndExecute(0, 0);

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/MergerFactoryIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/MergerFactoryIT.java
@@ -23,9 +23,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import java.sql.Types;
+import java.util.List;
 
 import org.apache.cayenne.CayenneDataObject;
 import org.apache.cayenne.access.DataContext;
+import org.apache.cayenne.dbsync.merge.token.MergerToken;
 import org.apache.cayenne.di.Inject;
 import org.apache.cayenne.map.DbAttribute;
 import org.apache.cayenne.map.DbEntity;
@@ -33,6 +35,7 @@ import org.apache.cayenne.map.DbJoin;
 import org.apache.cayenne.map.DbRelationship;
 import org.apache.cayenne.map.ObjAttribute;
 import org.apache.cayenne.map.ObjEntity;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class MergerFactoryIT extends MergeCase {
@@ -301,17 +304,19 @@ r2 =     * Db -Rel 'toNewTableR2' - ARTIST 1 -> * NEW_TABLE" -- Not generated an
 
     @Test
     public void testAddTableWithSameNameInDifferentCapitalization() throws Exception {
+        // Mariadb don't support the case of binding tables when there are several tables with names in different cases.
+        Assume.assumeTrue(accessStackAdapter.supportsCaseSensitiveLike());
         map.setQuotingSQLIdentifiers(true);
+        List<MergerToken> tokens = syncDBForCaseSensitiveTest();
         dropTableIfPresent("NEW_TABLE");
         dropTableIfPresent("NEW_table");
-
         assertTokensAndExecute(0, 0,true);
 
         DbEntity dbEntity = new DbEntity("NEW_TABLE");
         attr(dbEntity, "ID", Types.INTEGER, true, true);
         attr(dbEntity, "NAME", Types.VARCHAR, false, false).setMaxLength(10);
         attr(dbEntity, "ARTIST_ID", Types.BIGINT, false, false);
-
+        setPrimaryKeyGeneratorDBGenerate(dbEntity);
         map.addDbEntity(dbEntity);
 
         DbEntity artistDbEntity = map.getDbEntity("ARTIST");
@@ -320,7 +325,7 @@ r2 =     * Db -Rel 'toNewTableR2' - ARTIST 1 -> * NEW_TABLE" -- Not generated an
         assertTokensAndExecute(1, 0,true);
         assertTokensAndExecute(0, 0,true);
 
-        // relation from new_table to artist
+        // relation from NEW_TABLE to artist
         DbRelationship r1 = new DbRelationship("toArtistR1");
         r1.setSourceEntity(dbEntity);
         r1.setTargetEntityName(artistDbEntity);
@@ -328,7 +333,7 @@ r2 =     * Db -Rel 'toNewTableR2' - ARTIST 1 -> * NEW_TABLE" -- Not generated an
         r1.addJoin(new DbJoin(r1, "ARTIST_ID", "ARTIST_ID"));
         dbEntity.addRelationship(r1);
 
-        // relation from artist to new_table
+        // relation from artist to NEW_TABLE
         DbRelationship r2 = new DbRelationship("toNewTableR2");
         r2.setSourceEntity(artistDbEntity);
         r2.setTargetEntityName(dbEntity);
@@ -343,13 +348,14 @@ r2 =     * Db -Rel 'toNewTableR2' - ARTIST 1 -> * NEW_TABLE" -- Not generated an
         attr(dbEntity1, "ID", Types.INTEGER, true, true);
         attr(dbEntity1, "NAME", Types.VARCHAR, false, false).setMaxLength(10);
         attr(dbEntity1, "ARTIST_ID", Types.BIGINT, false, false);
-
+        //to prevent postgresql from creating pk_table
+        setPrimaryKeyGeneratorDBGenerate(dbEntity1);
         map.addDbEntity(dbEntity1);
 
         assertTokensAndExecute(1, 0,true);
         assertTokensAndExecute(0, 0,true);
 
-        // relation from new_table to artist
+        // relation from NEW_table to artist
         DbRelationship r3 = new DbRelationship("toArtistR3");
         r3.setSourceEntity(dbEntity1);
         r3.setTargetEntityName(artistDbEntity);
@@ -357,7 +363,7 @@ r2 =     * Db -Rel 'toNewTableR2' - ARTIST 1 -> * NEW_TABLE" -- Not generated an
         r3.addJoin(new DbJoin(r3, "ARTIST_ID", "ARTIST_ID"));
         dbEntity1.addRelationship(r3);
 
-        // relation from artist to new_table
+        // relation from artist to NEW_table
         DbRelationship r4 = new DbRelationship("toNewTableR4");
         r4.setSourceEntity(artistDbEntity);
         r4.setTargetEntityName(dbEntity1);
@@ -394,13 +400,17 @@ r2 =     * Db -Rel 'toNewTableR2' - ARTIST 1 -> * NEW_TABLE" -- Not generated an
 
         assertTokensAndExecute(2, 0,true);
         assertTokensAndExecute(0, 0,true);
-
+        reverseSyncDBForCaseSensitiveTest(tokens);
         map.setQuotingSQLIdentifiers(false);
     }
 
 
     @Test
     public void testAddAttrWithSameNameInDifferentCapitalization() throws Exception {
+        // Mariadb don't support the same attributes name in different cases.
+        Assume.assumeTrue(accessStackAdapter.supportsCaseSensitiveLike());
+        map.setQuotingSQLIdentifiers(true);
+        List<MergerToken> tokens = syncDBForCaseSensitiveTest();
         dropTableIfPresent("NEW_TABLE");
 
         assertTokensAndExecute(0, 0,true);
@@ -410,7 +420,8 @@ r2 =     * Db -Rel 'toNewTableR2' - ARTIST 1 -> * NEW_TABLE" -- Not generated an
         attr(dbEntity, "NAME", Types.VARCHAR, false, false).setMaxLength(10);
         attr(dbEntity, "ARTIST_ID", Types.BIGINT, false, false);
 
-        map.setQuotingSQLIdentifiers(true);
+        //to prevent postgresql from creating pk_table
+        setPrimaryKeyGeneratorDBGenerate(dbEntity);
         map.addDbEntity(dbEntity);
 
         DbEntity artistDbEntity = map.getDbEntity("ARTIST");
@@ -424,6 +435,7 @@ r2 =     * Db -Rel 'toNewTableR2' - ARTIST 1 -> * NEW_TABLE" -- Not generated an
         assertTokensAndExecute(1, 0,true);
         assertTokensAndExecute(0, 0,true);
 
+        reverseSyncDBForCaseSensitiveTest(tokens);
         map.setQuotingSQLIdentifiers(false);
     }
 

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/TokensReverseTest.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/TokensReverseTest.java
@@ -20,6 +20,7 @@
 package org.apache.cayenne.dbsync.merge.token;
 
 import java.util.Collections;
+import java.util.function.Function;
 
 import org.apache.cayenne.dbsync.merge.factory.HSQLMergerTokenFactory;
 import org.apache.cayenne.dbsync.merge.factory.MergerTokenFactory;
@@ -72,8 +73,11 @@ public class TokensReverseTest {
         testOneToOneReverse(factory().createSetColumnTypeToDb(entity, attr, attr2));
         testOneToOneReverse(factory().createSetColumnTypeToModel(entity, attr, attr2));
 
-        testOneToOneReverse(factory().createSetPrimaryKeyToDb(entity, Collections.singleton(attr), Collections.singleton(attr2), "PK"));
-        testOneToOneReverse(factory().createSetPrimaryKeyToModel(entity, Collections.singleton(attr), Collections.singleton(attr2), "PK"));
+        testOneToOneReverse(factory().createSetPrimaryKeyToDb(entity, Collections.singleton(attr), Collections.singleton(attr2), "PK", String::toUpperCase));
+        testOneToOneReverse(factory().createSetPrimaryKeyToModel(entity, Collections.singleton(attr), Collections.singleton(attr2), "PK", String::toUpperCase));
+
+        testOneToOneReverse(factory().createSetPrimaryKeyToDb(entity, Collections.singleton(attr), Collections.singleton(attr2), "PK", Function.identity()));
+        testOneToOneReverse(factory().createSetPrimaryKeyToModel(entity, Collections.singleton(attr), Collections.singleton(attr2), "PK", Function.identity()));
 
         testOneToOneReverse(factory().createSetValueForNullToDb(entity, attr, new DefaultValueForNullProvider()));
 

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/ValueForNullIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/ValueForNullIT.java
@@ -38,6 +38,7 @@ import org.apache.cayenne.map.ObjAttribute;
 import org.apache.cayenne.map.ObjEntity;
 import org.apache.cayenne.query.ObjectSelect;
 import org.apache.cayenne.testdo.testmap.Painting;
+import org.junit.Assume;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -53,6 +54,7 @@ public class ValueForNullIT extends MergeCase {
 
     @Test
     public void test() throws Exception {
+        Assume.assumeTrue(accessStackAdapter.supportsColumnTypeReengineering());
         DbEntity dbEntity = map.getDbEntity("PAINTING");
         assertNotNull(dbEntity);
         ObjEntity objEntity = map.getObjEntity("Painting");

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/db/SetAllowNullToDbIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/db/SetAllowNullToDbIT.java
@@ -26,12 +26,14 @@ import java.sql.Types;
 import org.apache.cayenne.dbsync.merge.MergeCase;
 import org.apache.cayenne.map.DbAttribute;
 import org.apache.cayenne.map.DbEntity;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class SetAllowNullToDbIT extends MergeCase {
 
 	@Test
 	public void test() throws Exception {
+		Assume.assumeTrue(accessStackAdapter.supportsColumnTypeReengineering());
 		DbEntity dbEntity = map.getDbEntity("PAINTING");
 		assertNotNull(dbEntity);
 

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/db/SetGeneratedFlagToDbIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/db/SetGeneratedFlagToDbIT.java
@@ -30,6 +30,7 @@ import org.apache.cayenne.map.DbAttribute;
 import org.apache.cayenne.map.DbEntity;
 import org.apache.cayenne.unit.UnitDbAdapter;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -67,6 +68,7 @@ public class SetGeneratedFlagToDbIT extends MergeCase {
 
     @Test
     public void setGeneratedFlag() throws Exception {
+        Assume.assumeTrue(accessStackAdapter.supportsColumnTypeReengineering());
         DbEntity dbEntity = createTestTable(false);
         assertNotNull(dbEntity);
 
@@ -111,7 +113,7 @@ public class SetGeneratedFlagToDbIT extends MergeCase {
         attribute.setGenerated(false);
 
         List<MergerToken> tokens = createMergeTokens();
-        if(!dbAdapter.supportsGeneratedKeys()) {
+        if(!dbAdapter.supportsGeneratedKeys() || !accessStackAdapter.supportsColumnTypeReengineering()) {
             assertEquals(0, tokens.size());
             return;
         }

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/db/SetNotNullToDbIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/db/SetNotNullToDbIT.java
@@ -26,12 +26,14 @@ import java.sql.Types;
 import org.apache.cayenne.dbsync.merge.MergeCase;
 import org.apache.cayenne.map.DbAttribute;
 import org.apache.cayenne.map.DbEntity;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class SetNotNullToDbIT extends MergeCase {
 
 	@Test
 	public void test() throws Exception {
+		Assume.assumeTrue(accessStackAdapter.supportsColumnTypeReengineering());
 		DbEntity dbEntity = map.getDbEntity("PAINTING");
 		assertNotNull(dbEntity);
 

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/db/SetPrimaryKeyToDbIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/db/SetPrimaryKeyToDbIT.java
@@ -33,6 +33,7 @@ public class SetPrimaryKeyToDbIT extends MergeCase {
 
 	@Test
 	public void test() throws Exception {
+		Assume.assumeTrue(accessStackAdapter.supportsColumnTypeReengineering());
 		dropTableIfPresent("NEW_TABLE");
 		assertTokensAndExecute(0, 0);
 

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/db/SetPrimaryKeyToDbIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/db/SetPrimaryKeyToDbIT.java
@@ -57,4 +57,42 @@ public class SetPrimaryKeyToDbIT extends MergeCase {
 		assertTokensAndExecute(1, 0);
 		assertTokensAndExecute(0, 0);
 	}
+
+	@Test
+	public void testCaseSensitiveNaming() throws Exception {
+		map.setQuotingSQLIdentifiers(true);
+		dropTableIfPresent("NEW_TABLE");
+		assertTokensAndExecute(0, 0, true);
+
+		DbEntity dbEntity1 = new DbEntity("NEW_TABLE");
+
+		DbAttribute e1col1 = new DbAttribute("ID1", Types.INTEGER, dbEntity1);
+		e1col1.setMandatory(true);
+		e1col1.setPrimaryKey(true);
+		dbEntity1.addAttribute(e1col1);
+		map.addDbEntity(dbEntity1);
+
+		assertTokensAndExecute(1, 0, true);
+		assertTokensAndExecute(0, 0, true);
+
+		DbAttribute e1col2 = new DbAttribute("id1", Types.INTEGER, dbEntity1);
+		e1col2.setMandatory(true);
+		dbEntity1.addAttribute(e1col2);
+
+		assertTokensAndExecute(2, 0, true);
+		assertTokensAndExecute(0, 0, true);
+
+		e1col1.setPrimaryKey(false);
+		e1col2.setPrimaryKey(true);
+
+		assertTokensAndExecute(1, 0, true);
+		assertTokensAndExecute(0, 0, true);
+
+		//clear entity
+		map.removeDbEntity(dbEntity1.getName());
+		dropTableIfPresent("NEW_TABLE");
+
+		assertTokensAndExecute(0, 0, true);
+		map.setQuotingSQLIdentifiers(false);
+	}
 }

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/db/SetPrimaryKeyToDbIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/db/SetPrimaryKeyToDbIT.java
@@ -20,10 +20,13 @@
 package org.apache.cayenne.dbsync.merge.token.db;
 
 import java.sql.Types;
+import java.util.List;
 
 import org.apache.cayenne.dbsync.merge.MergeCase;
+import org.apache.cayenne.dbsync.merge.token.MergerToken;
 import org.apache.cayenne.map.DbAttribute;
 import org.apache.cayenne.map.DbEntity;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class SetPrimaryKeyToDbIT extends MergeCase {
@@ -60,7 +63,10 @@ public class SetPrimaryKeyToDbIT extends MergeCase {
 
 	@Test
 	public void testCaseSensitiveNaming() throws Exception {
+		// Mariadb don't support the same attributes name in different cases.
+		Assume.assumeTrue(accessStackAdapter.supportsCaseSensitiveLike());
 		map.setQuotingSQLIdentifiers(true);
+		List<MergerToken> tokens = syncDBForCaseSensitiveTest();
 		dropTableIfPresent("NEW_TABLE");
 		assertTokensAndExecute(0, 0, true);
 
@@ -70,6 +76,9 @@ public class SetPrimaryKeyToDbIT extends MergeCase {
 		e1col1.setMandatory(true);
 		e1col1.setPrimaryKey(true);
 		dbEntity1.addAttribute(e1col1);
+
+		//to prevent postgresql from creating pk_table
+		setPrimaryKeyGeneratorDBGenerate(dbEntity1);
 		map.addDbEntity(dbEntity1);
 
 		assertTokensAndExecute(1, 0, true);
@@ -93,6 +102,7 @@ public class SetPrimaryKeyToDbIT extends MergeCase {
 		dropTableIfPresent("NEW_TABLE");
 
 		assertTokensAndExecute(0, 0, true);
+		reverseSyncDBForCaseSensitiveTest(tokens);
 		map.setQuotingSQLIdentifiers(false);
 	}
 }

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/model/AddColumnToModelIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/model/AddColumnToModelIT.java
@@ -22,6 +22,7 @@ package org.apache.cayenne.dbsync.merge.token.model;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.sql.Types;
@@ -96,6 +97,77 @@ public class AddColumnToModelIT extends MergeCase {
 
         assertTokensAndExecute(1, 0);
         assertTokensAndExecute(0, 0);
+    }
+
+    @Test
+    public void testAddColumnCaseSensitiveNaming() throws Exception {
+        map.setQuotingSQLIdentifiers(true);
+        dropTableIfPresent("NEW_TABLE");
+        assertTokensAndExecute(0, 0);
+
+        DbEntity dbEntity = new DbEntity("NEW_TABLE");
+
+        DbAttribute column1 = new DbAttribute("ID", Types.INTEGER, dbEntity);
+        column1.setMandatory(true);
+        column1.setPrimaryKey(true);
+        dbEntity.addAttribute(column1);
+
+        DbAttribute column2 = new DbAttribute("NAME", Types.VARCHAR, dbEntity);
+        column2.setMaxLength(10);
+        column2.setMandatory(false);
+        dbEntity.addAttribute(column2);
+
+        DbAttribute column3 = new DbAttribute("name", Types.VARCHAR, dbEntity);
+        column3.setMaxLength(10);
+        column3.setMandatory(false);
+        dbEntity.addAttribute(column3);
+        map.addDbEntity(dbEntity);
+
+        assertTokensAndExecute(1, 0);
+        assertTokensAndExecute(0, 0);
+
+        ObjEntity objEntity = new ObjEntity("NewTable");
+        objEntity.setDbEntity(dbEntity);
+        ObjAttribute oatr1 = new ObjAttribute("name");
+        oatr1.setDbAttributePath(column2.getName());
+        oatr1.setType("java.lang.String");
+        objEntity.addAttribute(oatr1);
+
+        ObjAttribute oatr2 = new ObjAttribute("name1");
+        oatr2.setDbAttributePath(column3.getName());
+        oatr2.setType("java.lang.String");
+        objEntity.addAttribute(oatr2);
+        map.addObjEntity(objEntity);
+
+        // remove name column
+        objEntity.removeAttribute(oatr2.getName());
+        dbEntity.removeAttribute(column3.getName());
+        assertNull(objEntity.getAttribute(oatr2.getName()));
+        assertEquals(1, objEntity.getAttributes().size());
+        assertNull(dbEntity.getAttribute(column3.getName()));
+        assertSame(column2, dbEntity.getAttribute(column2.getName()));
+
+        List<MergerToken> tokens = createMergeTokens(true);
+        assertEquals(1, tokens.size());
+        MergerToken token = tokens.get(0);
+        if (token.getDirection().isToDb()) {
+            token = token.createReverse(mergerFactory());
+        }
+        assertTrue(token instanceof AddColumnToModel);
+        execute(token);
+        assertEquals(2, objEntity.getAttributes().size());
+
+        // clear up
+        map.removeObjEntity(objEntity.getName(), true);
+        map.removeDbEntity(dbEntity.getName(), true);
+        resolver.refreshMappingCache();
+        assertNull(map.getObjEntity(objEntity.getName()));
+        assertNull(map.getDbEntity(dbEntity.getName()));
+        assertFalse(map.getDbEntities().contains(dbEntity));
+
+        assertTokensAndExecute(1, 0);
+        assertTokensAndExecute(0, 0);
+        map.setQuotingSQLIdentifiers(false);
     }
 
 }

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/model/CreateTableToModelIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/model/CreateTableToModelIT.java
@@ -26,12 +26,15 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.sql.Types;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.cayenne.dbsync.merge.MergeCase;
 import org.apache.cayenne.dbsync.merge.token.MergerToken;
 import org.apache.cayenne.map.DbAttribute;
 import org.apache.cayenne.map.DbEntity;
+import org.apache.cayenne.map.DbJoin;
+import org.apache.cayenne.map.DbRelationship;
 import org.apache.cayenne.map.ObjEntity;
 import org.junit.Test;
 
@@ -96,5 +99,192 @@ public class CreateTableToModelIT extends MergeCase {
 
 		assertTokensAndExecute(1, 0);
 		assertTokensAndExecute(0, 0);
+	}
+
+	@Test
+	public void testAddTableCaseSensitive() throws Exception {
+		map.setQuotingSQLIdentifiers(true);
+		dropTableIfPresent("NEW_TABLE");
+		dropTableIfPresent("NEW_table");
+		assertTokensAndExecute(0, 0);
+
+		DbEntity dbEntity = new DbEntity("NEW_TABLE");
+
+		DbAttribute column1 = new DbAttribute("ID", Types.INTEGER, dbEntity);
+		column1.setMandatory(true);
+		column1.setPrimaryKey(true);
+		dbEntity.addAttribute(column1);
+
+		DbAttribute column2 = new DbAttribute("NAME", Types.VARCHAR, dbEntity);
+		column2.setMaxLength(10);
+		column2.setMandatory(false);
+		dbEntity.addAttribute(column2);
+
+
+		DbEntity dbEntity1 = new DbEntity("NEW_table");
+
+		DbAttribute column3 = new DbAttribute("ID", Types.INTEGER, dbEntity1);
+		column3.setMandatory(true);
+		column3.setPrimaryKey(true);
+		dbEntity1.addAttribute(column3);
+
+		DbAttribute column4 = new DbAttribute("NUMBER", Types.INTEGER, dbEntity1);
+		column4.setMaxLength(10);
+		column4.setMandatory(false);
+		dbEntity1.addAttribute(column4);
+
+		// for the new entity to the db
+		map.addDbEntity(dbEntity);
+		map.addDbEntity(dbEntity1);
+		execute(mergerFactory().createCreateTableToDb(dbEntity));
+		execute(mergerFactory().createCreateTableToDb(dbEntity1));
+		map.removeDbEntity(dbEntity.getName());
+		map.removeDbEntity(dbEntity1.getName());
+
+		List<MergerToken> tokens = createMergeTokensWithoutEmptyFilter(true);
+		List<MergerToken> reverseTokens = new ArrayList<>();
+		for (MergerToken token : tokens) {
+			if (token.getDirection().isToDb()) {
+				reverseTokens.add(token.createReverse(mergerFactory()));
+			}
+		}
+		execute(filterEmpty(reverseTokens));
+
+		ObjEntity objEntity1 = null;
+		for (ObjEntity candidate : map.getObjEntities()) {
+			if (dbEntity1.getName().equals(candidate.getDbEntityName())) {
+				objEntity1 = candidate;
+				break;
+			}
+		}
+		assertNotNull(objEntity1);
+
+		assertEquals(objEntity1.getClassName(), map.getDefaultPackage() + "." + objEntity1.getName());
+		assertEquals(objEntity1.getSuperClassName(), map.getDefaultSuperclass());
+		assertEquals(objEntity1.getClientClassName(), map.getDefaultClientPackage() + "." + objEntity1.getName());
+		assertEquals(objEntity1.getClientSuperClassName(), map.getDefaultClientSuperclass());
+
+		assertEquals(1, objEntity1.getAttributes().size());
+		assertEquals("java.lang.Integer", objEntity1.getAttributes().iterator().next().getType());
+
+		// clear up
+		// fix psql case issue
+		map.removeDbEntity(objEntity1.getDbEntity().getName(), true);
+		map.removeObjEntity(objEntity1.getName(), true);
+		map.removeDbEntity(dbEntity1.getName(), true);
+
+		ObjEntity objEntity = null;
+		for (ObjEntity candidate : map.getObjEntities()) {
+			if (dbEntity.getName().equals(candidate.getDbEntityName())) {
+				objEntity = candidate;
+				break;
+			}
+		}
+		map.removeDbEntity(objEntity.getDbEntity().getName(), true);
+		map.removeObjEntity(objEntity.getName(), true);
+		map.removeDbEntity(dbEntity.getName(), true);
+		resolver.refreshMappingCache();
+		assertNull(map.getObjEntity(objEntity.getName()));
+		assertNull(map.getDbEntity(dbEntity.getName()));
+		assertFalse(map.getDbEntities().contains(dbEntity));
+		assertNull(map.getObjEntity(objEntity1.getName()));
+		assertNull(map.getDbEntity(dbEntity1.getName()));
+		assertFalse(map.getDbEntities().contains(dbEntity1));
+
+		assertTokensAndExecute(2, 0, true);
+		assertTokensAndExecute(0, 0, true);
+		map.setQuotingSQLIdentifiers(false);
+	}
+
+	@Test
+	public void testAddTableWithRelationship() throws Exception {
+		map.setQuotingSQLIdentifiers(true);
+		dropTableIfPresent("NEW_TABLE");
+		dropTableIfPresent("NEW_table");
+		assertTokensAndExecute(0, 0);
+
+		DbEntity dbEntity1 = new DbEntity("NEW_TABLE");
+
+		DbAttribute column1 = new DbAttribute("ID", Types.INTEGER, dbEntity1);
+		column1.setMandatory(true);
+		column1.setPrimaryKey(true);
+		dbEntity1.addAttribute(column1);
+
+		DbAttribute column2 = new DbAttribute("NAME", Types.VARCHAR, dbEntity1);
+		column2.setMaxLength(10);
+		column2.setMandatory(false);
+		dbEntity1.addAttribute(column2);
+
+		DbEntity dbEntity2 = new DbEntity("NEW_table");
+
+		DbAttribute column3 = new DbAttribute("ID", Types.INTEGER, dbEntity2);
+		column3.setMandatory(true);
+		column3.setPrimaryKey(true);
+		dbEntity2.addAttribute(column3);
+
+		DbAttribute column4 = new DbAttribute("NUMBER", Types.INTEGER, dbEntity2);
+		column4.setMaxLength(10);
+		column4.setMandatory(false);
+		dbEntity2.addAttribute(column4);
+
+		// create db relationships
+		DbRelationship rel1To2 = new DbRelationship("rel1To2");
+		rel1To2.setSourceEntity(dbEntity1);
+		rel1To2.setTargetEntityName(dbEntity2);
+		rel1To2.setToMany(true);
+		rel1To2.addJoin(new DbJoin(rel1To2, column1.getName(), column3.getName()));
+		dbEntity1.addRelationship(rel1To2);
+
+		DbRelationship rel2To1 = new DbRelationship("rel2To1");
+		rel2To1.setSourceEntity(dbEntity2);
+		rel2To1.setTargetEntityName(dbEntity1);
+		rel2To1.setToMany(false);
+		rel2To1.addJoin(new DbJoin(rel2To1, column3.getName(), column1.getName()));
+		dbEntity2.addRelationship(rel2To1);
+
+		// for the new entity to the db
+		map.addDbEntity(dbEntity1);
+		map.addDbEntity(dbEntity2);
+		execute(mergerFactory().createCreateTableToDb(dbEntity1));
+		execute(mergerFactory().createCreateTableToDb(dbEntity2));
+		map.removeDbEntity(dbEntity1.getName());
+		map.removeDbEntity(dbEntity2.getName());
+
+		List<MergerToken> tokens = createMergeTokensWithoutEmptyFilter(true);
+		List<MergerToken> reverseTokens = new ArrayList<>();
+		for (MergerToken token : tokens) {
+			if (token.getDirection().isToDb()) {
+				reverseTokens.add(token.createReverse(mergerFactory()));
+			}
+		}
+		execute(filterEmpty(reverseTokens));
+
+		ObjEntity objEntity1 = null;
+		ObjEntity objEntity2 = null;
+		for (ObjEntity candidate : map.getObjEntities()) {
+			if (dbEntity1.getName().equals(candidate.getDbEntityName())) {
+				objEntity1 = candidate;
+				continue;
+			}
+			if (dbEntity2.getName().equals(candidate.getDbEntityName())) {
+				objEntity2 = candidate;
+			}
+		}
+
+		assertNotNull(objEntity1);
+		assertNotNull(objEntity2);
+		assertEquals(0, objEntity1.getRelationships().size());
+		assertEquals(0, objEntity2.getRelationships().size());
+
+		//clear entity
+		map.removeDbEntity(dbEntity1.getName());
+		map.removeDbEntity(dbEntity2.getName());
+		map.removeObjEntity(objEntity1.getName(), true);
+		map.removeObjEntity(objEntity2.getName(), true);
+		dropTableIfPresent("NEW_table");
+		dropTableIfPresent("NEW_TABLE");
+
+		assertTokensAndExecute(0, 0, true);
+		map.setQuotingSQLIdentifiers(false);
 	}
 }

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/model/CreateTableToModelIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/model/CreateTableToModelIT.java
@@ -155,7 +155,7 @@ public class CreateTableToModelIT extends MergeCase {
 				reverseTokens.add(token.createReverse(mergerFactory()));
 			}
 		}
-		execute(filterEmpty(reverseTokens));
+		execute(filterNotValid(reverseTokens));
 
 		ObjEntity objEntity1 = null;
 		for (ObjEntity candidate : map.getObjEntities()) {
@@ -270,7 +270,7 @@ public class CreateTableToModelIT extends MergeCase {
 				reverseTokens.add(token.createReverse(mergerFactory()));
 			}
 		}
-		execute(filterEmpty(reverseTokens));
+		execute(filterNotValid(reverseTokens));
 
 		ObjEntity objEntity1 = null;
 		ObjEntity objEntity2 = null;

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/model/DropColumnToModelIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/model/DropColumnToModelIT.java
@@ -126,7 +126,7 @@ public class DropColumnToModelIT extends MergeCase {
 		e2col1.setMandatory(true);
 		e2col1.setPrimaryKey(true);
 		dbEntity2.addAttribute(e2col1);
-		DbAttribute e2col2 = new DbAttribute("FK", Types.INTEGER, dbEntity2);
+		DbAttribute e2col2 = new DbAttribute("FK_ID", Types.INTEGER, dbEntity2);
 		dbEntity2.addAttribute(e2col2);
 		DbAttribute e2col3 = new DbAttribute("NAME", Types.VARCHAR, dbEntity2);
 		e2col3.setMaxLength(10);

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/model/DropColumnToModelIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/model/DropColumnToModelIT.java
@@ -38,6 +38,7 @@ import org.apache.cayenne.map.DbRelationship;
 import org.apache.cayenne.map.ObjAttribute;
 import org.apache.cayenne.map.ObjEntity;
 import org.apache.cayenne.map.ObjRelationship;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class DropColumnToModelIT extends MergeCase {
@@ -102,6 +103,7 @@ public class DropColumnToModelIT extends MergeCase {
 
 	@Test
 	public void testRemoveFKColumnWithoutRelationshipInDb() throws Exception {
+		Assume.assumeTrue(accessStackAdapter.supportsFKConstraints());
 		dropTableIfPresent("NEW_TABLE");
 		dropTableIfPresent("NEW_TABLE2");
 

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/model/DropRelationshipToModelIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/model/DropRelationshipToModelIT.java
@@ -44,6 +44,7 @@ public class DropRelationshipToModelIT extends MergeCase {
 
 	@Test
 	public void testForeignKey() throws Exception {
+		Assume.assumeTrue(accessStackAdapter.supportsFKConstraints());
 		dropTableIfPresent("NEW_TABLE");
 		dropTableIfPresent("NEW_TABLE2");
 

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/model/DropRelationshipToModelIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/merge/token/model/DropRelationshipToModelIT.java
@@ -189,4 +189,228 @@ public class DropRelationshipToModelIT extends MergeCase {
 		assertTokensAndExecute(2, 0);
 		assertTokensAndExecute(0, 0);
 	}
+
+	@Test
+	public void testForeignKeyCaseSensitiveNaming() throws Exception {
+		map.setQuotingSQLIdentifiers(true);
+		dropTableIfPresent("NEW_TABLE");
+		dropTableIfPresent("NEW_TABLE2");
+		dropTableIfPresent("NEW_table");
+
+		assertTokensAndExecute(0, 0);
+
+		DbEntity dbEntity1 = new DbEntity("NEW_TABLE");
+
+		DbAttribute e1col1 = new DbAttribute("ID", Types.INTEGER, dbEntity1);
+		e1col1.setMandatory(true);
+		e1col1.setPrimaryKey(true);
+		dbEntity1.addAttribute(e1col1);
+
+		DbAttribute e1col2 = new DbAttribute("NAME", Types.VARCHAR, dbEntity1);
+		e1col2.setMaxLength(10);
+		e1col2.setMandatory(false);
+		dbEntity1.addAttribute(e1col2);
+
+		map.addDbEntity(dbEntity1);
+
+		DbEntity dbEntity2 = new DbEntity("NEW_TABLE2");
+		DbAttribute e2col1 = new DbAttribute("ID", Types.INTEGER, dbEntity2);
+		e2col1.setMandatory(true);
+		e2col1.setPrimaryKey(true);
+		dbEntity2.addAttribute(e2col1);
+		DbAttribute e2col2 = new DbAttribute("FK", Types.INTEGER, dbEntity2);
+		dbEntity2.addAttribute(e2col2);
+		DbAttribute e2col3 = new DbAttribute("NAME", Types.VARCHAR, dbEntity2);
+		e2col3.setMaxLength(10);
+		dbEntity2.addAttribute(e2col3);
+
+		map.addDbEntity(dbEntity2);
+
+
+		DbEntity dbEntity3 = new DbEntity("NEW_table");
+
+		DbAttribute e3col1 = new DbAttribute("ID", Types.INTEGER, dbEntity3);
+		e3col1.setMandatory(true);
+		e3col1.setPrimaryKey(true);
+		dbEntity3.addAttribute(e3col1);
+
+		DbAttribute e3col2 = new DbAttribute("NAME", Types.VARCHAR, dbEntity3);
+		e3col2.setMaxLength(10);
+		e3col2.setMandatory(false);
+		dbEntity3.addAttribute(e3col2);
+
+		map.addDbEntity(dbEntity3);
+
+		// create db relationships
+		DbRelationship rel1To2 = new DbRelationship("rel1To2");
+		rel1To2.setSourceEntity(dbEntity1);
+		rel1To2.setTargetEntityName(dbEntity2);
+		rel1To2.setToMany(true);
+		rel1To2.addJoin(new DbJoin(rel1To2, e1col1.getName(), e2col2.getName()));
+		dbEntity1.addRelationship(rel1To2);
+		DbRelationship rel2To1 = new DbRelationship("rel2To1");
+		rel2To1.setSourceEntity(dbEntity2);
+		rel2To1.setTargetEntityName(dbEntity1);
+		rel2To1.setToMany(false);
+		rel2To1.addJoin(new DbJoin(rel2To1, e2col2.getName(), e1col1.getName()));
+		dbEntity2.addRelationship(rel2To1);
+
+		DbRelationship rel3To2 = new DbRelationship("rel3To2");
+		rel3To2.setSourceEntity(dbEntity3);
+		rel3To2.setTargetEntityName(dbEntity2);
+		rel3To2.setToMany(true);
+		rel3To2.addJoin(new DbJoin(rel3To2, e3col1.getName(), e2col2.getName()));
+		dbEntity3.addRelationship(rel3To2);
+
+		DbRelationship rel2To3 = new DbRelationship("rel2To3");
+		rel2To3.setSourceEntity(dbEntity2);
+		rel2To3.setTargetEntityName(dbEntity3);
+		rel2To3.setToMany(false);
+		rel2To3.addJoin(new DbJoin(rel2To3, e2col2.getName(), e3col1.getName()));
+		dbEntity2.addRelationship(rel2To3);
+
+		assertSame(rel1To2, rel2To1.getReverseRelationship());
+		assertSame(rel2To1, rel1To2.getReverseRelationship());
+		assertSame(rel3To2, rel2To3.getReverseRelationship());
+		assertSame(rel2To3, rel3To2.getReverseRelationship());
+
+		assertTokensAndExecute(5, 0, true);
+		assertTokensAndExecute(0, 0, true);
+
+		// create ObjEntities
+		ObjEntity objEntity1 = new ObjEntity("NewTable");
+		objEntity1.setDbEntity(dbEntity1);
+		ObjAttribute oatr1 = new ObjAttribute("name");
+		oatr1.setDbAttributePath(e1col2.getName());
+		oatr1.setType("java.lang.String");
+		objEntity1.addAttribute(oatr1);
+
+		map.addObjEntity(objEntity1);
+		ObjEntity objEntity2 = new ObjEntity("NewTable2");
+		objEntity2.setDbEntity(dbEntity2);
+		ObjAttribute o2a1 = new ObjAttribute("name");
+		o2a1.setDbAttributePath(e2col3.getName());
+		o2a1.setType("java.lang.String");
+		objEntity2.addAttribute(o2a1);
+		map.addObjEntity(objEntity2);
+
+		ObjEntity objEntity3 = new ObjEntity("NewTable3");
+		objEntity3.setDbEntity(dbEntity3);
+		ObjAttribute o3atr1 = new ObjAttribute("name");
+		o3atr1.setDbAttributePath(e1col2.getName());
+		o3atr1.setType("java.lang.String");
+		objEntity3.addAttribute(o3atr1);
+		map.addObjEntity(objEntity3);
+
+		// create ObjRelationships
+		assertEquals(0, objEntity1.getRelationships().size());
+		assertEquals(0, objEntity2.getRelationships().size());
+		assertEquals(0, objEntity3.getRelationships().size());
+		ObjRelationship objRel1To2 = new ObjRelationship("objRel1To2");
+		objRel1To2.addDbRelationship(rel1To2);
+		objRel1To2.setSourceEntity(objEntity1);
+		objRel1To2.setTargetEntityName(objEntity2);
+		objEntity1.addRelationship(objRel1To2);
+
+		ObjRelationship objRel2To1 = new ObjRelationship("objRel2To1");
+		objRel2To1.addDbRelationship(rel2To1);
+		objRel2To1.setSourceEntity(objEntity2);
+		objRel2To1.setTargetEntityName(objEntity1);
+		objEntity2.addRelationship(objRel2To1);
+
+		ObjRelationship objRel2To3 = new ObjRelationship("objRel2To3");
+		objRel2To3.addDbRelationship(rel2To3);
+		objRel2To3.setSourceEntity(objEntity2);
+		objRel2To3.setTargetEntityName(objEntity3);
+		objEntity2.addRelationship(objRel2To3);
+
+		ObjRelationship objRel3To2 = new ObjRelationship("objRel2To3");
+		objRel3To2.addDbRelationship(rel3To2);
+		objRel3To2.setSourceEntity(objEntity3);
+		objRel3To2.setTargetEntityName(objEntity2);
+		objEntity3.addRelationship(objRel3To2);
+
+		assertEquals(1, objEntity1.getRelationships().size());
+		assertEquals(2, objEntity2.getRelationships().size());
+		assertEquals(1, objEntity3.getRelationships().size());
+		assertSame(objRel1To2, objRel2To1.getReverseRelationship());
+		assertSame(objRel2To1, objRel1To2.getReverseRelationship());
+		assertSame(objRel2To3, objRel3To2.getReverseRelationship());
+		assertSame(objRel3To2, objRel2To3.getReverseRelationship());
+
+		// remove relationship and fk from model, merge to db and read to model
+		dbEntity2.removeRelationship(rel2To3.getName());
+		dbEntity3.removeRelationship(rel3To2.getName());
+		List<MergerToken> tokens = createMergeTokens(true);
+
+		/**
+		 * Drop Relationship NEW_TABLE2->NEW_TABLE To DB
+		 * Drop Column NEW_TABLE2.FK To DB
+		 * */
+		assertTokens(tokens, 1, 0);
+		for (MergerToken token : tokens) {
+			if (token.getDirection().isToDb()) {
+				execute(token);
+			}
+		}
+		assertTokensAndExecute(0, 0, true);
+
+		dbEntity2.addRelationship(rel2To3);
+		dbEntity3.addRelationship(rel3To2);
+
+		// try do use the merger to remove the relationship in the model
+		tokens = createMergeTokens(true);
+		assertTokens(tokens, 1, 0);
+		// TODO: reversing the following two tokens should also reverse the
+		// order
+		MergerToken token0 = tokens.get(0).createReverse(mergerFactory());
+		if (!(token0 instanceof DropRelationshipToModel)) {
+			fail();
+		}
+		execute(token0);
+
+		// check after merging
+		assertEquals(0, dbEntity3.getRelationships().size());
+		assertEquals(1, dbEntity2.getRelationships().size());
+		assertEquals(0, objEntity3.getRelationships().size());
+		assertEquals(1, objEntity2.getRelationships().size());
+		assertEquals(1, objEntity1.getRelationships().size());
+
+		// clear up
+		dbEntity1.removeRelationship(rel3To2.getName());
+		dbEntity2.removeRelationship(rel2To3.getName());
+		map.removeObjEntity(objEntity1.getName(), true);
+		map.removeDbEntity(dbEntity1.getName(), true);
+		map.removeObjEntity(objEntity2.getName(), true);
+		map.removeDbEntity(dbEntity2.getName(), true);
+		map.removeObjEntity(objEntity3.getName(), true);
+		map.removeDbEntity(dbEntity3.getName(), true);
+		resolver.refreshMappingCache();
+		assertNull(map.getObjEntity(objEntity1.getName()));
+		assertNull(map.getDbEntity(dbEntity1.getName()));
+		assertNull(map.getObjEntity(objEntity2.getName()));
+		assertNull(map.getDbEntity(dbEntity2.getName()));
+		assertNull(map.getObjEntity(objEntity3.getName()));
+		assertNull(map.getDbEntity(dbEntity3.getName()));
+		assertFalse(map.getDbEntities().contains(dbEntity1));
+		assertFalse(map.getDbEntities().contains(dbEntity2));
+		assertFalse(map.getDbEntities().contains(dbEntity3));
+
+		assertTokensAndExecute(4, 0, true);
+		assertTokensAndExecute(0, 0, true);
+
+		//clear entity
+		map.removeDbEntity(dbEntity1.getName());
+		map.removeDbEntity(dbEntity2.getName());
+		map.removeDbEntity(dbEntity3.getName());
+		map.removeObjEntity(objEntity1.getName(), true);
+		map.removeObjEntity(objEntity2.getName(), true);
+		map.removeObjEntity(objEntity3.getName(), true);
+		dropTableIfPresent("NEW_table");
+		dropTableIfPresent("NEW_TABLE");
+		dropTableIfPresent("NEW_TABLE2");
+
+		assertTokensAndExecute(0, 0, true);
+		map.setQuotingSQLIdentifiers(false);
+	}
 }

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/naming/NameBuilderTest.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/naming/NameBuilderTest.java
@@ -269,4 +269,24 @@ public class NameBuilderTest {
         assertEquals("getUntitledAttr1", c3);
         entity.getCallbackMap().getPostAdd().addCallbackMethod(c3);
     }
+
+    @Test
+    public void testName_MixedCase_DataMapContext() {
+        ObjectNameGenerator nameGenerator = new DefaultObjectNameGenerator();
+
+        DataMap dataMap = new DataMap();
+        DbEntity dbEntity1 = new DbEntity();
+        dbEntity1.setName("Artist");
+        ObjEntity objEntity1 = new ObjEntity();
+        objEntity1.setName(NameBuilder.builder(objEntity1, dataMap).baseName(nameGenerator.objEntityName(dbEntity1)).name());
+        dataMap.addObjEntity(objEntity1);
+        assertEquals("Artist", objEntity1.getName());
+
+        DbEntity dbEntity2 = new DbEntity();
+        dbEntity2.setName("ARTIST");
+        ObjEntity objEntity2 = new ObjEntity();
+        objEntity2.setName(NameBuilder.builder(objEntity2, dataMap).baseName(nameGenerator.objEntityName(dbEntity2)).name());
+        dataMap.addObjEntity(objEntity2);
+        assertEquals("Artist1", objEntity2.getName());
+    }
 }

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/reverse/dbimport/DefaultDbImportActionTest.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/reverse/dbimport/DefaultDbImportActionTest.java
@@ -125,7 +125,7 @@ public class DefaultDbImportActionTest {
         when(config.createNameGenerator()).thenReturn(new DefaultObjectNameGenerator(NoStemStemmer.getInstance()));
         when(config.createMeaningfulPKFilter()).thenReturn(NamePatternMatcher.EXCLUDE_ALL);
 
-        DbLoader dbLoader = new DbLoader(mockAdapter, mockConnection, config.getDbLoaderConfig(), mockDelegate, mockNameGenerator) {
+        DbLoader dbLoader = new DbLoader(mockAdapter, mockConnection, config.getDbLoaderConfig(), mockDelegate, mockNameGenerator, String::toUpperCase) {
             @Override
             public DataMap load() throws SQLException {
                 DataMap map = new DataMap();
@@ -161,7 +161,7 @@ public class DefaultDbImportActionTest {
         when(config.createNameGenerator()).thenReturn(new DefaultObjectNameGenerator(NoStemStemmer.getInstance()));
         when(config.createMeaningfulPKFilter()).thenReturn(NamePatternMatcher.EXCLUDE_ALL);
 
-        DbLoader dbLoader = new DbLoader(mockAdapter, mockConnection, config.getDbLoaderConfig(), mockDelegate, mockNameGenerator) {
+        DbLoader dbLoader = new DbLoader(mockAdapter, mockConnection, config.getDbLoaderConfig(), mockDelegate, mockNameGenerator, String::toUpperCase) {
             @Override
             public DataMap load() throws SQLException {
                 DataMap dataMap = new DataMap();
@@ -227,7 +227,7 @@ public class DefaultDbImportActionTest {
         when(config.createMergeDelegate()).thenReturn(new DefaultModelMergeDelegate());
         when(config.getDbLoaderConfig()).thenReturn(new DbLoaderConfiguration());
 
-        DbLoader dbLoader = new DbLoader(mockAdapter, mockConnection, config.getDbLoaderConfig(), mockDelegate, mockNameGenerator) {
+        DbLoader dbLoader = new DbLoader(mockAdapter, mockConnection, config.getDbLoaderConfig(), mockDelegate, mockNameGenerator, String::toUpperCase) {
             @Override
             public DataMap load() throws SQLException {
                 DataMap dataMap = new DataMap();

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/reverse/dbload/AttributeLoaderIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/reverse/dbload/AttributeLoaderIT.java
@@ -25,6 +25,7 @@ import java.sql.Types;
 import org.apache.cayenne.dba.TypesMapping;
 import org.apache.cayenne.map.DbAttribute;
 import org.apache.cayenne.map.DbEntity;
+import org.junit.Assume;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -36,6 +37,7 @@ public class AttributeLoaderIT extends BaseLoaderIT {
 
     @Test
     public void testAttributeLoad() throws Exception {
+        Assume.assumeTrue(accessStackAdapter.supportsColumnTypeReengineering());
         createDbEntities();
 
         AttributeLoader loader = new AttributeLoader(adapter, EMPTY_CONFIG, new DefaultDbLoaderDelegate());
@@ -79,6 +81,7 @@ public class AttributeLoaderIT extends BaseLoaderIT {
 
     @Test
     public void testAttributeLoadTypes() throws Exception {
+        Assume.assumeTrue(accessStackAdapter.supportsColumnTypeReengineering());
         DatabaseMetaData metaData = connection.getMetaData();
         DbLoaderDelegate delegate = new DefaultDbLoaderDelegate();
 

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/reverse/dbload/AttributeLoaderIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/reverse/dbload/AttributeLoaderIT.java
@@ -44,8 +44,9 @@ public class AttributeLoaderIT extends BaseLoaderIT {
         DbEntity artist = getDbEntity("ARTIST");
         DbAttribute a = getDbAttribute(artist, "ARTIST_ID");
         assertNotNull(a);
+        //For oracle type numeric
         if(accessStackAdapter.onlyGenericNumberType()) {
-            assertEquals(Types.INTEGER, a.getType());
+            assertTrue(Types.INTEGER == a.getType() || Types.NUMERIC == a.getType());
         } else {
             assertEquals(Types.BIGINT, a.getType());
         }
@@ -105,15 +106,15 @@ public class AttributeLoaderIT extends BaseLoaderIT {
         // check varchar
         assertEquals(msgForTypeMismatch(Types.VARCHAR, varcharAttr), Types.VARCHAR, varcharAttr.getType());
         assertEquals(255, varcharAttr.getMaxLength());
-        // check integer
-        assertEquals(msgForTypeMismatch(Types.INTEGER, integerAttr), Types.INTEGER, integerAttr.getType());
+        // check integer. For oracle type numeric
+        assertTrue(msgForTypeMismatch(Types.INTEGER, integerAttr), Types.INTEGER == integerAttr.getType() || Types.NUMERIC == decimalAttr.getType());
         // check float
         assertTrue(msgForTypeMismatch(Types.FLOAT, floatAttr), Types.FLOAT == floatAttr.getType()
                 || Types.DOUBLE == floatAttr.getType() || Types.REAL == floatAttr.getType());
 
-        // check smallint
+        // check smallint. For oracle type numeric
         assertTrue(msgForTypeMismatch(Types.SMALLINT, smallintAttr), Types.SMALLINT == smallintAttr.getType()
-                || Types.INTEGER == smallintAttr.getType());
+                || Types.INTEGER == smallintAttr.getType() || Types.NUMERIC == decimalAttr.getType());
     }
 
     private void assertGenerated() {

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/reverse/dbload/BaseLoaderIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/reverse/dbload/BaseLoaderIT.java
@@ -59,7 +59,7 @@ public class BaseLoaderIT extends ServerCase {
 
     @Before
     public void before() throws Exception {
-        store = new DbLoadDataStore();
+        store = new DbLoadDataStore(String::toUpperCase);
         assertTrue("Store is not empty", store.getDbEntities().isEmpty());
         this.connection = dataSourceFactory.getSharedDataSource().getConnection();
     }

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/reverse/dbload/DbLoaderIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/reverse/dbload/DbLoaderIT.java
@@ -34,6 +34,7 @@ import org.apache.cayenne.unit.di.server.ServerCase;
 import org.apache.cayenne.unit.di.server.ServerCaseDataSourceFactory;
 import org.apache.cayenne.unit.di.server.UseServerRuntime;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -72,6 +73,7 @@ public class DbLoaderIT extends ServerCase {
      */
     @Test
     public void testSimpleLoad() throws Exception {
+        Assume.assumeTrue(accessStackAdapter.supportsFKConstraints());
         DbLoader loader = createDbLoader(true, true);
         DataMap loaded = loader.load();
         assertNotNull(loaded);

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/reverse/dbload/DbLoaderIT.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/reverse/dbload/DbLoaderIT.java
@@ -121,7 +121,7 @@ public class DbLoaderIT extends ServerCase {
     }
 
     private DbLoader createDbLoader(boolean meaningfulPK, boolean meaningfulFK) {
-        return new DbLoader(adapter, connection, CONFIG, null, new DefaultObjectNameGenerator(NoStemStemmer.getInstance()));
+        return new DbLoader(adapter, connection, CONFIG, null, new DefaultObjectNameGenerator(NoStemStemmer.getInstance()), String::toUpperCase);
     }
 
     @After

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/reverse/filters/FiltersConfigBuilderTest.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/reverse/filters/FiltersConfigBuilderTest.java
@@ -128,6 +128,23 @@ public class FiltersConfigBuilderTest {
     }
 
     @Test
+    public void testCompact_05() {
+        ReverseEngineering engineering = new ReverseEngineering();
+        engineering.setUseCaseSensitiveNaming(true);
+        engineering.addSchema(new Schema("s"));
+
+        FiltersConfigBuilder builder = new FiltersConfigBuilder(engineering);
+        builder.compact();
+        assertEquals(
+                "ReverseEngineering: \n" +
+                        "  Catalog: null\n" +
+                        "    Schema: s\n" +
+                        "      IncludeTable: null\n\n" +
+                        "  Use primitives\n" +
+                        "  Use case sensitive naming", engineering.toString());
+    }
+
+    @Test
     public void testCompact_full() {
         ReverseEngineering engineering = new ReverseEngineering();
         Catalog cat01 = new Catalog("cat_01");

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/reverse/filters/FiltersConfigTest.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/reverse/filters/FiltersConfigTest.java
@@ -47,10 +47,10 @@ public class FiltersConfigTest extends TestCase {
                         new SchemaFilter("schema_21", TableFilter.everything(), PatternFilter.INCLUDE_NOTHING),
                         new SchemaFilter("schema_22",
                                 new TableFilter(
-                                        includes(new IncludeTableFilter(null, PatternFilter.INCLUDE_NOTHING)),
+                                        includes(new IncludeTableFilter(null, PatternFilter.INCLUDE_NOTHING, false)),
                                         excludes("aaa")),
                                 PatternFilter.INCLUDE_NOTHING),
-                        new SchemaFilter("schema_23", TableFilter.include("include"), PatternFilter.INCLUDE_NOTHING)
+                        new SchemaFilter("schema_23", TableFilter.include("include", false), PatternFilter.INCLUDE_NOTHING)
                 )
         );
 
@@ -78,7 +78,7 @@ public class FiltersConfigTest extends TestCase {
     private SortedSet<Pattern> excludes(String ... p) {
         SortedSet<Pattern> patterns = new TreeSet<Pattern>(PatternFilter.PATTERN_COMPARATOR);
         for (String pattern : p) {
-            patterns.add(PatternFilter.pattern(pattern));
+            patterns.add(PatternFilter.pattern(pattern, false));
         }
         return patterns;
     }

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/reverse/filters/PatternFilterTest.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/reverse/filters/PatternFilterTest.java
@@ -23,7 +23,7 @@ import junit.framework.TestCase;
 public class PatternFilterTest extends TestCase {
 
     public void testInclude() throws Exception {
-        PatternFilter filter = new PatternFilter()
+        PatternFilter filter = new PatternFilter(false)
                 .include("aaa")
                 .include("bbb");
 
@@ -33,7 +33,7 @@ public class PatternFilterTest extends TestCase {
         assertFalse(filter.isIncluded("aa"));
         assertFalse(filter.isIncluded("abb"));
 
-        filter = new PatternFilter().include("^v_.*$");
+        filter = new PatternFilter(false).include("^v_.*$");
         assertTrue(filter.isIncluded("v_new_view"));
         assertFalse(filter.isIncluded("new_view"));
         assertFalse(filter.isIncluded("view"));
@@ -41,7 +41,7 @@ public class PatternFilterTest extends TestCase {
     }
 
     public void testExclude() throws Exception {
-        PatternFilter filter = new PatternFilter()
+        PatternFilter filter = new PatternFilter(false)
                 .exclude("aaa")
                 .exclude("bbb");
 
@@ -53,7 +53,7 @@ public class PatternFilterTest extends TestCase {
     }
 
     public void testIncludeExclude() throws Exception {
-        PatternFilter filter = new PatternFilter()
+        PatternFilter filter = new PatternFilter(false)
                 .include("aa.*")
                 .exclude("aaa");
 
@@ -74,5 +74,45 @@ public class PatternFilterTest extends TestCase {
         assertFalse(PatternFilter.INCLUDE_NOTHING.isIncluded("qwe"));
         assertFalse(PatternFilter.INCLUDE_NOTHING.isIncluded(""));
         assertFalse(PatternFilter.INCLUDE_NOTHING.isIncluded(null));
+    }
+
+    public void testIncludeCaseSensitive() throws Exception {
+        PatternFilter filter = new PatternFilter(true)
+                .include("aaa")
+                .include("bbb");
+
+        assertTrue(filter.isIncluded("aaa"));
+        assertTrue(filter.isIncluded("bbb"));
+        assertFalse(filter.isIncluded("aaA"));
+        assertFalse(filter.isIncluded("AAA"));
+        assertFalse(filter.isIncluded("Bbb"));
+
+        filter = new PatternFilter(true).include("^v_.*$");
+        assertTrue(filter.isIncluded("v_new_view"));
+        assertFalse(filter.isIncluded("V_new_view"));
+    }
+
+    public void testExcludeCaseSensitive() throws Exception {
+        PatternFilter filter = new PatternFilter(true)
+                .exclude("aaa")
+                .exclude("bbb");
+
+        assertTrue(filter.isIncluded("Aaa"));
+        assertTrue(filter.isIncluded("bbB"));
+        assertTrue(filter.isIncluded("AAA"));
+        assertTrue(filter.isIncluded("Bbb"));
+    }
+
+    public void testIncludeExcludeCaseSensitive() throws Exception {
+        PatternFilter filter = new PatternFilter(true)
+                .include("aa.*")
+                .exclude("aaa");
+
+        assertFalse(filter.isIncluded("aaa"));
+        assertTrue(filter.isIncluded("aaA"));
+        assertFalse(filter.isIncluded("bbb"));
+        assertFalse(filter.isIncluded("Aaaa"));
+        assertTrue(filter.isIncluded("aaAA"));
+        assertFalse(filter.isIncluded("abb"));
     }
 }

--- a/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/reverse/filters/TableFilterTest.java
+++ b/cayenne-dbsync/src/test/java/org/apache/cayenne/dbsync/reverse/filters/TableFilterTest.java
@@ -40,8 +40,8 @@ public class TableFilterTest {
     @Test
     public void testInclude() {
         TreeSet<IncludeTableFilter> includes = new TreeSet<>();
-        includes.add(new IncludeTableFilter("aaa"));
-        includes.add(new IncludeTableFilter("bb"));
+        includes.add(new IncludeTableFilter("aaa", false));
+        includes.add(new IncludeTableFilter("bb", false));
 
         TableFilter filter = new TableFilter(includes, new TreeSet<>(PatternFilter.PATTERN_COMPARATOR));
 
@@ -61,7 +61,7 @@ public class TableFilterTest {
         excludes.add(Pattern.compile("bb"));
 
         TreeSet<IncludeTableFilter> includes = new TreeSet<>();
-        includes.add(new IncludeTableFilter(null, PatternFilter.INCLUDE_EVERYTHING));
+        includes.add(new IncludeTableFilter(null, PatternFilter.INCLUDE_EVERYTHING, false));
 
         TableFilter filter = new TableFilter(includes, excludes);
 
@@ -81,7 +81,7 @@ public class TableFilterTest {
         excludes.add(Pattern.compile("bb"));
 
         TreeSet<IncludeTableFilter> includes = new TreeSet<>();
-        includes.add(new IncludeTableFilter("aa.*"));
+        includes.add(new IncludeTableFilter("aa.*", false));
 
         TableFilter filter = new TableFilter(includes, excludes);
 
@@ -97,8 +97,8 @@ public class TableFilterTest {
     @Test
     public void testGetTableFilter() {
         TreeSet<IncludeTableFilter> includes = new TreeSet<IncludeTableFilter>();
-        includes.add(new IncludeTableFilter("aaa"));
-        includes.add(new IncludeTableFilter("bb"));
+        includes.add(new IncludeTableFilter("aaa", false));
+        includes.add(new IncludeTableFilter("bb", false));
 
         TreeSet<Pattern> excludes = new TreeSet<>();
 
@@ -111,5 +111,81 @@ public class TableFilterTest {
         assertNotNull(filter.getIncludeTableColumnFilter("bb"));
         assertNull(filter.getIncludeTableColumnFilter(""));
         assertNull(filter.getIncludeTableColumnFilter("bbbb"));
+    }
+
+    @Test
+    public void testIncludeCaseSensitive() {
+        TreeSet<IncludeTableFilter> includes = new TreeSet<>();
+        includes.add(new IncludeTableFilter("aaa", true));
+        includes.add(new IncludeTableFilter("bb", true));
+
+        TableFilter filter = new TableFilter(includes, new TreeSet<>(PatternFilter.PATTERN_COMPARATOR));
+
+        assertTrue(filter.isIncludeTable("aaa"));
+        assertFalse(filter.isIncludeTable("aaA"));
+        assertFalse(filter.isIncludeTable("AAA"));
+
+        assertTrue(filter.isIncludeTable("bb"));
+        assertFalse(filter.isIncludeTable("Bb"));
+        assertFalse(filter.isIncludeTable("BB"));
+    }
+
+    @Test
+    public void testExcludeCaseSensitive() {
+        TreeSet<Pattern> excludes = new TreeSet<>(PatternFilter.PATTERN_COMPARATOR);
+        excludes.add(Pattern.compile("aaa"));
+        excludes.add(Pattern.compile("bb"));
+
+        TreeSet<IncludeTableFilter> includes = new TreeSet<>();
+        includes.add(new IncludeTableFilter(null, PatternFilter.INCLUDE_EVERYTHING, true));
+
+        TableFilter filter = new TableFilter(includes, excludes);
+
+        assertTrue(filter.isIncludeTable("aaA"));
+        assertTrue(filter.isIncludeTable("AAA"));
+        assertTrue(filter.isIncludeTable("aaaa"));
+
+        assertTrue(filter.isIncludeTable("bB"));
+        assertTrue(filter.isIncludeTable(""));
+        assertTrue(filter.isIncludeTable("bbbb"));
+    }
+
+    @Test
+    public void testIncludeExcludeCaseSensitive() {
+        TreeSet<Pattern> excludes = new TreeSet<>(PatternFilter.PATTERN_COMPARATOR);
+        excludes.add(Pattern.compile("aaa"));
+        excludes.add(Pattern.compile("bb"));
+
+        TreeSet<IncludeTableFilter> includes = new TreeSet<>();
+        includes.add(new IncludeTableFilter("aa.*", true));
+
+        TableFilter filter = new TableFilter(includes, excludes);
+
+        assertFalse(filter.isIncludeTable("aaa"));
+        assertTrue(filter.isIncludeTable("aa"));
+        assertTrue(filter.isIncludeTable("aaA"));
+
+        assertFalse(filter.isIncludeTable("bb"));
+        assertFalse(filter.isIncludeTable(""));
+        assertFalse(filter.isIncludeTable("bB"));
+    }
+
+    @Test
+    public void testGetTableFilterCaseSensitive() {
+        TreeSet<IncludeTableFilter> includes = new TreeSet<IncludeTableFilter>();
+        includes.add(new IncludeTableFilter("aaa", true));
+        includes.add(new IncludeTableFilter("bb", true));
+
+        TreeSet<Pattern> excludes = new TreeSet<>();
+
+        TableFilter filter = new TableFilter(includes, excludes);
+
+        assertNotNull(filter.getIncludeTableColumnFilter("aaa"));
+        assertNull(filter.getIncludeTableColumnFilter("aa"));
+        assertNull(filter.getIncludeTableColumnFilter("aaA"));
+
+        assertNotNull(filter.getIncludeTableColumnFilter("bb"));
+        assertNull(filter.getIncludeTableColumnFilter(""));
+        assertNull(filter.getIncludeTableColumnFilter("bB"));
     }
 }

--- a/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/DbImportTask.java
+++ b/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/DbImportTask.java
@@ -146,6 +146,7 @@ public class DbImportTask extends BaseCayenneTask {
         config.setForceDataMapSchema(reverseEngineering.isForceDataMapSchema());
         config.setDefaultPackage(reverseEngineering.getDefaultPackage());
         config.setUsePrimitives(reverseEngineering.isUsePrimitives());
+        config.setUseCaseSensitiveNaming(reverseEngineering.isUseCaseSensitiveNaming());
         config.setUseJava7Types(reverseEngineering.isUseJava7Types());
         config.setCayenneProject(cayenneProject);
 

--- a/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/model/DbImportConfig.java
+++ b/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/model/DbImportConfig.java
@@ -93,6 +93,12 @@ public class DbImportConfig extends SchemaContainer {
     private boolean usePrimitives = true;
 
     /**
+     * <p>If true, would use case sensitive naming.</p>
+     * <p>Default is <b>"false"</b>, i.e. case insensitive naming will be used.</p>
+     */
+    private boolean useCaseSensitiveNaming = false;
+
+    /**
      * Use old Java 7 date types
      */
     private boolean useJava7Types = false;
@@ -135,6 +141,7 @@ public class DbImportConfig extends SchemaContainer {
         reverseEngineering.setNamingStrategy(namingStrategy);
         reverseEngineering.setStripFromTableNames(stripFromTableNames);
         reverseEngineering.setUsePrimitives(usePrimitives);
+        reverseEngineering.setUseCaseSensitiveNaming(useCaseSensitiveNaming);
         reverseEngineering.setUseJava7Types(useJava7Types);
         reverseEngineering.setTableTypes(tableTypes);
 
@@ -257,6 +264,27 @@ public class DbImportConfig extends SchemaContainer {
 
     public void usePrimitives(boolean usePrimitives) {
         setUsePrimitives(usePrimitives);
+    }
+
+    /**
+     * @since 4.2
+     */
+    public boolean isUseCaseSensitiveNaming() {
+        return useCaseSensitiveNaming;
+    }
+
+    /**
+     * @since 4.2
+     */
+    public void setUseCaseSensitiveNaming(boolean useCaseSensitiveNaming) {
+        this.useCaseSensitiveNaming = useCaseSensitiveNaming;
+    }
+
+    /**
+     * @since 4.2
+     */
+    public void useCaseSensitiveNaming(boolean useCaseSensitiveNaming) {
+        setUseCaseSensitiveNaming(useCaseSensitiveNaming);
     }
 
     public boolean isUseJava7Types() {

--- a/cayenne-server/src/main/java/org/apache/cayenne/dba/DefaultQuotingStrategy.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/dba/DefaultQuotingStrategy.java
@@ -89,7 +89,7 @@ public class DefaultQuotingStrategy implements QuotingStrategy {
         StringBuilder buffer = new StringBuilder();
 
         for (String part : identifierParts) {
-            if (part == null) {
+            if (part == null || part.isEmpty()) {
                 continue;
             }
             if (buffer.length() > 0) {

--- a/cayenne-server/src/main/resources/org/apache/cayenne/schema/10/dbimport.xsd
+++ b/cayenne-server/src/main/resources/org/apache/cayenne/schema/10/dbimport.xsd
@@ -42,6 +42,7 @@
                         <xs:element name="stripFromTableNames" minOccurs="0" type="xs:string"/>
                         <xs:element name="useJava7Types" minOccurs="0" type="xs:boolean"/>
                         <xs:element name="usePrimitives" minOccurs="0" type="xs:boolean"/>
+                        <xs:element name="useCaseSensitiveNaming" minOccurs="0" type="xs:boolean"/>
 
                         <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other" processContents="lax"/>
                     </xs:sequence>

--- a/cayenne-server/src/test/java/org/apache/cayenne/unit/SQLiteUnitDbAdapter.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/unit/SQLiteUnitDbAdapter.java
@@ -49,4 +49,8 @@ public class SQLiteUnitDbAdapter extends UnitDbAdapter {
     public boolean supportsEscapeInLike() {
         return false;
     }
+
+    public boolean onlyGenericNumberType() {
+        return true;
+    }
 }

--- a/cayenne-server/src/test/java/org/apache/cayenne/unit/di/server/ServerCaseDataSourceInfoProvider.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/unit/di/server/ServerCaseDataSourceInfoProvider.java
@@ -111,7 +111,7 @@ public class ServerCaseDataSourceInfoProvider implements Provider<DataSourceInfo
         sqlite.setAdapterClassName(SQLiteAdapter.class.getName());
         sqlite.setUserName("sa");
         sqlite.setPassword("");
-        sqlite.setDataSourceUrl("jdbc:sqlite:file:memdb?mode=memory&cache=shared&date_class=text");
+        sqlite.setDataSourceUrl("jdbc:sqlite:file:memdb?mode=memory&cache=shared&date_class=text&limit_compound_select=0");
         sqlite.setJdbcDriver("org.sqlite.JDBC");
         sqlite.setMinConnections(ConnectionProperties.MIN_CONNECTIONS);
         sqlite.setMaxConnections(ConnectionProperties.MAX_CONNECTIONS);

--- a/docs/asciidoc/cayenne-guide/src/docs/asciidoc/_cayenne-guide/part4/revEngineering.adoc
+++ b/docs/asciidoc/cayenne-guide/src/docs/asciidoc/_cayenne-guide/part4/revEngineering.adoc
@@ -57,6 +57,8 @@ Here is a list of options to tune what will be processed by reverse engineering:
 
 - *Use Java primitive types*: Use primitive types (e.g. *int*) or Object types (e.g. *java.lang.Integer*).
 
+- *Use case sensitive naming*: Use case sensitive naming (e.g. "Name", "NAME") for tables, attributes etc.
+
 - *Use old java.util.Date type*: Use *java.util.Date* for all columns with *DATE/TIME/TIMESTAMP* types. By default *java.time.* types will be used.
 
 ==== DataSource selection

--- a/docs/asciidoc/cayenne-guide/src/docs/asciidoc/_cayenne-guide/part6/gradle-plugin.adoc
+++ b/docs/asciidoc/cayenne-guide/src/docs/asciidoc/_cayenne-guide/part6/gradle-plugin.adoc
@@ -96,6 +96,7 @@ cdbimport {
     dbImport {
         // additional settings
         usePrimitives false
+        useCaseSensitiveNaming true
         defaultPackage 'org.apache.cayenne.test'
 
         // DB filter configuration

--- a/docs/asciidoc/cayenne-guide/src/docs/asciidoc/_cayenne-guide/part6/maven-plugin.adoc
+++ b/docs/asciidoc/cayenne-guide/src/docs/asciidoc/_cayenne-guide/part6/maven-plugin.adoc
@@ -263,6 +263,10 @@ a|Regex that matches the part of the table name that needs to be stripped off wh
 .^|boolean
 .^|Whether numeric and boolean data types should be mapped as Java primitives or Java classes. Default is "true", i.e. primitives will be used.
 
+.^|useCaseSensitiveNaming
+.^|boolean
+.^|If the database uses case-sensitive naming, this option helps to convey the same names with different case-type letters. The default is "false", i.e. case-insensitive naming will be used. Note that if the database uses different case-type letters, merges are possible without this option.
+
 .^|useJava7Types
 .^|boolean
 .^|Whether _DATE_, _TIME_ and _TIMESTAMP_ data types should be mapped as `java.util.Date` or `java.time.* classes`. Default is "false", i.e. `java.time.*` will be used.
@@ -320,6 +324,7 @@ Example - loading a DB schema from a local HSQLDB database (essentially a revers
                 </dataSource>
                 <dbimport>
                     <defaultPackage>com.example.cayenne</defaultPackage>
+                    <useCaseSensitiveNaming>true</useCaseSensitiveNaming>
                 </dbimport>
             </configuration>
             <goals>

--- a/maven-plugins/cayenne-maven-plugin/src/main/java/org/apache/cayenne/tools/DbImporterMojo.java
+++ b/maven-plugins/cayenne-maven-plugin/src/main/java/org/apache/cayenne/tools/DbImporterMojo.java
@@ -177,6 +177,7 @@ public class DbImporterMojo extends AbstractMojo {
         config.setUrl(dataSource.getUrl());
         config.setUsername(dataSource.getUsername());
         config.setUsePrimitives(dbImportConfig.isUsePrimitives());
+        config.setUseCaseSensitiveNaming(dbImportConfig.isUseCaseSensitiveNaming());
         config.setUseJava7Types(dbImportConfig.isUseJava7Types());
 
         return config;

--- a/maven-plugins/cayenne-maven-plugin/src/test/java/org/apache/cayenne/tools/DbImporterMojoConfigurationTest.java
+++ b/maven-plugins/cayenne-maven-plugin/src/test/java/org/apache/cayenne/tools/DbImporterMojoConfigurationTest.java
@@ -76,10 +76,10 @@ public class DbImporterMojoConfigurationTest extends AbstractMojoTestCase {
         FiltersConfig filters = dbImportConfiguration.getDbLoaderConfig().getFiltersConfig();
 
         TreeSet<IncludeTableFilter> includes = new TreeSet<>();
-        includes.add(new IncludeTableFilter(null, new PatternFilter().exclude("^ETL_.*")));
+        includes.add(new IncludeTableFilter(null, new PatternFilter(false).exclude("^ETL_.*"), false));
 
         TreeSet<Pattern> excludes = new TreeSet<>(PatternFilter.PATTERN_COMPARATOR);
-        excludes.add(PatternFilter.pattern("^ETL_.*"));
+        excludes.add(PatternFilter.pattern("^ETL_.*", false));
 
         assertEquals(filters.tableFilter(null, "NHL_STATS"),
                 new TableFilter(includes, excludes));

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testConfigFromDataMap.map.xml-result
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testConfigFromDataMap.map.xml-result
@@ -44,5 +44,6 @@
 		<skipRelationshipsLoading>false</skipRelationshipsLoading>
 		<useJava7Types>false</useJava7Types>
 		<usePrimitives>true</usePrimitives>
+		<useCaseSensitiveNaming>false</useCaseSensitiveNaming>
 	</dbImport>
 </data-map>

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportAddColumnCaseSensitiveNaming-pom.xml
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportAddColumnCaseSensitiveNaming-pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	Licensed to the Apache Software Foundation (ASF) under one
+	or more contributor license agreements.  See the NOTICE file
+	distributed with this work for additional information
+	regarding copyright ownership.  The ASF licenses this file
+	to you under the Apache License, Version 2.0 (the
+	"License"); you may not use this file except in compliance
+	with the License.  You may obtain a copy of the License at
+	
+	https://www.apache.org/licenses/LICENSE-2.0
+	
+	Unless required by applicable law or agreed to in writing,
+	software distributed under the License is distributed on an
+	"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+	KIND, either express or implied.  See the License for the
+	specific language governing permissions and limitations
+	under the License.   
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+	http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<name>DbImporterMojo Test1</name>
+	<groupId>org.apache.maven.plugin-testing</groupId>
+	<artifactId>maven-plugin-testing</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<modelVersion>4.0.0</modelVersion>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>cayenne-maven-plugin</artifactId>
+				<configuration>
+					<map>target/test-classes/org/apache/cayenne/tools/dbimport/testImportAddColumnCaseSensitiveNaming.map.xml</map>
+					<dataSource>
+						<driver>org.apache.derby.jdbc.EmbeddedDriver</driver>
+						<url>jdbc:derby:memory:DbImporterMojoTest;create=true</url>
+					</dataSource>
+					<project implementation="org.apache.cayenne.stubs.CayenneProjectStub"/>
+
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportAddColumnCaseSensitiveNaming.map.xml
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportAddColumnCaseSensitiveNaming.map.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+	Licensed to the Apache Software Foundation (ASF) under one
+	or more contributor license agreements.  See the NOTICE file
+	distributed with this work for additional information
+	regarding copyright ownership.  The ASF licenses this file
+	to you under the Apache License, Version 2.0 (the
+	"License"); you may not use this file except in compliance
+	with the License.  You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing,
+	software distributed under the License is distributed on an
+	"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+	KIND, either express or implied.  See the License for the
+	specific language governing permissions and limitations
+	under the License.
+-->
+<data-map xmlns="http://cayenne.apache.org/schema/10/modelMap"
+	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	 xsi:schemaLocation="http://cayenne.apache.org/schema/10/modelMap http://cayenne.apache.org/schema/10/modelMap.xsd"
+	 project-version="10">
+	<db-entity name="CHILD" schema="APP">
+		<db-attribute name="COL1" type="INTEGER" isPrimaryKey="true" isMandatory="true" length="10"/>
+		<db-attribute name="COL2" type="CHAR" length="25"/>
+		<db-attribute name="col3" type="DECIMAL" length="10" scale="2"/>
+	</db-entity>
+	<obj-entity name="Child" className="Child" dbEntityName="CHILD">
+		<obj-attribute name="col2" type="java.lang.String" db-attribute-path="COL2"/>
+		<obj-attribute name="col3" type="java.math.BigDecimal" db-attribute-path="COL3"/>
+	</obj-entity>
+</data-map>

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportAddColumnCaseSensitiveNaming.map.xml-result
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportAddColumnCaseSensitiveNaming.map.xml-result
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+	Licensed to the Apache Software Foundation (ASF) under one
+	or more contributor license agreements.  See the NOTICE file
+	distributed with this work for additional information
+	regarding copyright ownership.  The ASF licenses this file
+	to you under the Apache License, Version 2.0 (the
+	"License"); you may not use this file except in compliance
+	with the License.  You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing,
+	software distributed under the License is distributed on an
+	"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+	KIND, either express or implied.  See the License for the
+	specific language governing permissions and limitations
+	under the License.
+-->
+<data-map xmlns="http://cayenne.apache.org/schema/10/modelMap"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://cayenne.apache.org/schema/10/modelMap http://cayenne.apache.org/schema/10/modelMap.xsd"
+          project-version="10">
+    <db-entity name="CHILD" schema="APP">
+        <db-attribute name="COL2" type="CHAR" length="25"/>
+        <db-attribute name="COL3" type="DECIMAL" length="10" scale="2"/>
+        <db-attribute name="ID" type="INTEGER" isPrimaryKey="true" isMandatory="true" length="10"/>
+    </db-entity>
+    <db-entity name="child" schema="APP">
+        <db-attribute name="COL2" type="CHAR" length="25"/>
+        <db-attribute name="col2" type="DECIMAL" length="10" scale="2"/>
+        <db-attribute name="ID" type="INTEGER" isPrimaryKey="true" isMandatory="true" length="10"/>
+    </db-entity>
+    <obj-entity name="Child" className="Child" dbEntityName="CHILD">
+        <obj-attribute name="col2" type="java.lang.String" db-attribute-path="COL2"/>
+        <obj-attribute name="col3" type="java.math.BigDecimal" db-attribute-path="COL3"/>
+    </obj-entity>
+    <obj-entity name="Child1" className="Child1" dbEntityName="child">
+        <obj-attribute name="col2" type="java.lang.String" db-attribute-path="COL2"/>
+        <obj-attribute name="col21" type="java.math.BigDecimal" db-attribute-path="col2"/>
+    </obj-entity>
+</data-map>

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportAddColumnCaseSensitiveNaming.sql
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportAddColumnCaseSensitiveNaming.sql
@@ -1,0 +1,33 @@
+--  Licensed to the Apache Software Foundation (ASF) under one
+--  or more contributor license agreements.  See the NOTICE file
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+--  to you under the Apache License, Version 2.0 (the
+--  "License"); you may not use this file except in compliance
+--  with the License.  You may obtain a copy of the License at
+--
+--    https://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing,
+--  software distributed under the License is distributed on an
+--  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+--  KIND, either express or implied.  See the License for the
+--  specific language governing permissions and limitations
+--  under the License.
+
+CREATE TABLE "CHILD" (
+  id INTEGER NOT NULL,
+  COL2 CHAR(25),
+  COL3 DECIMAL(10,2),
+
+  PRIMARY KEY (id),
+  UNIQUE (COL3)
+);
+
+CREATE TABLE "child" (
+  id INTEGER NOT NULL,
+  "COL2" CHAR(25),
+  "col2" DECIMAL(10,2),
+
+  PRIMARY KEY (id)
+);

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportAddTableCaseSensitiveNaming-pom.xml
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportAddTableCaseSensitiveNaming-pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	Licensed to the Apache Software Foundation (ASF) under one
+	or more contributor license agreements.  See the NOTICE file
+	distributed with this work for additional information
+	regarding copyright ownership.  The ASF licenses this file
+	to you under the Apache License, Version 2.0 (the
+	"License"); you may not use this file except in compliance
+	with the License.  You may obtain a copy of the License at
+	
+	https://www.apache.org/licenses/LICENSE-2.0
+	
+	Unless required by applicable law or agreed to in writing,
+	software distributed under the License is distributed on an
+	"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+	KIND, either express or implied.  See the License for the
+	specific language governing permissions and limitations
+	under the License.   
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+	http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<name>DbImporterMojo Test1</name>
+	<groupId>org.apache.maven.plugin-testing</groupId>
+	<artifactId>maven-plugin-testing</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<modelVersion>4.0.0</modelVersion>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>cayenne-maven-plugin</artifactId>
+				<configuration>
+					<map>target/test-classes/org/apache/cayenne/tools/dbimport/testImportAddTableCaseSensitiveNaming.map.xml</map>
+					<dataSource>
+						<driver>org.apache.derby.jdbc.EmbeddedDriver</driver>
+						<url>jdbc:derby:memory:DbImporterMojoTest;create=true</url>
+					</dataSource>
+					<project implementation="org.apache.cayenne.stubs.CayenneProjectStub"/>
+
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportAddTableCaseSensitiveNaming.map.xml
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportAddTableCaseSensitiveNaming.map.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+	Licensed to the Apache Software Foundation (ASF) under one
+	or more contributor license agreements.  See the NOTICE file
+	distributed with this work for additional information
+	regarding copyright ownership.  The ASF licenses this file
+	to you under the Apache License, Version 2.0 (the
+	"License"); you may not use this file except in compliance
+	with the License.  You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing,
+	software distributed under the License is distributed on an
+	"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+	KIND, either express or implied.  See the License for the
+	specific language governing permissions and limitations
+	under the License.
+-->
+<data-map xmlns="http://cayenne.apache.org/schema/10/modelMap"
+	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	 xsi:schemaLocation="http://cayenne.apache.org/schema/10/modelMap http://cayenne.apache.org/schema/10/modelMap.xsd"
+	 project-version="10">
+	<db-entity name="CHILD" schema="APP">
+		<db-attribute name="COL1" type="INTEGER" isPrimaryKey="true" isMandatory="true" length="10"/>
+		<db-attribute name="COL2" type="CHAR" length="25"/>
+		<db-attribute name="col3" type="DECIMAL" length="10" scale="2"/>
+	</db-entity>
+	<obj-entity name="Child" className="Child" dbEntityName="CHILD">
+		<obj-attribute name="col2" type="java.lang.String" db-attribute-path="COL2"/>
+		<obj-attribute name="col3" type="java.math.BigDecimal" db-attribute-path="COL3"/>
+	</obj-entity>
+</data-map>

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportAddTableCaseSensitiveNaming.map.xml-result
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportAddTableCaseSensitiveNaming.map.xml-result
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+	Licensed to the Apache Software Foundation (ASF) under one
+	or more contributor license agreements.  See the NOTICE file
+	distributed with this work for additional information
+	regarding copyright ownership.  The ASF licenses this file
+	to you under the Apache License, Version 2.0 (the
+	"License"); you may not use this file except in compliance
+	with the License.  You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing,
+	software distributed under the License is distributed on an
+	"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+	KIND, either express or implied.  See the License for the
+	specific language governing permissions and limitations
+	under the License.
+-->
+<data-map xmlns="http://cayenne.apache.org/schema/10/modelMap"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://cayenne.apache.org/schema/10/modelMap http://cayenne.apache.org/schema/10/modelMap.xsd"
+          project-version="10">
+    <db-entity name="CHILD" schema="APP">
+        <db-attribute name="COL2" type="CHAR" length="25"/>
+        <db-attribute name="COL3" type="DECIMAL" length="10" scale="2"/>
+        <db-attribute name="ID" type="INTEGER" isPrimaryKey="true" isMandatory="true" length="10"/>
+    </db-entity>
+    <db-entity name="child" schema="APP">
+        <db-attribute name="COL2" type="CHAR" length="25"/>
+        <db-attribute name="COL3" type="DECIMAL" length="10" scale="2"/>
+        <db-attribute name="ID" type="INTEGER" isPrimaryKey="true" isMandatory="true" length="10"/>
+    </db-entity>
+    <obj-entity name="Child" className="Child" dbEntityName="CHILD">
+        <obj-attribute name="col2" type="java.lang.String" db-attribute-path="COL2"/>
+        <obj-attribute name="col3" type="java.math.BigDecimal" db-attribute-path="COL3"/>
+    </obj-entity>
+    <obj-entity name="Child1" className="Child1" dbEntityName="child">
+        <obj-attribute name="col2" type="java.lang.String" db-attribute-path="COL2"/>
+        <obj-attribute name="col3" type="java.math.BigDecimal" db-attribute-path="COL3"/>
+    </obj-entity>
+</data-map>

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportAddTableCaseSensitiveNaming.sql
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportAddTableCaseSensitiveNaming.sql
@@ -1,0 +1,33 @@
+--  Licensed to the Apache Software Foundation (ASF) under one
+--  or more contributor license agreements.  See the NOTICE file
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+--  to you under the Apache License, Version 2.0 (the
+--  "License"); you may not use this file except in compliance
+--  with the License.  You may obtain a copy of the License at
+--
+--    https://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing,
+--  software distributed under the License is distributed on an
+--  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+--  KIND, either express or implied.  See the License for the
+--  specific language governing permissions and limitations
+--  under the License.
+
+CREATE TABLE "CHILD" (
+  id INTEGER NOT NULL,
+  COL2 CHAR(25),
+  COL3 DECIMAL(10,2),
+
+  PRIMARY KEY (id),
+  UNIQUE (COL3)
+);
+
+CREATE TABLE "child" (
+  id INTEGER NOT NULL,
+  COL2 CHAR(25),
+  COL3 DECIMAL(10,2),
+
+  PRIMARY KEY (id)
+);

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportNewRelationshipCaseSensitiveNaming-pom.xml
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportNewRelationshipCaseSensitiveNaming-pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~   Licensed to the Apache Software Foundation (ASF) under one
+  ~  or more contributor license agreements.  See the NOTICE file
+  ~  distributed with this work for additional information
+  ~  regarding copyright ownership.  The ASF licenses this file
+  ~  to you under the Apache License, Version 2.0 (the
+  ~  "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~    https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+	http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <name>DbImporterMojo Test1</name>
+    <groupId>org.apache.maven.plugin-testing</groupId>
+    <artifactId>maven-plugin-testing</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <modelVersion>4.0.0</modelVersion>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>cayenne-maven-plugin</artifactId>
+                <configuration>
+                    <map>target/test-classes/org/apache/cayenne/tools/dbimport/testImportNewRelationshipCaseSensitiveNaming.map.xml</map>
+                    <dataSource>
+                        <driver>org.apache.derby.jdbc.EmbeddedDriver</driver>
+                        <url>jdbc:derby:memory:DbImporterMojoTest;create=true</url>
+                    </dataSource>
+                    <dbimport>
+                        <schema>SCHEMA_01</schema>
+                    </dbimport>
+                    <project implementation="org.apache.cayenne.stubs.CayenneProjectStub"/>
+
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportNewRelationshipCaseSensitiveNaming.map.xml
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportNewRelationshipCaseSensitiveNaming.map.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+	Licensed to the Apache Software Foundation (ASF) under one
+	or more contributor license agreements.  See the NOTICE file
+	distributed with this work for additional information
+	regarding copyright ownership.  The ASF licenses this file
+	to you under the Apache License, Version 2.0 (the
+	"License"); you may not use this file except in compliance
+	with the License.  You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing,
+	software distributed under the License is distributed on an
+	"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+	KIND, either express or implied.  See the License for the
+	specific language governing permissions and limitations
+	under the License.
+-->
+<data-map xmlns="http://cayenne.apache.org/schema/10/modelMap"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://cayenne.apache.org/schema/10/modelMap http://cayenne.apache.org/schema/10/modelMap.xsd"
+          project-version="10">
+    <property name="defaultSchema" value="SCHEMA_01"/>
+    <db-entity name="TABLE1" schema="SCHEMA_01">
+        <db-attribute name="ID" type="INTEGER" isPrimaryKey="true" isMandatory="true" length="10"/>
+        <db-attribute name="T1_NAME" type="VARCHAR" length="45"/>
+    </db-entity>
+    <obj-entity name="Table1" className="Table1" dbEntityName="TABLE1">
+        <obj-attribute name="t1Name" type="java.lang.String" db-attribute-path="T1_NAME"/>
+    </obj-entity>
+</data-map>

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportNewRelationshipCaseSensitiveNaming.map.xml-result
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportNewRelationshipCaseSensitiveNaming.map.xml-result
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~   Licensed to the Apache Software Foundation (ASF) under one
+  ~  or more contributor license agreements.  See the NOTICE file
+  ~  distributed with this work for additional information
+  ~  regarding copyright ownership.  The ASF licenses this file
+  ~  to you under the Apache License, Version 2.0 (the
+  ~  "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~    https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<data-map xmlns="http://cayenne.apache.org/schema/10/modelMap"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://cayenne.apache.org/schema/10/modelMap http://cayenne.apache.org/schema/10/modelMap.xsd"
+          project-version="10">
+    <property name="defaultSchema" value="SCHEMA_01"/>
+    <db-entity name="TABLE1" schema="SCHEMA_01">
+        <db-attribute name="ID" type="INTEGER" isPrimaryKey="true" isMandatory="true" length="10"/>
+        <db-attribute name="T1_NAME" type="VARCHAR" length="45"/>
+    </db-entity>
+    <db-entity name="TABLE2" schema="SCHEMA_01">
+        <db-attribute name="ID" type="INTEGER" isPrimaryKey="true" isMandatory="true" length="10"/>
+        <db-attribute name="T2_NAME" type="VARCHAR" length="45"/>
+        <db-attribute name="TABLE1_id" type="INTEGER" isMandatory="true" length="10"/>
+        <db-attribute name="table1_id" type="INTEGER" isMandatory="true" length="10"/>
+    </db-entity>
+    <db-entity name="table1" schema="SCHEMA_01">
+        <db-attribute name="ID" type="INTEGER" isPrimaryKey="true" isMandatory="true" length="10"/>
+        <db-attribute name="T3_NAME" type="VARCHAR" length="45"/>
+    </db-entity>
+    <obj-entity name="Table1" className="Table1" dbEntityName="TABLE1">
+        <obj-attribute name="t1Name" type="java.lang.String" db-attribute-path="T1_NAME"/>
+    </obj-entity>
+    <obj-entity name="Table11" className="Table11" dbEntityName="table1">
+        <obj-attribute name="t3Name" type="java.lang.String" db-attribute-path="T3_NAME"/>
+    </obj-entity>
+    <obj-entity name="Table2" className="Table2" dbEntityName="TABLE2">
+        <obj-attribute name="t2Name" type="java.lang.String" db-attribute-path="T2_NAME"/>
+    </obj-entity>
+    <db-relationship name="table2s" source="TABLE1" target="TABLE2" toMany="true">
+        <db-attribute-pair source="ID" target="TABLE1_id"/>
+    </db-relationship>
+    <db-relationship name="table1" source="TABLE2" target="table1">
+        <db-attribute-pair source="table1_id" target="ID"/>
+    </db-relationship>
+    <db-relationship name="table11" source="TABLE2" target="TABLE1">
+        <db-attribute-pair source="TABLE1_id" target="ID"/>
+    </db-relationship>
+    <db-relationship name="table2s" source="table1" target="TABLE2" toMany="true">
+        <db-attribute-pair source="ID" target="table1_id"/>
+    </db-relationship>
+    <obj-relationship name="table2s" source="Table1" target="Table2" deleteRule="Deny" db-relationship-path="table2s"/>
+    <obj-relationship name="table2s" source="Table11" target="Table2" deleteRule="Deny" db-relationship-path="table2s"/>
+    <obj-relationship name="table1" source="Table2" target="Table11" deleteRule="Nullify" db-relationship-path="table1"/>
+    <obj-relationship name="table11" source="Table2" target="Table1" deleteRule="Nullify" db-relationship-path="table11"/>
+</data-map>

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportNewRelationshipCaseSensitiveNaming.sql
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportNewRelationshipCaseSensitiveNaming.sql
@@ -1,0 +1,41 @@
+--  Licensed to the Apache Software Foundation (ASF) under one
+--  or more contributor license agreements.  See the NOTICE file
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+--  to you under the Apache License, Version 2.0 (the
+--  "License"); you may not use this file except in compliance
+--  with the License.  You may obtain a copy of the License at
+--
+--    https://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing,
+--  software distributed under the License is distributed on an
+--  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+--  KIND, either express or implied.  See the License for the
+--  specific language governing permissions and limitations
+--  under the License.
+
+CREATE SCHEMA schema_01;
+SET SCHEMA schema_01;
+
+CREATE TABLE schema_01."TABLE1" (
+    id INTEGER  NOT NULL,
+    t1_name VARCHAR (45),
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE schema_01."table1" (
+    id INTEGER  NOT NULL,
+    t3_name VARCHAR (45),
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE schema_01.table2 (
+    id INTEGER  NOT NULL,
+    t2_name VARCHAR (45),
+    "TABLE1_id" INTEGER  NOT NULL,
+    "table1_id" INTEGER  NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_table2_table1b_id FOREIGN KEY ("TABLE1_id") REFERENCES schema_01."TABLE1" (id),
+    CONSTRAINT fk_table2_table1_id FOREIGN KEY ("table1_id") REFERENCES schema_01."table1" (id)
+);

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportProcedureCaseSensitiveNaming-pom.xml
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportProcedureCaseSensitiveNaming-pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~   Licensed to the Apache Software Foundation (ASF) under one
+  ~  or more contributor license agreements.  See the NOTICE file
+  ~  distributed with this work for additional information
+  ~  regarding copyright ownership.  The ASF licenses this file
+  ~  to you under the Apache License, Version 2.0 (the
+  ~  "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~    https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+	http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <name>DbImporterMojo Test1</name>
+    <groupId>org.apache.maven.plugin-testing</groupId>
+    <artifactId>maven-plugin-testing</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <modelVersion>4.0.0</modelVersion>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>cayenne-maven-plugin</artifactId>
+                <configuration>
+                    <map>target/test-classes/org/apache/cayenne/tools/dbimport/testImportProcedureCaseSensitiveNaming.map.xml</map>
+                    <dataSource>
+                        <driver>org.apache.derby.jdbc.EmbeddedDriver</driver>
+                        <url>jdbc:derby:memory:DbImporterMojoTest;create=true</url>
+                    </dataSource>
+                    <dbImport>
+                        <includeTable>.*</includeTable>
+                        <includeProcedure>PRO.</includeProcedure>
+                    </dbImport>
+                    <project implementation="org.apache.cayenne.stubs.CayenneProjectStub"/>
+
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportProcedureCaseSensitiveNaming.map.xml
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportProcedureCaseSensitiveNaming.map.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~   Licensed to the Apache Software Foundation (ASF) under one
+  ~  or more contributor license agreements.  See the NOTICE file
+  ~  distributed with this work for additional information
+  ~  regarding copyright ownership.  The ASF licenses this file
+  ~  to you under the Apache License, Version 2.0 (the
+  ~  "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~    https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<data-map xmlns="http://cayenne.apache.org/schema/10/modelMap"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://cayenne.apache.org/schema/10/modelMap https://cayenne.apache.org/schema/10/modelMap.xsd"
+          project-version="10">
+    <db-entity name="TABLE1" schema="SCHEMA_01">
+        <db-attribute name="ID" type="INTEGER" isPrimaryKey="true" isMandatory="true" length="10"/>
+        <db-attribute name="T1_NAME" type="VARCHAR" length="45"/>
+    </db-entity>
+    <obj-entity name="Table1" className="Table1" dbEntityName="TABLE1">
+        <obj-attribute name="t1Name" type="java.lang.String" db-attribute-path="T1_NAME"/>
+    </obj-entity>
+</data-map>

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportProcedureCaseSensitiveNaming.map.xml-result
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportProcedureCaseSensitiveNaming.map.xml-result
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~   Licensed to the Apache Software Foundation (ASF) under one
+  ~  or more contributor license agreements.  See the NOTICE file
+  ~  distributed with this work for additional information
+  ~  regarding copyright ownership.  The ASF licenses this file
+  ~  to you under the Apache License, Version 2.0 (the
+  ~  "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~    https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<data-map xmlns="http://cayenne.apache.org/schema/10/modelMap"
+	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	 xsi:schemaLocation="http://cayenne.apache.org/schema/10/modelMap https://cayenne.apache.org/schema/10/modelMap.xsd"
+	 project-version="10">
+	<procedure name="PROc" schema="SCHEMA_01">
+	    <procedure-parameter name="TEST" type="INTEGER" length="4" direction="in"/>
+    	<procedure-parameter name="TOTAL" type="DECIMAL" length="24" precision="2" direction="out"/>
+    </procedure>
+	<db-entity name="TABLE2" schema="SCHEMA_01">
+		<db-attribute name="ID" type="INTEGER" isPrimaryKey="true" isMandatory="true" length="10"/>
+		<db-attribute name="T1_NAME" type="VARCHAR" length="45"/>
+	</db-entity>
+	<obj-entity name="Table2" className="Table2" dbEntityName="TABLE2">
+		<obj-attribute name="t1Name" type="java.lang.String" db-attribute-path="T1_NAME"/>
+	</obj-entity>
+</data-map>

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportProcedureCaseSensitiveNaming.sql
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testImportProcedureCaseSensitiveNaming.sql
@@ -1,0 +1,29 @@
+--  Licensed to the Apache Software Foundation (ASF) under one
+--  or more contributor license agreements.  See the NOTICE file
+--  distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+--  to you under the Apache License, Version 2.0 (the
+--  "License"); you may not use this file except in compliance
+--  with the License.  You may obtain a copy of the License at
+--
+--    https://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing,
+--  software distributed under the License is distributed on an
+--  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+--  KIND, either express or implied.  See the License for the
+--  specific language governing permissions and limitations
+--  under the License.
+
+CREATE SCHEMA schema_01;
+SET SCHEMA schema_01;
+
+CREATE TABLE schema_01.table2 (
+    id INTEGER  NOT NULL,
+    t1_name VARCHAR (45),
+    PRIMARY KEY (id)
+);
+
+CREATE PROCEDURE "PROc"(IN test INTEGER, OUT TOTAL DECIMAL(10,2))
+PARAMETER STYLE JAVA READS SQL DATA LANGUAGE JAVA EXTERNAL NAME
+'org.apache.cayenne.test';

--- a/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testTableTypesMap.map.xml-result
+++ b/maven-plugins/cayenne-maven-plugin/src/test/resources/org/apache/cayenne/tools/dbimport/testTableTypesMap.map.xml-result
@@ -37,5 +37,6 @@
            <skipRelationshipsLoading>false</skipRelationshipsLoading>
            <useJava7Types>false</useJava7Types>
            <usePrimitives>true</usePrimitives>
+	       <useCaseSensitiveNaming>false</useCaseSensitiveNaming>
     </dbImport>
 </data-map>

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/db/load/DbLoaderContext.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/db/load/DbLoaderContext.java
@@ -117,6 +117,7 @@ public class DbLoaderContext {
 
     private void fillReverseEngineeringFromView(ReverseEngineering reverseEngineering, DbImportView view) {
         reverseEngineering.setUsePrimitives(view.isUsePrimitives());
+        reverseEngineering.setUseCaseSensitiveNaming(view.isUseCaseSensitiveNaming());
         reverseEngineering.setUseJava7Types(view.isUseJava7Typed());
         reverseEngineering.setForceDataMapCatalog(view.isForceDataMapCatalog());
         reverseEngineering.setForceDataMapSchema(view.isForceDataMapSchema());
@@ -180,6 +181,7 @@ public class DbLoaderContext {
         config.setDefaultPackage(reverseEngineering.getDefaultPackage());
         config.setStripFromTableNames(reverseEngineering.getStripFromTableNames());
         config.setUsePrimitives(reverseEngineering.isUsePrimitives());
+        config.setUseCaseSensitiveNaming(reverseEngineering.isUseCaseSensitiveNaming());
         config.setUseJava7Types(reverseEngineering.isUseJava7Types());
         config.setForceDataMapCatalog(reverseEngineering.isForceDataMapCatalog());
         config.setForceDataMapSchema(reverseEngineering.isForceDataMapSchema());

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/db/merge/MergerOptions.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/db/merge/MergerOptions.java
@@ -73,6 +73,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.Function;
 
 public class MergerOptions extends CayenneController {
 
@@ -162,6 +163,7 @@ public class MergerOptions extends CayenneController {
 
             DataMapMerger merger = DataMapMerger.builder(mergerTokenFactory)
                     .filters(filters)
+                    .nameConverter(Function.identity())
                     .build();
 
             DbLoaderConfiguration config = new DbLoaderConfiguration();
@@ -174,7 +176,8 @@ public class MergerOptions extends CayenneController {
                 dbImport = new DbLoader(adapter, conn,
                         config,
                         new LoggingDbLoaderDelegate(LoggerFactory.getLogger(DbLoader.class)),
-                        new DefaultObjectNameGenerator(NoStemStemmer.getInstance()))
+                        new DefaultObjectNameGenerator(NoStemStemmer.getInstance()),
+                        Function.identity())
                         .load();
             } catch (SQLException e) {
                 throw new CayenneRuntimeException("Can't doLoad dataMap from db.", e);

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/db/merge/MergerOptions.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/dialog/db/merge/MergerOptions.java
@@ -251,7 +251,12 @@ public class MergerOptions extends CayenneController {
      * Performs configured schema operations via DbGenerator.
      */
     public void generateSchemaAction() {
-        refreshGeneratorAction();
+        try {
+            refreshGeneratorAction();
+        } catch (CayenneRuntimeException ex) {
+            reportError("SQL query creating Error", ex);
+            return;
+        }
 
         // sanity check...
         List<MergerToken> tokensToMigrate = tokens.getSelectedTokens();

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/SelectionModel.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/SelectionModel.java
@@ -165,9 +165,23 @@ class SelectionModel {
         selectedEntities.remove(objEntity.getName());
     }
 
+    /**
+     * @since 4.2
+     */
+    void removeFromSelectedEntities(String oldName) {
+        selectedEntities.remove(oldName);
+    }
+
     void removeFromSelectedEmbeddables(Embeddable embeddable) {
         initCollectionsForSelection(embeddable.getDataMap());
         selectedEmbeddables.remove(embeddable.getClassName());
+    }
+
+    /**
+     * @since 4.2
+     */
+    void removeFromSelectedEmbeddables(String oldName) {
+        selectedEmbeddables.remove(oldName);
     }
 
     void addSelectedEntities(Collection<String> entities) {

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/dbimport/DbImportView.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/dbimport/DbImportView.java
@@ -245,6 +245,13 @@ public class DbImportView extends JPanel {
         return configPanel.getUsePrimitives().isSelected();
     }
 
+    /**
+     * @since 4.2
+     */
+    public boolean isUseCaseSensitiveNaming() {
+        return configPanel.getUseCaseSensitiveNaming().isSelected();
+    }
+
     public boolean isUseJava7Typed() {
         return configPanel.getUseJava7Types().isSelected();
     }

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/dbimport/ReverseEngineeringConfigPanel.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/dbimport/ReverseEngineeringConfigPanel.java
@@ -53,6 +53,7 @@ public class ReverseEngineeringConfigPanel extends JPanel {
     private JCheckBox forceDataMapCatalog;
     private JCheckBox forceDataMapSchema;
     private JCheckBox usePrimitives;
+    private JCheckBox useCaseSensitiveNaming;
     private JCheckBox useJava7Types;
 
     private TextAdapter tableTypes;
@@ -81,6 +82,7 @@ public class ReverseEngineeringConfigPanel extends JPanel {
         panelBuilder.append("Force datamap catalog:", forceDataMapCatalog);
         panelBuilder.append("Force datamap schema:", forceDataMapSchema);
         panelBuilder.append("Use Java primitive types:", usePrimitives);
+        panelBuilder.append("Use case sensitive naming:", useCaseSensitiveNaming);
         panelBuilder.append("Use java.util.Date type:", useJava7Types);
         panelBuilder.append("Naming strategy:", strategyCombo);
         panelBuilder.append("Table types:", tableTypes.getComponent());
@@ -94,6 +96,7 @@ public class ReverseEngineeringConfigPanel extends JPanel {
         forceDataMapCatalog.setSelected(reverseEngineering.isForceDataMapCatalog());
         forceDataMapSchema.setSelected(reverseEngineering.isForceDataMapSchema());
         usePrimitives.setSelected(reverseEngineering.isUsePrimitives());
+        useCaseSensitiveNaming.setSelected(reverseEngineering.isUseCaseSensitiveNaming());
         useJava7Types.setSelected(reverseEngineering.isUseJava7Types());
     }
 
@@ -191,6 +194,8 @@ public class ReverseEngineeringConfigPanel extends JPanel {
                 "By default <b>java.time.*</b> types will be used.</html>");
         usePrimitives = new JCheckBox();
         usePrimitives.setToolTipText("<html>Use primitive types (e.g. int) or Object types (e.g. java.lang.Integer)</html>");
+        useCaseSensitiveNaming = new JCheckBox();
+        usePrimitives.setToolTipText("<html>Use case sensitive namespace</html>");
     }
 
     private void initListeners() {
@@ -220,6 +225,12 @@ public class ReverseEngineeringConfigPanel extends JPanel {
         });
         usePrimitives.addActionListener(e -> {
             getReverseEngineeringBySelectedMap().setUsePrimitives(usePrimitives.isSelected());
+            if(!dbImportView.isInitFromModel()) {
+                projectController.setDirty(true);
+            }
+        });
+        useCaseSensitiveNaming.addActionListener(e -> {
+            getReverseEngineeringBySelectedMap().setUseCaseSensitiveNaming(useCaseSensitiveNaming.isSelected());
             if(!dbImportView.isInitFromModel()) {
                 projectController.setDirty(true);
             }
@@ -283,6 +294,13 @@ public class ReverseEngineeringConfigPanel extends JPanel {
 
     JCheckBox getUsePrimitives() {
         return usePrimitives;
+    }
+
+    /**
+     * @since 4.2
+     */
+    JCheckBox getUseCaseSensitiveNaming() {
+        return useCaseSensitiveNaming;
     }
 
     JCheckBox getUseJava7Types() {

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/util/AdapterMapping.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/util/AdapterMapping.java
@@ -88,7 +88,7 @@ public class AdapterMapping {
         adapterToJDBCURLMap.put(OpenBaseAdapter.class.getName(), "jdbc:openbase://localhost/database");
         adapterToJDBCURLMap.put(SQLServerAdapter.class.getName(),
                 "jdbc:sqlserver://localhost:1433;databaseName=database;SelectMethod=cursor");
-        adapterToJDBCURLMap.put(SQLiteAdapter.class.getName(), "jdbc:sqlite:testdb");
+        adapterToJDBCURLMap.put(SQLiteAdapter.class.getName(), "jdbc:sqlite:testdb?limit_compound_select=0");
         adapterToJDBCURLMap.put(FirebirdAdapter.class.getName(), "jdbc:firebirdsql:localhost/3050:database.fdb");
 
         // TODO: embedded Derby Mode... change to client-server once we figure

--- a/pom.xml
+++ b/pom.xml
@@ -1618,7 +1618,7 @@
 				<dependency>
 					<groupId>org.xerial</groupId>
 					<artifactId>sqlite-jdbc</artifactId>
-					<version>3.25.2</version>
+					<version>3.36.0.2</version>
 					<scope>test</scope>
 				</dependency>
 			</dependencies>


### PR DESCRIPTION
The feature was developed for work with case-sensitive naming (e.g. "name", "Name", "NAME"). Added a button for using case-sensitive naming in modeler. The useCaseSensitive parameter allows to have in database case sensitive naming (for tables, attributes etc) and pass its initial state. Added quoted identifier in loaders. Added asciidoc and test for case-sensitive naming.
An example of naming that can be passed from the database (this is not an example of the correct naming rules but it shows
program capabilities):
![image](https://user-images.githubusercontent.com/71207387/151783123-46cda50b-0ad3-41b6-a19d-5ef6316e5127.png)
![image](https://user-images.githubusercontent.com/71207387/151783144-13a0f871-a62c-4dfe-bf63-6069b98f6b69.png)
