### PR TITLE
CAY-2733 Modeler can't use custom templates set in a datamap

### DIFF
--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/CodeTemplateManager.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/CodeTemplateManager.java
@@ -59,63 +59,68 @@ public class CodeTemplateManager {
 
 	public static final String NODE_NAME = "codeTemplateManager";
 
-	private List<String> standardSubclassTemplates;
-	private List<String> standardSuperclassTemplates;
-	private List<String> standardClientSubclassTemplates;
-	private List<String> standardClientSuperclassTemplates;
+	private List<String> defaultSubclassTemplates;
+	private List<String> defaultSuperclassTemplates;
+	private List<String> defaultClientSubclassTemplates;
+	private List<String> defaultClientSuperclassTemplates;
 	private Map<String, String> customTemplates;
 	private Map<String, String> reverseCustomTemplate;
-	private Map<String, String> standardTemplates;
+	private Map<String, String> defaultTemplates;
 
-	private List<String> standardEmbeddableTemplates;
-	private List<String> standardEmbeddableSuperclassTemplates;
+	private List<String> defaultEmbeddableTemplates;
+	private List<String> defaultEmbeddableSuperclassTemplates;
 
-	private List<String> standardServerDataMapTemplates;
-	private List<String> standardServerDataMapSuperclassTemplates;
-	private List<String> standardClientDataMapTemplates;
-	private List<String> standardClientDataMapSuperclassTemplates;
+	private List<String> defaultServerDataMapTemplates;
+	private List<String> defaultServerDataMapSuperclassTemplates;
+	private List<String> defaultClientDataMapTemplates;
+	private List<String> defaultClientDataMapSuperclassTemplates;
 
-	private Map<String, String> reverseStandartTemplates;
+	private Map<String, String> reverseDefaultsTemplates;
 
-	private static Logger logger = LoggerFactory.getLogger(CodeTemplateManager.class);
+	private final Application application;
+	private final Preferences templatePreferences;
+
+	private static final Logger logger = LoggerFactory.getLogger(CodeTemplateManager.class);
 
 	public Preferences getTemplatePreferences(Application application) {
 		return application.getPreferencesNode(this.getClass(), NODE_NAME);
 	}
 
 	public CodeTemplateManager(Application application) {
-		standardSuperclassTemplates = new ArrayList<>(2);
-		standardSuperclassTemplates.add(STANDARD_SERVER_SUPERCLASS);
+		this.application = application;
+		this.templatePreferences = getTemplatePreferences(application);
+		defaultSuperclassTemplates = new ArrayList<>(2);
+		defaultSuperclassTemplates.add(STANDARD_SERVER_SUPERCLASS);
 
-		standardClientSuperclassTemplates = new ArrayList<>();
-		standardClientSuperclassTemplates.add(STANDARD_CLIENT_SUPERCLASS);
+		defaultClientSuperclassTemplates = new ArrayList<>();
+		defaultClientSuperclassTemplates.add(STANDARD_CLIENT_SUPERCLASS);
 
-		standardSubclassTemplates = new ArrayList<>(2);
-		standardSubclassTemplates.add(SINGLE_SERVER_CLASS);
-		standardSubclassTemplates.add(STANDARD_SERVER_SUBCLASS);
+		defaultSubclassTemplates = new ArrayList<>(2);
+		defaultSubclassTemplates.add(SINGLE_SERVER_CLASS);
+		defaultSubclassTemplates.add(STANDARD_SERVER_SUBCLASS);
 
-		standardClientSubclassTemplates = new ArrayList<>();
-		standardClientSubclassTemplates.add(STANDARD_CLIENT_SUBCLASS);
+		defaultClientSubclassTemplates = new ArrayList<>();
+		defaultClientSubclassTemplates.add(STANDARD_CLIENT_SUBCLASS);
 
-		standardEmbeddableTemplates = new ArrayList<>();
-		standardEmbeddableTemplates.add(STANDARD_EMBEDDABLE_SUBCLASS);
-		standardEmbeddableTemplates.add(SINGLE_EMBEDDABLE_CLASS);
+		defaultEmbeddableTemplates = new ArrayList<>();
+		defaultEmbeddableTemplates.add(STANDARD_EMBEDDABLE_SUBCLASS);
+		defaultEmbeddableTemplates.add(SINGLE_EMBEDDABLE_CLASS);
 
-		standardEmbeddableSuperclassTemplates = new ArrayList<>();
-		standardEmbeddableSuperclassTemplates.add(STANDARD_EMBEDDABLE_SUPERCLASS);
+		defaultEmbeddableSuperclassTemplates = new ArrayList<>();
+		defaultEmbeddableSuperclassTemplates.add(STANDARD_EMBEDDABLE_SUPERCLASS);
 
-		standardServerDataMapTemplates = new ArrayList<>();
-		standardServerDataMapTemplates.add(STANDARD_SERVER_DATAMAP_SUBCLASS);
-		standardServerDataMapTemplates.add(SINGLE_DATAMAP_CLASS);
+		defaultServerDataMapTemplates = new ArrayList<>();
+		defaultServerDataMapTemplates.add(STANDARD_SERVER_DATAMAP_SUBCLASS);
+		defaultServerDataMapTemplates.add(SINGLE_DATAMAP_CLASS);
 
-		standardServerDataMapSuperclassTemplates = new ArrayList<>();
-		standardServerDataMapSuperclassTemplates.add(STANDARD_SERVER_DATAMAP_SUPERCLASS);
+		defaultServerDataMapSuperclassTemplates = new ArrayList<>();
+		defaultServerDataMapSuperclassTemplates.add(STANDARD_SERVER_DATAMAP_SUPERCLASS);
 		
-		standardClientDataMapTemplates = new ArrayList<>();
-		standardClientDataMapTemplates.add(STANDARD_CLIENT_DATAMAP_SUBCLASS);
+		defaultClientDataMapTemplates = new ArrayList<>();
+		defaultClientDataMapTemplates.add(STANDARD_CLIENT_DATAMAP_SUBCLASS);
 		
-		standardClientDataMapSuperclassTemplates = new ArrayList<>();
-		standardClientDataMapSuperclassTemplates.add(STANDARD_CLIENT_DATAMAP_SUPERCLASS);
+		defaultClientDataMapSuperclassTemplates = new ArrayList<>();
+		defaultClientDataMapSuperclassTemplates.add(STANDARD_CLIENT_DATAMAP_SUPERCLASS);
 
 		updateCustomTemplates(getTemplatePreferences(application));
 		reverseCustomTemplate = new HashMap<>();
@@ -123,39 +128,27 @@ public class CodeTemplateManager {
 			reverseCustomTemplate.put(entry.getValue(), entry.getKey());
 		}
 
-		standardTemplates = new HashMap<>();
-		standardTemplates.put(STANDARD_SERVER_SUPERCLASS, ClassGenerationAction.SUPERCLASS_TEMPLATE);
-		standardTemplates.put(STANDARD_CLIENT_SUPERCLASS, ClientClassGenerationAction.SUPERCLASS_TEMPLATE);
-		standardTemplates.put(STANDARD_SERVER_SUBCLASS, ClassGenerationAction.SUBCLASS_TEMPLATE);
-		standardTemplates.put(STANDARD_CLIENT_SUBCLASS, ClientClassGenerationAction.SUBCLASS_TEMPLATE);
-		standardTemplates.put(SINGLE_SERVER_CLASS, ClassGenerationAction.SINGLE_CLASS_TEMPLATE);
+		defaultTemplates = new HashMap<>();
+		defaultTemplates.put(STANDARD_SERVER_SUPERCLASS, ClassGenerationAction.SUPERCLASS_TEMPLATE);
+		defaultTemplates.put(STANDARD_CLIENT_SUPERCLASS, ClientClassGenerationAction.SUPERCLASS_TEMPLATE);
+		defaultTemplates.put(STANDARD_SERVER_SUBCLASS, ClassGenerationAction.SUBCLASS_TEMPLATE);
+		defaultTemplates.put(STANDARD_CLIENT_SUBCLASS, ClientClassGenerationAction.SUBCLASS_TEMPLATE);
+		defaultTemplates.put(SINGLE_SERVER_CLASS, ClassGenerationAction.SINGLE_CLASS_TEMPLATE);
 
-		standardTemplates.put(STANDARD_EMBEDDABLE_SUPERCLASS, ClassGenerationAction.EMBEDDABLE_SUPERCLASS_TEMPLATE);
-		standardTemplates.put(STANDARD_EMBEDDABLE_SUBCLASS, ClassGenerationAction.EMBEDDABLE_SUBCLASS_TEMPLATE);
-		standardTemplates.put(SINGLE_EMBEDDABLE_CLASS, ClassGenerationAction.EMBEDDABLE_SINGLE_CLASS_TEMPLATE);
+		defaultTemplates.put(STANDARD_EMBEDDABLE_SUPERCLASS, ClassGenerationAction.EMBEDDABLE_SUPERCLASS_TEMPLATE);
+		defaultTemplates.put(STANDARD_EMBEDDABLE_SUBCLASS, ClassGenerationAction.EMBEDDABLE_SUBCLASS_TEMPLATE);
+		defaultTemplates.put(SINGLE_EMBEDDABLE_CLASS, ClassGenerationAction.EMBEDDABLE_SINGLE_CLASS_TEMPLATE);
 
-		standardTemplates.put(STANDARD_SERVER_DATAMAP_SUBCLASS, ClassGenerationAction.DATAMAP_SUBCLASS_TEMPLATE);
-		standardTemplates.put(STANDARD_CLIENT_DATAMAP_SUBCLASS, ClientClassGenerationAction.DMAP_SUBCLASS_TEMPLATE);
-		standardTemplates.put(SINGLE_DATAMAP_CLASS, ClassGenerationAction.DATAMAP_SINGLE_CLASS_TEMPLATE);
-		standardTemplates.put(STANDARD_SERVER_DATAMAP_SUPERCLASS, ClassGenerationAction.DATAMAP_SUPERCLASS_TEMPLATE);
-		standardTemplates.put(STANDARD_CLIENT_DATAMAP_SUPERCLASS, ClientClassGenerationAction.DMAP_SUPERCLASS_TEMPLATE);
+		defaultTemplates.put(STANDARD_SERVER_DATAMAP_SUBCLASS, ClassGenerationAction.DATAMAP_SUBCLASS_TEMPLATE);
+		defaultTemplates.put(STANDARD_CLIENT_DATAMAP_SUBCLASS, ClientClassGenerationAction.DMAP_SUBCLASS_TEMPLATE);
+		defaultTemplates.put(SINGLE_DATAMAP_CLASS, ClassGenerationAction.DATAMAP_SINGLE_CLASS_TEMPLATE);
+		defaultTemplates.put(STANDARD_SERVER_DATAMAP_SUPERCLASS, ClassGenerationAction.DATAMAP_SUPERCLASS_TEMPLATE);
+		defaultTemplates.put(STANDARD_CLIENT_DATAMAP_SUPERCLASS, ClientClassGenerationAction.DMAP_SUPERCLASS_TEMPLATE);
 
-		reverseStandartTemplates = new HashMap<>();
-		reverseStandartTemplates.put(ClassGenerationAction.SUBCLASS_TEMPLATE, STANDARD_SERVER_SUBCLASS);
-		reverseStandartTemplates.put(ClientClassGenerationAction.SUBCLASS_TEMPLATE, STANDARD_CLIENT_SUBCLASS);
-		reverseStandartTemplates.put(ClassGenerationAction.SINGLE_CLASS_TEMPLATE, SINGLE_SERVER_CLASS);
-		reverseStandartTemplates.put(ClientClassGenerationAction.SUPERCLASS_TEMPLATE, STANDARD_CLIENT_SUPERCLASS);
-		reverseStandartTemplates.put(ClassGenerationAction.SUPERCLASS_TEMPLATE, STANDARD_SERVER_SUPERCLASS);
-
-		reverseStandartTemplates.put(ClassGenerationAction.EMBEDDABLE_SUPERCLASS_TEMPLATE, STANDARD_EMBEDDABLE_SUPERCLASS);
-		reverseStandartTemplates.put(ClassGenerationAction.EMBEDDABLE_SUBCLASS_TEMPLATE, STANDARD_EMBEDDABLE_SUBCLASS);
-		reverseStandartTemplates.put(ClassGenerationAction.EMBEDDABLE_SINGLE_CLASS_TEMPLATE, SINGLE_EMBEDDABLE_CLASS);
-
-		reverseStandartTemplates.put(ClassGenerationAction.DATAMAP_SUBCLASS_TEMPLATE, STANDARD_SERVER_DATAMAP_SUBCLASS);
-		reverseStandartTemplates.put(ClientClassGenerationAction.DMAP_SUBCLASS_TEMPLATE, STANDARD_CLIENT_DATAMAP_SUBCLASS);
-		reverseStandartTemplates.put(ClassGenerationAction.DATAMAP_SINGLE_CLASS_TEMPLATE, SINGLE_DATAMAP_CLASS);
-		reverseStandartTemplates.put(ClassGenerationAction.DATAMAP_SUPERCLASS_TEMPLATE, STANDARD_SERVER_DATAMAP_SUPERCLASS);
-		reverseStandartTemplates.put(ClientClassGenerationAction.DMAP_SUPERCLASS_TEMPLATE, STANDARD_CLIENT_DATAMAP_SUPERCLASS);
+		reverseDefaultsTemplates = new HashMap<>();
+		for(Map.Entry<String, String> entry : defaultTemplates.entrySet()){
+			reverseDefaultsTemplates.put(entry.getValue(), entry.getKey());
+		}
 	}
 
 	/**
@@ -191,61 +184,97 @@ public class CodeTemplateManager {
 				logger.warn("Path for template named '{}' could not be resolved", name);
 			}
 		}
-		value = standardTemplates.get(name);
+		value = defaultTemplates.get(name);
 		return value != null ? value.toString() : null;
 	}
 
 	public String getNameByPath(String name, Path rootPath) {
-		String fullPath = rootPath.resolve(Paths.get(name)).normalize().toString();
-		if(reverseCustomTemplate.containsKey(fullPath)){
-			return reverseCustomTemplate.get(fullPath);
+		Path path = Paths.get(name);
+		String normalizedPath = (rootPath == null) ?
+				path.normalize().toString() :
+				rootPath.resolve(path).normalize().toString();
+		if (reverseCustomTemplate.containsKey(normalizedPath)) {
+			return reverseCustomTemplate.get(normalizedPath);
 		} else {
-			Object value = reverseStandartTemplates.get(name);
-			return value != null ? value.toString() : null;
+			Object value = reverseDefaultsTemplates.get(name);
+			if (value != null) {
+				return value.toString();
+			} else {
+				String preparedName = prepareName(Paths.get(normalizedPath), templatePreferences);
+				return addTemplate(normalizedPath, preparedName).getKey();
+			}
 		}
+	}
+
+	public FSPath addTemplate(String path, String name) {
+		Preferences newNode = templatePreferences.node(name);
+		FSPath fsPath = (FSPath) application
+				.getCayenneProjectPreferences()
+				.getProjectDetailObject(FSPath.class, newNode);
+		fsPath.setPath(path);
+		return fsPath;
+	}
+
+	/**
+	 * Prepares template name from the path. First, remove the extension and add "_0" to the name.
+	 * Next step is check for unique. If the same name is exist, increases number at the end to the next one.
+	 */
+	private String prepareName(Path path, Preferences templatePreferences) {
+		String preparedName = path.getFileName().toString().replaceAll(".vm$", "");
+		preparedName += "_0";
+		int j = 1;
+		try {
+			while (templatePreferences.nodeExists(preparedName)) {
+				preparedName = preparedName.replaceAll("_.*[0-9]", "_" + j);
+				j++;
+			}
+		} catch (BackingStoreException e) {
+			logger.warn("Error reading preferences");
+		}
+		return preparedName;
 	}
 
 	public Map<String, String> getCustomTemplates() {
 		return customTemplates;
 	}
 
-	public List<String> getStandardSubclassTemplates() {
-		return standardSubclassTemplates;
+	public List<String> getDefaultSubclassTemplates() {
+		return defaultSubclassTemplates;
 	}
 
-	public List<String> getStandardClientSubclassTemplates() {
-		return standardClientSubclassTemplates;
+	public List<String> getDefaultClientSubclassTemplates() {
+		return defaultClientSubclassTemplates;
 	}
 
-	public List<String> getStandardSuperclassTemplates() {
-		return standardSuperclassTemplates;
+	public List<String> getDefaultSuperclassTemplates() {
+		return defaultSuperclassTemplates;
 	}
 
-	public List<String> getStandardClientSuperclassTemplates() {
-		return standardClientSuperclassTemplates;
+	public List<String> getDefaultClientSuperclassTemplates() {
+		return defaultClientSuperclassTemplates;
 	}
 
-	public List<String> getStandartEmbeddableTemplates() {
-		return standardEmbeddableTemplates;
+	public List<String> getDefaultEmbeddableTemplates() {
+		return defaultEmbeddableTemplates;
 	}
 
-	public List<String> getStandartEmbeddableSuperclassTemplates() {
-		return standardEmbeddableSuperclassTemplates;
+	public List<String> getDefaultEmbeddableSuperclassTemplates() {
+		return defaultEmbeddableSuperclassTemplates;
 	}
 
-	public List<String> getStandartDataMapTemplates() {
-		return standardServerDataMapTemplates; 
+	public List<String> getDefaultDataMapTemplates() {
+		return defaultServerDataMapTemplates;
 	}
 
-	public List<String> getStandartDataMapSuperclassTemplates() {
-		return standardServerDataMapSuperclassTemplates;
+	public List<String> getDefaultDataMapSuperclassTemplates() {
+		return defaultServerDataMapSuperclassTemplates;
 	}
 	
-	public List<String> getStandardClientDataMapTemplates() {
-		return standardClientDataMapTemplates; 
+	public List<String> getDefaultClientDataMapTemplates() {
+		return defaultClientDataMapTemplates;
 	}
 	
-	public List<String> getStandardClientDataMapSuperclassTemplates() { 
-		return standardClientDataMapSuperclassTemplates; 
+	public List<String> getDefaultClientDataMapSuperclassTemplates() {
+		return defaultClientDataMapSuperclassTemplates;
 	}
 }

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/CustomModeController.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/CustomModeController.java
@@ -19,7 +19,6 @@
 
 package org.apache.cayenne.modeler.editor.cgen;
 
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -30,7 +29,6 @@ import org.apache.cayenne.gen.CgenConfiguration;
 import org.apache.cayenne.gen.ClassGenerationAction;
 import org.apache.cayenne.gen.ClientClassGenerationAction;
 import org.apache.cayenne.modeler.CodeTemplateManager;
-import org.apache.cayenne.modeler.dialog.cgen.TemplateDialog;
 import org.apache.cayenne.modeler.dialog.pref.PreferenceDialog;
 import org.apache.cayenne.swing.BindingBuilder;
 
@@ -71,36 +69,36 @@ public class CustomModeController extends GeneratorController {
         Collections.sort(customTemplates);
 
         List<String> superTemplates = isClient ?
-                new ArrayList<>(templateManager.getStandardClientSuperclassTemplates()) :
-                new ArrayList<>(templateManager.getStandardSuperclassTemplates());
+                new ArrayList<>(templateManager.getDefaultClientSuperclassTemplates()) :
+                new ArrayList<>(templateManager.getDefaultSuperclassTemplates());
         Collections.sort(superTemplates);
         superTemplates.addAll(customTemplates);
 
         List<String> subTemplates = isClient ?
-                new ArrayList<>(templateManager.getStandardClientSubclassTemplates()) :
-                new ArrayList<>(templateManager.getStandardSubclassTemplates());
+                new ArrayList<>(templateManager.getDefaultClientSubclassTemplates()) :
+                new ArrayList<>(templateManager.getDefaultSubclassTemplates());
         Collections.sort(subTemplates);
         subTemplates.addAll(customTemplates);
 
         List<String> querySuperTemplates = isClient ?
-                new ArrayList<>(templateManager.getStandardClientDataMapSuperclassTemplates()) :
-                new ArrayList<>(templateManager.getStandartDataMapSuperclassTemplates());
+                new ArrayList<>(templateManager.getDefaultClientDataMapSuperclassTemplates()) :
+                new ArrayList<>(templateManager.getDefaultDataMapSuperclassTemplates());
         Collections.sort(querySuperTemplates);
         querySuperTemplates.addAll(customTemplates);
 
         List<String> queryTemplates = isClient ?
-                new ArrayList<>(templateManager.getStandardClientDataMapTemplates()) :
-                new ArrayList<>(templateManager.getStandartDataMapTemplates());
+                new ArrayList<>(templateManager.getDefaultClientDataMapTemplates()) :
+                new ArrayList<>(templateManager.getDefaultDataMapTemplates());
         Collections.sort(queryTemplates);
         queryTemplates.addAll(customTemplates);
 
-        List<String> embeddableSuperTemplates = new ArrayList<>(templateManager.getStandartEmbeddableSuperclassTemplates());
-		Collections.sort(embeddableSuperTemplates);
-		embeddableSuperTemplates.addAll(customTemplates);
+        List<String> embeddableSuperTemplates = new ArrayList<>(templateManager.getDefaultEmbeddableSuperclassTemplates());
+        Collections.sort(embeddableSuperTemplates);
+        embeddableSuperTemplates.addAll(customTemplates);
 
-		List<String> embeddableTemplates = new ArrayList<>(templateManager.getStandartEmbeddableTemplates());
-		Collections.sort(embeddableTemplates);
-		embeddableTemplates.addAll(customTemplates);
+        List<String> embeddableTemplates = new ArrayList<>(templateManager.getDefaultEmbeddableTemplates());
+        Collections.sort(embeddableTemplates);
+        embeddableTemplates.addAll(customTemplates);
 
         this.view.getSubclassTemplate().getComboBox().setModel(new DefaultComboBoxModel<>(subTemplates.toArray(new String[0])));
         this.view.getSuperclassTemplate().getComboBox().setModel(new DefaultComboBoxModel<>(superTemplates.toArray(new String[0])));
@@ -108,11 +106,6 @@ public class CustomModeController extends GeneratorController {
         this.view.getQuerySuperTemplate().getComboBox().setModel(new DefaultComboBoxModel<>(querySuperTemplates.toArray(new String[0])));
         this.view.getEmbeddableTemplate().getComboBox().setModel(new DefaultComboBoxModel<>(embeddableTemplates.toArray(new String[0])));
         this.view.getEmbeddableSuperTemplate().getComboBox().setModel(new DefaultComboBoxModel<>(embeddableSuperTemplates.toArray(new String[0])));
-    }
-
-    public void missTemplateDialog(CgenConfiguration cgenConfiguration, String template, String superTemplate) {
-        new TemplateDialog(this, cgenConfiguration, template, superTemplate).startupAction();
-        updateComboBoxes();
     }
 
     public void popPreferencesAction() {
@@ -132,63 +125,30 @@ public class CustomModeController extends GeneratorController {
         String superTemplateName = getApplication().getCodeTemplateManager().getNameByPath(
                 cgenConfiguration.getSuperTemplate(), cgenConfiguration.getRootPath());
         String embeddableTemplateName = getApplication().getCodeTemplateManager().getNameByPath(
-        		cgenConfiguration.getEmbeddableTemplate(), cgenConfiguration.getRootPath());
+                cgenConfiguration.getEmbeddableTemplate(), cgenConfiguration.getRootPath());
         String embeddableSuperTemplateName = getApplication().getCodeTemplateManager().getNameByPath(
-        		cgenConfiguration.getEmbeddableSuperTemplate(), cgenConfiguration.getRootPath());
+                cgenConfiguration.getEmbeddableSuperTemplate(), cgenConfiguration.getRootPath());
         String queryTemplateName = getApplication().getCodeTemplateManager().getNameByPath(
-        		cgenConfiguration.getQueryTemplate(), cgenConfiguration.getRootPath());
+                cgenConfiguration.getQueryTemplate(), cgenConfiguration.getRootPath());
         String querySuperTemplateName = getApplication().getCodeTemplateManager().getNameByPath(
-        		cgenConfiguration.getQuerySuperTemplate(), cgenConfiguration.getRootPath());
+                cgenConfiguration.getQuerySuperTemplate(), cgenConfiguration.getRootPath());
 
-        String path = cgenConfiguration.getRootPath().resolve(Paths.get(cgenConfiguration.getTemplate())).normalize().toString();
-        String superPath = cgenConfiguration.getRootPath().resolve(Paths.get(cgenConfiguration.getSuperTemplate())).normalize().toString();
-        String embeddableTemplatePath = cgenConfiguration.getRootPath().resolve(Paths.get(cgenConfiguration.getEmbeddableTemplate())).normalize().toString();
-        String embeddableSuperTemplatePath = cgenConfiguration.getRootPath().resolve(Paths.get(cgenConfiguration.getEmbeddableSuperTemplate())).normalize().toString();
-        String queryTemplatePath = cgenConfiguration.getRootPath().resolve(Paths.get(cgenConfiguration.getQueryTemplate())).normalize().toString();
-        String querySuperTemplatePath = cgenConfiguration.getRootPath().resolve(Paths.get(cgenConfiguration.getQuerySuperTemplate())).normalize().toString();
+        view.getSubclassTemplate().setItem(templateName);
+        view.getSuperclassTemplate().setItem(superTemplateName);
 
-        if(templateName == null && superTemplateName == null) {
-            view.getSubclassTemplate().setItem(null);
-            view.getSuperclassTemplate().setItem(null);
-            missTemplateDialog(cgenConfiguration, path, superPath);
-        } else if(templateName == null) {
-            view.getSubclassTemplate().setItem(null);
-            missTemplateDialog(cgenConfiguration, path, null);
-        } else if(superTemplateName == null) {
-            view.getSuperclassTemplate().setItem(null);
-            missTemplateDialog(cgenConfiguration, null, superPath);
-        } else {
-            view.getSubclassTemplate().setItem(templateName);
-            view.getSuperclassTemplate().setItem(superTemplateName);
-        }
+        view.getEmbeddableTemplate().setItem(embeddableTemplateName);
+        view.getEmbeddableSuperTemplate().setItem(embeddableSuperTemplateName);
 
-        if(embeddableTemplateName == null && embeddableSuperTemplateName == null) {
-        	missTemplateDialog(cgenConfiguration, embeddableTemplatePath, embeddableSuperTemplatePath);
-        } else if(embeddableTemplateName == null) {
-        	missTemplateDialog(cgenConfiguration, embeddableTemplatePath, null);
-        } else if(embeddableSuperTemplateName == null) {
-        	missTemplateDialog(cgenConfiguration, null, embeddableSuperTemplatePath);
-        }
-    	view.getEmbeddableTemplate().setItem(embeddableTemplateName);
-    	view.getEmbeddableSuperTemplate().setItem(embeddableSuperTemplateName);
-
-    	if(queryTemplateName == null && querySuperTemplateName == null) {
-    		missTemplateDialog(cgenConfiguration, queryTemplatePath, querySuperTemplatePath);
-    	} else if(queryTemplateName == null) {
-    		missTemplateDialog(cgenConfiguration, queryTemplatePath, null);
-    	} else if(querySuperTemplateName == null) {
-    		missTemplateDialog(cgenConfiguration, null, querySuperTemplatePath);
-    	}
-    	view.getQueryTemplate().setItem(queryTemplateName);
-    	view.getQuerySuperTemplate().setItem(querySuperTemplateName);
+        view.getQueryTemplate().setItem(queryTemplateName);
+        view.getQuerySuperTemplate().setItem(querySuperTemplateName);
 
         view.setDisableSuperComboBoxes(view.getPairs().isSelected());
     }
 
-    private void initListeners(){
+    private void initListeners() {
         view.getPairs().addActionListener(val -> {
             cgenConfiguration.setMakePairs(view.getPairs().isSelected());
-            if(!view.getPairs().isSelected()) {
+            if (!view.getPairs().isSelected()) {
                 cgenConfiguration.setTemplate(ClassGenerationAction.SINGLE_CLASS_TEMPLATE);
                 cgenConfiguration.setEmbeddableTemplate(ClassGenerationAction.EMBEDDABLE_SINGLE_CLASS_TEMPLATE);
                 cgenConfiguration.setQueryTemplate(ClassGenerationAction.DATAMAP_SINGLE_CLASS_TEMPLATE);
@@ -224,7 +184,7 @@ public class CustomModeController extends GeneratorController {
         view.getClientMode().addActionListener(val -> {
             boolean isSelected = view.getClientMode().isSelected();
             cgenConfiguration.setClient(isSelected);
-            if(isSelected) {
+            if (isSelected) {
                 cgenConfiguration.setTemplate(ClientClassGenerationAction.SUBCLASS_TEMPLATE);
                 cgenConfiguration.setSuperTemplate(ClientClassGenerationAction.SUPERCLASS_TEMPLATE);
                 cgenConfiguration.setQueryTemplate(ClientClassGenerationAction.DMAP_SUBCLASS_TEMPLATE);
@@ -247,15 +207,15 @@ public class CustomModeController extends GeneratorController {
                             ClassGenerationAction.SUBCLASS_TEMPLATE,
                     cgenConfiguration.getRootPath());
             String queryTemplateName = getApplication().getCodeTemplateManager().getNameByPath(
-            		isSelected ?
-            				ClientClassGenerationAction.DMAP_SUBCLASS_TEMPLATE :
-            					ClassGenerationAction.DATAMAP_SUBCLASS_TEMPLATE,
-            					cgenConfiguration.getRootPath());
+                    isSelected ?
+                            ClientClassGenerationAction.DMAP_SUBCLASS_TEMPLATE :
+                            ClassGenerationAction.DATAMAP_SUBCLASS_TEMPLATE,
+                    cgenConfiguration.getRootPath());
             String querySuperTemplateName = getApplication().getCodeTemplateManager().getNameByPath(
-            		isSelected ?
-            				ClientClassGenerationAction.DMAP_SUPERCLASS_TEMPLATE :
-            					ClassGenerationAction.DATAMAP_SUPERCLASS_TEMPLATE,
-            					cgenConfiguration.getRootPath());
+                    isSelected ?
+                            ClientClassGenerationAction.DMAP_SUPERCLASS_TEMPLATE :
+                            ClassGenerationAction.DATAMAP_SUPERCLASS_TEMPLATE,
+                    cgenConfiguration.getRootPath());
             view.getSubclassTemplate().setItem(templateName);
             view.getSuperclassTemplate().setItem(superTemplateName);
             view.getQueryTemplate().setItem(queryTemplateName);
@@ -264,7 +224,8 @@ public class CustomModeController extends GeneratorController {
         });
     }
 
-    public void initForm(CgenConfiguration cgenConfiguration){
+    @Override
+    public void initForm(CgenConfiguration cgenConfiguration) {
         super.initForm(cgenConfiguration);
         view.getClientMode().setSelected(cgenConfiguration.isClient());
         updateTemplates();


### PR DESCRIPTION
The solution for the issue with the missing custom templates. Now, if there is no template in the configuration, a template is created with the name, like a name of file specified in datamap.xml with an ordinal number attached to it (_for an example /templates/CustomTemplate.vm. will create template with name CustomTemplate_0)._
When generating classes (if the template file is missing), an error message will be displayed indicating the path to it.
