### PR TITLE
CAY-2759 Add utility methods to the SELF property

### DIFF
--- a/cayenne-cgen/src/main/java/org/apache/cayenne/gen/PropertyUtils.java
+++ b/cayenne-cgen/src/main/java/org/apache/cayenne/gen/PropertyUtils.java
@@ -42,6 +42,7 @@ import org.apache.cayenne.exp.property.MapProperty;
 import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.NumericProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
+import org.apache.cayenne.exp.property.SelfProperty;
 import org.apache.cayenne.exp.property.SetProperty;
 import org.apache.cayenne.exp.property.StringProperty;
 import org.apache.cayenne.gen.property.PropertyDescriptorCreator;
@@ -133,7 +134,7 @@ public class PropertyUtils {
 
     public void addImportForSelfProperty(ObjEntity entity) {
         importUtils.addType(PropertyFactory.class.getName());
-        importUtils.addType(EntityProperty.class.getName());
+        importUtils.addType(SelfProperty.class.getName());
         importUtils.addType(entity.getJavaClassName());
     }
 
@@ -173,7 +174,7 @@ public class PropertyUtils {
 
     public String selfPropertyDefinition(ObjEntity entity) {
         String propertyType = importUtils.formatJavaType(entity.getJavaClassName());
-        return String.format("public static final EntityProperty<%s> SELF = PropertyFactory.createSelf(%s.class);",
+        return String.format("public static final SelfProperty<%s> SELF = PropertyFactory.createSelf(%s.class);",
                 propertyType, propertyType);
     }
 

--- a/cayenne-cgen/src/test/resources/templateTest/_auto/_ObjEntity.java
+++ b/cayenne-cgen/src/test/resources/templateTest/_auto/_ObjEntity.java
@@ -5,9 +5,9 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
+import org.apache.cayenne.exp.property.SelfProperty;
 import test.ObjEntity;
 
 /**
@@ -20,7 +20,7 @@ public abstract class _ObjEntity extends BaseDataObject {
 
     private static final long serialVersionUID = 1L;
 
-    public static final EntityProperty<ObjEntity> SELF = PropertyFactory.createSelf(ObjEntity.class);
+    public static final SelfProperty<ObjEntity> SELF = PropertyFactory.createSelf(ObjEntity.class);
 
     public static final NumericIdProperty<Integer> ID_PK_PROPERTY = PropertyFactory.createNumericId("id", "null", Integer.class);
     public static final String ID_PK_COLUMN = "id";

--- a/cayenne-server/src/main/java/org/apache/cayenne/exp/property/PropertyFactory.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/exp/property/PropertyFactory.java
@@ -267,8 +267,8 @@ public class PropertyFactory {
      * @param <T> type of represented entity
      * @return new 'self' property
      */
-    public static <T extends Persistent> EntityProperty<T> createSelf(Class<T> type) {
-        return createEntity(ExpressionFactory.fullObjectExp(), type);
+    public static <T extends Persistent> SelfProperty<T> createSelf(Class<T> type) {
+        return new SelfProperty<>(null, ExpressionFactory.fullObjectExp(), type);
     }
 
     /**

--- a/cayenne-server/src/main/java/org/apache/cayenne/exp/property/SelfProperty.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/exp/property/SelfProperty.java
@@ -1,0 +1,75 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.exp.property;
+
+import org.apache.cayenne.Persistent;
+import org.apache.cayenne.exp.Expression;
+import org.apache.cayenne.exp.ExpressionFactory;
+import org.apache.cayenne.query.ColumnSelect;
+import org.apache.cayenne.query.ObjectSelect;
+
+/**
+ * Property that represents root entity
+ * <br>
+ * Usage example: <code><pre>
+ * List<Object[]> result = Artist.SELF.columnQuery(Artist.SELF, Artist.PAINTING_ARRAY.count()).select(context);
+ * </pre></code>
+ *
+ * @since 5.0
+ * @param <E> type of the property
+ */
+public class SelfProperty<E extends Persistent> extends EntityProperty<E> {
+
+    /**
+     * Constructs a new property with the given name and expression
+     *
+     * @param name       of the property (will be used as alias for the expression)
+     * @param expression expression for property
+     * @param type       of the property
+     * @see PropertyFactory#createBase(String, Expression, Class)
+     */
+    protected SelfProperty(String name, Expression expression, Class<E> type) {
+        super(name, expression, type);
+    }
+
+    public Expression exists(Expression where) {
+        return ExpressionFactory.exists(ObjectSelect.query(getType()).where(where));
+    }
+
+    public Expression notExists(Expression where) {
+        return ExpressionFactory.notExists(ObjectSelect.query(getType()).where(where));
+    }
+
+    public ObjectSelect<E> query(Expression where) {
+        return ObjectSelect.query(getType()).where(where);
+    }
+
+    public ObjectSelect<E> query() {
+        return ObjectSelect.query(getType());
+    }
+
+    public <T> ColumnSelect<T> columnQuery(Property<T> property) {
+        return ObjectSelect.columnQuery(getType(), property);
+    }
+
+    public ColumnSelect<Object[]> columnQuery(Property<?>... properties) {
+        return ObjectSelect.columnQuery(getType(), properties);
+    }
+}

--- a/cayenne-server/src/test/java/org/apache/cayenne/exp/property/SelfPropertyTest.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/exp/property/SelfPropertyTest.java
@@ -1,0 +1,126 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.exp.property;
+
+import org.apache.cayenne.exp.Expression;
+import org.apache.cayenne.exp.ExpressionFactory;
+import org.apache.cayenne.exp.parser.ASTExists;
+import org.apache.cayenne.exp.parser.ASTNotExists;
+import org.apache.cayenne.exp.parser.ASTSubquery;
+import org.apache.cayenne.exp.parser.Node;
+import org.apache.cayenne.query.ColumnSelect;
+import org.apache.cayenne.query.ObjectSelect;
+import org.apache.cayenne.testdo.testmap.Artist;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import static org.junit.Assert.*;
+
+public class SelfPropertyTest {
+
+    private SelfProperty<Artist> property;
+
+    @Before
+    public void createProperty() {
+        property = new SelfProperty<>("path", null, Artist.class);
+    }
+
+    @Test
+    public void testQuery() {
+        ObjectSelect<Artist> query = property.query();
+
+        assertNotNull(query);
+        assertEquals(Artist.class, query.getEntityType());
+        assertNull(query.getWhere());
+    }
+
+    @Test
+    public void testQueryWithExp() {
+        ObjectSelect<Artist> query = property.query(Artist.ARTIST_NAME.eq("test"));
+
+        assertNotNull(query);
+        assertEquals(Artist.class, query.getEntityType());
+        assertEquals(ExpressionFactory.exp("artistName = 'test'"), query.getWhere());
+    }
+
+    @Test
+    public void testColumnQuery() {
+        ColumnSelect<String> query = property.columnQuery(Artist.ARTIST_NAME);
+
+        assertNotNull(query);
+        assertEquals(Artist.class, query.getEntityType());
+        assertEquals(1, query.getColumns().size());
+        assertEquals(Artist.ARTIST_NAME, query.getColumns().iterator().next());
+        assertNull(query.getWhere());
+    }
+
+    @Test
+    public void testColumnsQuery() {
+        ColumnSelect<Object[]> query = property.columnQuery(Artist.ARTIST_NAME, Artist.DATE_OF_BIRTH);
+
+        assertNotNull(query);
+        assertEquals(Artist.class, query.getEntityType());
+        assertEquals(2, query.getColumns().size());
+        Iterator<Property<?>> iterator = query.getColumns().iterator();
+        assertEquals(Artist.ARTIST_NAME, iterator.next());
+        assertEquals(Artist.DATE_OF_BIRTH, iterator.next());
+        assertNull(query.getWhere());
+    }
+
+    @Test
+    public void testExists() {
+        Expression exp = property.exists(Artist.ARTIST_NAME.eq("test"));
+
+        assertNotNull(exp);
+        assertTrue(exp instanceof ASTExists);
+
+        ASTExists exists = (ASTExists) exp;
+        Node node = exists.jjtGetChild(0);
+        assertTrue(node instanceof ASTSubquery);
+
+        ASTSubquery subquery = (ASTSubquery) node;
+        assertTrue(subquery.getQuery().unwrap() instanceof ObjectSelect);
+
+        ObjectSelect<?> subSelect = (ObjectSelect<?>) subquery.getQuery().unwrap();
+        assertEquals(Artist.class, subSelect.getEntityType());
+        assertEquals(ExpressionFactory.exp("artistName = 'test'"), subSelect.getWhere());
+    }
+
+    @Test
+    public void testNotExists() {
+        Expression exp = property.notExists(Artist.ARTIST_NAME.eq("test"));
+
+        assertNotNull(exp);
+        assertTrue(exp instanceof ASTNotExists);
+
+        ASTNotExists exists = (ASTNotExists) exp;
+        Node node = exists.jjtGetChild(0);
+        assertTrue(node instanceof ASTSubquery);
+
+        ASTSubquery subquery = (ASTSubquery) node;
+        assertTrue(subquery.getQuery().unwrap() instanceof ObjectSelect);
+
+        ObjectSelect<?> subSelect = (ObjectSelect<?>) subquery.getQuery().unwrap();
+        assertEquals(Artist.class, subSelect.getEntityType());
+        assertEquals(ExpressionFactory.exp("artistName = 'test'"), subSelect.getWhere());
+    }
+}

--- a/cayenne-server/src/test/java/org/apache/cayenne/query/ColumnSelectIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/query/ColumnSelectIT.java
@@ -917,7 +917,7 @@ public class ColumnSelectIT extends ServerCase {
 
     @Test
     public void testSelfPropertyInWhere() {
-        Artist artist = ObjectSelect.query(Artist.class).selectFirst(context);
+        Artist artist = Artist.SELF.query().selectFirst(context);
         Artist selectedArtist = ObjectSelect.query(Artist.class)
                 .column(Artist.SELF)
                 .where(Artist.SELF.eq(artist))

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_ArtGroup.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_ArtGroup.java
@@ -10,6 +10,7 @@ import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.ListProperty;
 import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
+import org.apache.cayenne.exp.property.SelfProperty;
 import org.apache.cayenne.exp.property.StringProperty;
 import org.apache.cayenne.testdo.testmap.ArtGroup;
 import org.apache.cayenne.testdo.testmap.Artist;
@@ -24,7 +25,7 @@ public abstract class _ArtGroup extends BaseDataObject {
 
     private static final long serialVersionUID = 1L;
 
-    public static final EntityProperty<ArtGroup> SELF = PropertyFactory.createSelf(ArtGroup.class);
+    public static final SelfProperty<ArtGroup> SELF = PropertyFactory.createSelf(ArtGroup.class);
 
     public static final NumericIdProperty<Integer> GROUP_ID_PK_PROPERTY = PropertyFactory.createNumericId("GROUP_ID", "ArtGroup", Integer.class);
     public static final String GROUP_ID_PK_COLUMN = "GROUP_ID";

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_Artist.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_Artist.java
@@ -8,10 +8,10 @@ import java.util.List;
 
 import org.apache.cayenne.BaseDataObject;
 import org.apache.cayenne.exp.property.DateProperty;
-import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.ListProperty;
 import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
+import org.apache.cayenne.exp.property.SelfProperty;
 import org.apache.cayenne.exp.property.StringProperty;
 import org.apache.cayenne.testdo.testmap.ArtGroup;
 import org.apache.cayenne.testdo.testmap.Artist;
@@ -32,7 +32,7 @@ public abstract class _Artist extends BaseDataObject {
 
     private static final long serialVersionUID = 1L;
 
-    public static final EntityProperty<Artist> SELF = PropertyFactory.createSelf(Artist.class);
+    public static final SelfProperty<Artist> SELF = PropertyFactory.createSelf(Artist.class);
 
     public static final NumericIdProperty<Long> ARTIST_ID_PK_PROPERTY = PropertyFactory.createNumericId("ARTIST_ID", "Artist", Long.class);
     public static final String ARTIST_ID_PK_COLUMN = "ARTIST_ID";

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_ArtistCallback.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_ArtistCallback.java
@@ -7,9 +7,9 @@ import java.util.Date;
 
 import org.apache.cayenne.BaseDataObject;
 import org.apache.cayenne.exp.property.DateProperty;
-import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
+import org.apache.cayenne.exp.property.SelfProperty;
 import org.apache.cayenne.exp.property.StringProperty;
 import org.apache.cayenne.testdo.testmap.ArtistCallback;
 
@@ -23,7 +23,7 @@ public abstract class _ArtistCallback extends BaseDataObject {
 
     private static final long serialVersionUID = 1L;
 
-    public static final EntityProperty<ArtistCallback> SELF = PropertyFactory.createSelf(ArtistCallback.class);
+    public static final SelfProperty<ArtistCallback> SELF = PropertyFactory.createSelf(ArtistCallback.class);
 
     public static final NumericIdProperty<Integer> ARTIST_ID_PK_PROPERTY = PropertyFactory.createNumericId("ARTIST_ID", "ArtistCallback", Integer.class);
     public static final String ARTIST_ID_PK_COLUMN = "ARTIST_ID";

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_ArtistExhibit.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_ArtistExhibit.java
@@ -8,6 +8,7 @@ import org.apache.cayenne.BaseDataObject;
 import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
+import org.apache.cayenne.exp.property.SelfProperty;
 import org.apache.cayenne.testdo.testmap.Artist;
 import org.apache.cayenne.testdo.testmap.ArtistExhibit;
 import org.apache.cayenne.testdo.testmap.Exhibit;
@@ -22,7 +23,7 @@ public abstract class _ArtistExhibit extends BaseDataObject {
 
     private static final long serialVersionUID = 1L;
 
-    public static final EntityProperty<ArtistExhibit> SELF = PropertyFactory.createSelf(ArtistExhibit.class);
+    public static final SelfProperty<ArtistExhibit> SELF = PropertyFactory.createSelf(ArtistExhibit.class);
 
     public static final NumericIdProperty<Long> ARTIST_ID_PK_PROPERTY = PropertyFactory.createNumericId("ARTIST_ID", "ArtistExhibit", Long.class);
     public static final String ARTIST_ID_PK_COLUMN = "ARTIST_ID";

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_CompoundPainting.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_CompoundPainting.java
@@ -10,6 +10,7 @@ import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.NumericProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
+import org.apache.cayenne.exp.property.SelfProperty;
 import org.apache.cayenne.exp.property.StringProperty;
 import org.apache.cayenne.testdo.testmap.Artist;
 import org.apache.cayenne.testdo.testmap.CompoundPainting;
@@ -26,7 +27,7 @@ public abstract class _CompoundPainting extends BaseDataObject {
 
     private static final long serialVersionUID = 1L;
 
-    public static final EntityProperty<CompoundPainting> SELF = PropertyFactory.createSelf(CompoundPainting.class);
+    public static final SelfProperty<CompoundPainting> SELF = PropertyFactory.createSelf(CompoundPainting.class);
 
     public static final NumericIdProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumericId("PAINTING_ID", "CompoundPainting", Integer.class);
     public static final String PAINTING_ID_PK_COLUMN = "PAINTING_ID";

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_CompoundPaintingLongNames.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_CompoundPaintingLongNames.java
@@ -10,6 +10,7 @@ import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.NumericProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
+import org.apache.cayenne.exp.property.SelfProperty;
 import org.apache.cayenne.exp.property.StringProperty;
 import org.apache.cayenne.testdo.testmap.Artist;
 import org.apache.cayenne.testdo.testmap.CompoundPaintingLongNames;
@@ -27,7 +28,7 @@ public abstract class _CompoundPaintingLongNames extends BaseDataObject {
 
     private static final long serialVersionUID = 1L;
 
-    public static final EntityProperty<CompoundPaintingLongNames> SELF = PropertyFactory.createSelf(CompoundPaintingLongNames.class);
+    public static final SelfProperty<CompoundPaintingLongNames> SELF = PropertyFactory.createSelf(CompoundPaintingLongNames.class);
 
     public static final NumericIdProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumericId("PAINTING_ID", "CompoundPaintingLongNames", Integer.class);
     public static final String PAINTING_ID_PK_COLUMN = "PAINTING_ID";

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_Exhibit.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_Exhibit.java
@@ -12,6 +12,7 @@ import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.ListProperty;
 import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
+import org.apache.cayenne.exp.property.SelfProperty;
 import org.apache.cayenne.testdo.testmap.ArtistExhibit;
 import org.apache.cayenne.testdo.testmap.Exhibit;
 import org.apache.cayenne.testdo.testmap.Gallery;
@@ -26,7 +27,7 @@ public abstract class _Exhibit extends BaseDataObject {
 
     private static final long serialVersionUID = 1L;
 
-    public static final EntityProperty<Exhibit> SELF = PropertyFactory.createSelf(Exhibit.class);
+    public static final SelfProperty<Exhibit> SELF = PropertyFactory.createSelf(Exhibit.class);
 
     public static final NumericIdProperty<Integer> EXHIBIT_ID_PK_PROPERTY = PropertyFactory.createNumericId("EXHIBIT_ID", "Exhibit", Integer.class);
     public static final String EXHIBIT_ID_PK_COLUMN = "EXHIBIT_ID";

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_Gallery.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_Gallery.java
@@ -6,10 +6,10 @@ import java.io.ObjectOutputStream;
 import java.util.List;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.ListProperty;
 import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
+import org.apache.cayenne.exp.property.SelfProperty;
 import org.apache.cayenne.exp.property.StringProperty;
 import org.apache.cayenne.testdo.testmap.Exhibit;
 import org.apache.cayenne.testdo.testmap.Gallery;
@@ -25,7 +25,7 @@ public abstract class _Gallery extends BaseDataObject {
 
     private static final long serialVersionUID = 1L;
 
-    public static final EntityProperty<Gallery> SELF = PropertyFactory.createSelf(Gallery.class);
+    public static final SelfProperty<Gallery> SELF = PropertyFactory.createSelf(Gallery.class);
 
     public static final NumericIdProperty<Integer> GALLERY_ID_PK_PROPERTY = PropertyFactory.createNumericId("GALLERY_ID", "Gallery", Integer.class);
     public static final String GALLERY_ID_PK_COLUMN = "GALLERY_ID";

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_MeaningfulGeneratedColumnTestEntity.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_MeaningfulGeneratedColumnTestEntity.java
@@ -5,9 +5,9 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.NumericProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
+import org.apache.cayenne.exp.property.SelfProperty;
 import org.apache.cayenne.exp.property.StringProperty;
 import org.apache.cayenne.testdo.testmap.MeaningfulGeneratedColumnTestEntity;
 
@@ -21,7 +21,7 @@ public abstract class _MeaningfulGeneratedColumnTestEntity extends BaseDataObjec
 
     private static final long serialVersionUID = 1L;
 
-    public static final EntityProperty<MeaningfulGeneratedColumnTestEntity> SELF = PropertyFactory.createSelf(MeaningfulGeneratedColumnTestEntity.class);
+    public static final SelfProperty<MeaningfulGeneratedColumnTestEntity> SELF = PropertyFactory.createSelf(MeaningfulGeneratedColumnTestEntity.class);
 
     public static final String GENERATED_COLUMN_PK_COLUMN = "GENERATED_COLUMN";
 

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_NullTestEntity.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_NullTestEntity.java
@@ -5,9 +5,9 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
+import org.apache.cayenne.exp.property.SelfProperty;
 import org.apache.cayenne.exp.property.StringProperty;
 import org.apache.cayenne.testdo.testmap.NullTestEntity;
 
@@ -21,7 +21,7 @@ public abstract class _NullTestEntity extends BaseDataObject {
 
     private static final long serialVersionUID = 1L;
 
-    public static final EntityProperty<NullTestEntity> SELF = PropertyFactory.createSelf(NullTestEntity.class);
+    public static final SelfProperty<NullTestEntity> SELF = PropertyFactory.createSelf(NullTestEntity.class);
 
     public static final NumericIdProperty<Integer> ID_PK_PROPERTY = PropertyFactory.createNumericId("ID", "NullTestEntity", Integer.class);
     public static final String ID_PK_COLUMN = "ID";

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_Painting.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_Painting.java
@@ -9,6 +9,7 @@ import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.NumericProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
+import org.apache.cayenne.exp.property.SelfProperty;
 import org.apache.cayenne.exp.property.StringProperty;
 import org.apache.cayenne.testdo.testmap.ArtDataObject;
 import org.apache.cayenne.testdo.testmap.Artist;
@@ -26,7 +27,7 @@ public abstract class _Painting extends ArtDataObject {
 
     private static final long serialVersionUID = 1L;
 
-    public static final EntityProperty<Painting> SELF = PropertyFactory.createSelf(Painting.class);
+    public static final SelfProperty<Painting> SELF = PropertyFactory.createSelf(Painting.class);
 
     public static final NumericIdProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumericId("PAINTING_ID", "Painting", Integer.class);
     public static final String PAINTING_ID_PK_COLUMN = "PAINTING_ID";

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_Painting1.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_Painting1.java
@@ -10,6 +10,7 @@ import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.NumericProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
+import org.apache.cayenne.exp.property.SelfProperty;
 import org.apache.cayenne.exp.property.StringProperty;
 import org.apache.cayenne.testdo.testmap.Artist;
 import org.apache.cayenne.testdo.testmap.Painting1;
@@ -24,7 +25,7 @@ public abstract class _Painting1 extends BaseDataObject {
 
     private static final long serialVersionUID = 1L;
 
-    public static final EntityProperty<Painting1> SELF = PropertyFactory.createSelf(Painting1.class);
+    public static final SelfProperty<Painting1> SELF = PropertyFactory.createSelf(Painting1.class);
 
     public static final NumericIdProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumericId("PAINTING_ID", "Painting1", Integer.class);
     public static final String PAINTING_ID_PK_COLUMN = "PAINTING_ID";

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_PaintingInfo.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_PaintingInfo.java
@@ -9,6 +9,7 @@ import org.apache.cayenne.exp.property.BaseProperty;
 import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
+import org.apache.cayenne.exp.property.SelfProperty;
 import org.apache.cayenne.exp.property.StringProperty;
 import org.apache.cayenne.testdo.testmap.Painting;
 import org.apache.cayenne.testdo.testmap.PaintingInfo;
@@ -23,7 +24,7 @@ public abstract class _PaintingInfo extends BaseDataObject {
 
     private static final long serialVersionUID = 1L;
 
-    public static final EntityProperty<PaintingInfo> SELF = PropertyFactory.createSelf(PaintingInfo.class);
+    public static final SelfProperty<PaintingInfo> SELF = PropertyFactory.createSelf(PaintingInfo.class);
 
     public static final NumericIdProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumericId("PAINTING_ID", "PaintingInfo", Integer.class);
     public static final String PAINTING_ID_PK_COLUMN = "PAINTING_ID";

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_ROArtist.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_ROArtist.java
@@ -8,10 +8,10 @@ import java.util.List;
 
 import org.apache.cayenne.BaseDataObject;
 import org.apache.cayenne.exp.property.DateProperty;
-import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.ListProperty;
 import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
+import org.apache.cayenne.exp.property.SelfProperty;
 import org.apache.cayenne.exp.property.StringProperty;
 import org.apache.cayenne.testdo.testmap.Painting;
 import org.apache.cayenne.testdo.testmap.ROArtist;
@@ -26,7 +26,7 @@ public abstract class _ROArtist extends BaseDataObject {
 
     private static final long serialVersionUID = 1L;
 
-    public static final EntityProperty<ROArtist> SELF = PropertyFactory.createSelf(ROArtist.class);
+    public static final SelfProperty<ROArtist> SELF = PropertyFactory.createSelf(ROArtist.class);
 
     public static final NumericIdProperty<Long> ARTIST_ID_PK_PROPERTY = PropertyFactory.createNumericId("ARTIST_ID", "ROArtist", Long.class);
     public static final String ARTIST_ID_PK_COLUMN = "ARTIST_ID";

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_ROPainting.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_ROPainting.java
@@ -10,6 +10,7 @@ import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.NumericProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
+import org.apache.cayenne.exp.property.SelfProperty;
 import org.apache.cayenne.exp.property.StringProperty;
 import org.apache.cayenne.testdo.testmap.Artist;
 import org.apache.cayenne.testdo.testmap.ROPainting;
@@ -24,7 +25,7 @@ public abstract class _ROPainting extends BaseDataObject {
 
     private static final long serialVersionUID = 1L;
 
-    public static final EntityProperty<ROPainting> SELF = PropertyFactory.createSelf(ROPainting.class);
+    public static final SelfProperty<ROPainting> SELF = PropertyFactory.createSelf(ROPainting.class);
 
     public static final NumericIdProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumericId("PAINTING_ID", "ROPainting", Integer.class);
     public static final String PAINTING_ID_PK_COLUMN = "PAINTING_ID";

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_RWCompoundPainting.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_RWCompoundPainting.java
@@ -6,10 +6,10 @@ import java.io.ObjectOutputStream;
 import java.math.BigDecimal;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.NumericProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
+import org.apache.cayenne.exp.property.SelfProperty;
 import org.apache.cayenne.exp.property.StringProperty;
 import org.apache.cayenne.testdo.testmap.RWCompoundPainting;
 
@@ -23,7 +23,7 @@ public abstract class _RWCompoundPainting extends BaseDataObject {
 
     private static final long serialVersionUID = 1L;
 
-    public static final EntityProperty<RWCompoundPainting> SELF = PropertyFactory.createSelf(RWCompoundPainting.class);
+    public static final SelfProperty<RWCompoundPainting> SELF = PropertyFactory.createSelf(RWCompoundPainting.class);
 
     public static final NumericIdProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumericId("PAINTING_ID", "RWCompoundPainting", Integer.class);
     public static final String PAINTING_ID_PK_COLUMN = "PAINTING_ID";

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_SubPainting.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/testmap/auto/_SubPainting.java
@@ -5,9 +5,9 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 import org.apache.cayenne.BaseDataObject;
-import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.NumericIdProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
+import org.apache.cayenne.exp.property.SelfProperty;
 import org.apache.cayenne.exp.property.StringProperty;
 import org.apache.cayenne.testdo.testmap.SubPainting;
 
@@ -21,7 +21,7 @@ public abstract class _SubPainting extends BaseDataObject {
 
     private static final long serialVersionUID = 1L;
 
-    public static final EntityProperty<SubPainting> SELF = PropertyFactory.createSelf(SubPainting.class);
+    public static final SelfProperty<SubPainting> SELF = PropertyFactory.createSelf(SubPainting.class);
 
     public static final NumericIdProperty<Integer> PAINTING_ID_PK_PROPERTY = PropertyFactory.createNumericId("PAINTING_ID", "SubPainting", Integer.class);
     public static final String PAINTING_ID_PK_COLUMN = "PAINTING_ID";


### PR DESCRIPTION
Here are some usage examples of the methods added:
```java
// query() method to create ObjectSelect
List<Artist> artistList = Artist.SELF.query().select(context);
// same with a where clause
Artist artistById = Artist.SELF.query(Artist.SELF.eqId(1)).selectOne(context);
// shortcut for a EXISTS/NOT EXISTS subquery 
long count = Artist.SELF.query(Painting.SELF.notExists(Painting.TO_ARTIST.eq(Artist.SELF.enclosing()))).selectCount(context);
// column select
List<String> names = Artist.SELF.columnQuery(Artist.ARTIST_NAME).select(context);
```