### PR TITLE
Eclipse maven integration (m2e) - add two missing goals to prevent errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -557,6 +557,32 @@
 								<pluginExecution>
 									<pluginExecutionFilter>
 										<groupId>org.apache.maven.plugins</groupId>
+										<artifactId>maven-resources-plugin</artifactId>
+										<versionRange>[1.0,)</versionRange>
+										<goals>
+											<goal>testResources</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<execute />
+									</action>
+								</pluginExecution>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>org.apache.maven.plugins</groupId>
+										<artifactId>maven-resources-plugin</artifactId>
+										<versionRange>[1.0,)</versionRange>
+										<goals>
+											<goal>resources</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<execute />
+									</action>
+								</pluginExecution>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>org.apache.maven.plugins</groupId>
 										<artifactId>maven-javadoc-plugin</artifactId>
 										<versionRange>[1.0,)</versionRange>
 										<goals>


### PR DESCRIPTION
Eclipse maven integration (m2e) - add two missing goals to prevent errors on project

There were errors on the project like 'Plugin execution not covered by lifecycle configuration'