### PR TITLE
ServerModule conversion to extender API

### DIFF
--- a/cayenne-cache-invalidation/src/main/java/org/apache/cayenne/cache/invalidation/CacheInvalidationModule.java
+++ b/cayenne-cache-invalidation/src/main/java/org/apache/cayenne/cache/invalidation/CacheInvalidationModule.java
@@ -23,7 +23,6 @@ import org.apache.cayenne.configuration.server.ServerModule;
 import org.apache.cayenne.di.Binder;
 import org.apache.cayenne.di.ListBuilder;
 import org.apache.cayenne.di.Module;
-import org.apache.cayenne.tx.TransactionFilter;
 
 /**
  * This module is autoloaded, all extensions should be done via {@link CacheInvalidationModuleExtender}.
@@ -52,7 +51,6 @@ public class CacheInvalidationModule implements Module {
         contributeInvalidationHandler(binder).add(CacheGroupsHandler.class);
 
         // want the filter to be INSIDE transaction by default
-        ServerModule.contributeDomainSyncFilters(binder)
-                .insertBefore(CacheInvalidationFilter.class, TransactionFilter.class);
+        ServerModule.extend(binder).addSyncFilter(CacheInvalidationFilter.class, true);
     }
 }

--- a/cayenne-cgen/src/main/java/org/apache/cayenne/gen/CgenModule.java
+++ b/cayenne-cgen/src/main/java/org/apache/cayenne/gen/CgenModule.java
@@ -47,9 +47,9 @@ public class CgenModule implements Module {
         binder.bind(ToolsUtilsFactory.class).to(DefaultToolsUtilsFactory.class);
         binder.bind(MetadataUtils.class).to(MetadataUtils.class);
 
-        ProjectModule.contributeExtensions(binder)
-                .add(CgenExtension.class)
-                .add(InfoExtension.class); // info extension needed to get comments and other metadata
+        ProjectModule.extend(binder)
+                .addExtension(CgenExtension.class)
+                .addExtension(InfoExtension.class); // info extension needed to get comments and other metadata
 
         contributeUserProperties(binder)
                 .add(NumericPropertyDescriptorCreator.class)
@@ -58,6 +58,7 @@ public class CgenModule implements Module {
                 .add(EmbeddablePropertyDescriptorCreator.class);
     }
 
+    // TODO: either convert to an Extender to make non-public
     public static ListBuilder<PropertyDescriptorCreator> contributeUserProperties(Binder binder) {
         return binder.bindList(PropertyDescriptorCreator.class);
     }

--- a/cayenne-cgen/src/test/java/org/apache/cayenne/gen/PropertyUtilsTest.java
+++ b/cayenne-cgen/src/test/java/org/apache/cayenne/gen/PropertyUtilsTest.java
@@ -19,9 +19,6 @@
 
 package org.apache.cayenne.gen;
 
-import java.util.List;
-import java.util.Map;
-
 import org.apache.cayenne.access.types.TimestampType;
 import org.apache.cayenne.configuration.server.ServerModule;
 import org.apache.cayenne.di.DIBootstrap;
@@ -48,6 +45,9 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -67,10 +67,10 @@ public class PropertyUtilsTest {
         importUtils = new ImportUtils();
 
         DefaultScope testScope = new DefaultScope();
-        propertyUtils = DIBootstrap.createInjector(new CgenCaseModule(testScope), new CgenModule(),
-                binder ->
-                        ServerModule.contributeUserTypes(binder)
-                                .add(new TimestampType()))
+        propertyUtils = DIBootstrap.createInjector(
+                        new CgenCaseModule(testScope),
+                        new CgenModule(),
+                        binder -> ServerModule.extend(binder).addUserExtendedType(new TimestampType()))
                 .getInstance(ToolsUtilsFactory.class)
                 .createPropertyUtils(logger, importUtils);
     }

--- a/cayenne-commitlog/src/main/java/org/apache/cayenne/commitlog/CommitLogModuleExtender.java
+++ b/cayenne-commitlog/src/main/java/org/apache/cayenne/commitlog/CommitLogModuleExtender.java
@@ -25,7 +25,6 @@ import org.apache.cayenne.commitlog.meta.IncludeAllCommitLogEntityFactory;
 import org.apache.cayenne.configuration.server.ServerModule;
 import org.apache.cayenne.di.ListBuilder;
 import org.apache.cayenne.di.Module;
-import org.apache.cayenne.tx.TransactionFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,11 +113,7 @@ public class CommitLogModuleExtender {
                 listeners.add(type);
             }
 
-            if (excludeFromTransaction) {
-                ServerModule.contributeDomainSyncFilters(binder).addAfter(CommitLogFilter.class, TransactionFilter.class);
-            } else {
-                ServerModule.contributeDomainSyncFilters(binder).insertBefore(CommitLogFilter.class, TransactionFilter.class);
-            }
+            ServerModule.extend(binder).addSyncFilter(CommitLogFilter.class, !excludeFromTransaction);
         };
     }
 }

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/configuration/ToolsModule.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/configuration/ToolsModule.java
@@ -87,7 +87,6 @@ import org.apache.cayenne.di.spi.DefaultAdhocObjectFactory;
 import org.apache.cayenne.di.spi.DefaultClassLoaderManager;
 import org.apache.cayenne.log.JdbcEventLogger;
 import org.apache.cayenne.log.Slf4jJdbcEventLogger;
-import org.apache.cayenne.project.ProjectModule;
 import org.apache.cayenne.project.extension.ExtensionAwareHandlerFactory;
 import org.apache.cayenne.reflect.generic.DefaultValueComparisonStrategyFactory;
 import org.apache.cayenne.reflect.generic.ValueComparisonStrategyFactory;
@@ -113,7 +112,9 @@ public class ToolsModule implements Module {
 
     public void configure(Binder binder) {
 
-        new ToolsModuleExtender(binder)
+        new ToolsProjectModuleExtender(binder).initAllExtensions();
+
+        new ToolsServerModuleExtender(binder)
                 .initAllExtensions()
 
                 .addAdapterDetector(FirebirdSniffer.class)
@@ -169,8 +170,6 @@ public class ToolsModule implements Module {
         binder.bind(XMLReader.class).toProviderInstance(new XMLReaderProvider(true)).withoutScope();
         binder.bind(DataDomainFlushActionFactory.class).to(DefaultDataDomainFlushActionFactory.class);
         binder.bind(DbRowOpSorter.class).to(DefaultDbRowOpSorter.class);
-
-        ProjectModule.contributeExtensions(binder);
     }
 
 }

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/configuration/ToolsModuleExtender.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/configuration/ToolsModuleExtender.java
@@ -16,18 +16,21 @@
  *  specific language governing permissions and limitations
  *  under the License.
  ****************************************************************/
-package org.apache.cayenne.unit.di.server;
 
-import org.apache.cayenne.configuration.Constants;
-import org.apache.cayenne.configuration.server.ServerModule;
+package org.apache.cayenne.dbsync.reverse.configuration;
+
+import org.apache.cayenne.configuration.server.ServerModuleExtender;
 import org.apache.cayenne.di.Binder;
-import org.apache.cayenne.di.Module;
 
-public class WeakReferenceStrategyModule implements Module {
+// this class exists so that ToolsModule can call "initAllExtensions()" that is protected in ServerModuleExtender.
+class ToolsModuleExtender extends ServerModuleExtender {
+
+    public ToolsModuleExtender(Binder binder) {
+        super(binder);
+    }
+
     @Override
-    public void configure(Binder binder) {
-        ServerModule.contributeProperties(binder)
-                //Use in ObjectStoreGCIT
-                .put(Constants.SERVER_OBJECT_RETAIN_STRATEGY_PROPERTY, "weak");
+    protected ServerModuleExtender initAllExtensions() {
+        return super.initAllExtensions();
     }
 }

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/configuration/ToolsProjectModuleExtender.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/configuration/ToolsProjectModuleExtender.java
@@ -1,0 +1,36 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.dbsync.reverse.configuration;
+
+import org.apache.cayenne.di.Binder;
+import org.apache.cayenne.project.ProjectModuleExtender;
+
+// this class exists so that ToolsModule can call "initAllExtensions()" that is protected in ServerModuleExtender.
+class ToolsProjectModuleExtender extends ProjectModuleExtender {
+
+    public ToolsProjectModuleExtender(Binder binder) {
+        super(binder);
+    }
+
+    @Override
+    protected ProjectModuleExtender initAllExtensions() {
+        return super.initAllExtensions();
+    }
+}

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/configuration/ToolsServerModuleExtender.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/configuration/ToolsServerModuleExtender.java
@@ -23,9 +23,9 @@ import org.apache.cayenne.configuration.server.ServerModuleExtender;
 import org.apache.cayenne.di.Binder;
 
 // this class exists so that ToolsModule can call "initAllExtensions()" that is protected in ServerModuleExtender.
-class ToolsModuleExtender extends ServerModuleExtender {
+class ToolsServerModuleExtender extends ServerModuleExtender {
 
-    public ToolsModuleExtender(Binder binder) {
+    public ToolsServerModuleExtender(Binder binder) {
         super(binder);
     }
 

--- a/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/dbimport/DbImportModule.java
+++ b/cayenne-dbsync/src/main/java/org/apache/cayenne/dbsync/reverse/dbimport/DbImportModule.java
@@ -52,7 +52,8 @@ public class DbImportModule implements Module {
         binder.bind(HandlerFactory.class).to(DefaultHandlerFactory.class);
         binder.bind(DataChannelMetaData.class).to(DefaultDataChannelMetaData.class);
         binder.bind(HandlerFactory.class).to(ExtensionAwareHandlerFactory.class);
-        ProjectModule.contributeExtensions(binder).add(DbImportExtension.class);
+
+        ProjectModule.extend(binder).addExtension(DbImportExtension.class);
     }
 
 }

--- a/cayenne-jcache/src/main/java/org/apache/cayenne/jcache/JCacheModuleExtender.java
+++ b/cayenne-jcache/src/main/java/org/apache/cayenne/jcache/JCacheModuleExtender.java
@@ -16,41 +16,24 @@
  *  specific language governing permissions and limitations
  *  under the License.
  ****************************************************************/
-
 package org.apache.cayenne.jcache;
 
-import org.apache.cayenne.cache.QueryCache;
+import org.apache.cayenne.configuration.server.ServerModule;
 import org.apache.cayenne.di.Binder;
-import org.apache.cayenne.di.Module;
-
-import javax.cache.CacheManager;
 
 /**
- * <p>
- * JCache Module
- * </p>
- *
- * @since 4.0
+ * @since 5.0
  */
-public class JCacheModule implements Module {
+public class JCacheModuleExtender {
 
-    public static JCacheModuleExtender extend(Binder binder) {
-        return new JCacheModuleExtender(binder);
+    private final Binder binder;
+
+    protected JCacheModuleExtender(Binder binder) {
+        this.binder = binder;
     }
 
-    /**
-     * @deprecated in favor of {@link #extend(Binder)}
-     */
-    @Deprecated(since = "5.0")
-    public static void contributeJCacheProviderConfig(Binder binder, String providerConfigURI) {
-        extend(binder).setJCacheProviderConfig(providerConfigURI);
+    public JCacheModuleExtender setJCacheProviderConfig(String providerConfigURI) {
+        ServerModule.extend(binder).setProperty(JCacheConstants.JCACHE_PROVIDER_CONFIG, providerConfigURI);
+        return this;
     }
-
-    @Override
-    public void configure(Binder binder) {
-        binder.bind(CacheManager.class).toProvider(JCacheManagerProvider.class);
-        binder.bind(JCacheConfigurationFactory.class).to(JCacheDefaultConfigurationFactory.class);
-        binder.bind(QueryCache.class).to(JCacheQueryCache.class);
-    }
-
 }

--- a/cayenne-jcache/src/test/java/org/apache/cayenne/jcache/unit/CacheServerRuntimeProvider.java
+++ b/cayenne-jcache/src/test/java/org/apache/cayenne/jcache/unit/CacheServerRuntimeProvider.java
@@ -19,10 +19,6 @@
 
 package org.apache.cayenne.jcache.unit;
 
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Collection;
-
 import org.apache.cayenne.CayenneRuntimeException;
 import org.apache.cayenne.dba.DbAdapter;
 import org.apache.cayenne.di.Inject;
@@ -33,6 +29,10 @@ import org.apache.cayenne.unit.UnitDbAdapter;
 import org.apache.cayenne.unit.di.server.ServerCaseDataSourceFactory;
 import org.apache.cayenne.unit.di.server.ServerCaseProperties;
 import org.apache.cayenne.unit.di.server.ServerRuntimeProvider;
+
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collection;
 
 public class CacheServerRuntimeProvider extends ServerRuntimeProvider {
 
@@ -55,8 +55,7 @@ public class CacheServerRuntimeProvider extends ServerRuntimeProvider {
             throw new CayenneRuntimeException("Unable to resolve ehcache config resource URI.");
         }
 
-        modules.add(binder -> JCacheModule
-                .contributeJCacheProviderConfig(binder, configURI));
+        modules.add(b -> JCacheModule.extend(b).setJCacheProviderConfig(configURI));
         return modules;
     }
 }

--- a/cayenne-project-compatibility/src/main/java/org/apache/cayenne/project/compatibility/ProjectCompatibilityModule.java
+++ b/cayenne-project-compatibility/src/main/java/org/apache/cayenne/project/compatibility/ProjectCompatibilityModule.java
@@ -46,11 +46,11 @@ public class ProjectCompatibilityModule implements Module {
         binder.bind(UpgradeService.class).to(CompatibilityUpgradeService.class);
         binder.bind(DocumentProvider.class).to(DefaultDocumentProvider.class);
 
-        ProjectModule.contributeUpgradeHandler(binder)
-                .add(UpgradeHandler_V7.class)
-                .add(UpgradeHandler_V8.class)
-                .add(UpgradeHandler_V9.class)
-                .add(UpgradeHandler_V10.class)
-                .add(UpgradeHandler_V11.class);
+        ProjectModule.extend(binder)
+                .addUpgradeHandler(UpgradeHandler_V7.class)
+                .addUpgradeHandler(UpgradeHandler_V8.class)
+                .addUpgradeHandler(UpgradeHandler_V9.class)
+                .addUpgradeHandler(UpgradeHandler_V10.class)
+                .addUpgradeHandler(UpgradeHandler_V11.class);
     }
 }

--- a/cayenne-project/src/main/java/org/apache/cayenne/project/ProjectModule.java
+++ b/cayenne-project/src/main/java/org/apache/cayenne/project/ProjectModule.java
@@ -44,15 +44,26 @@ import org.apache.cayenne.project.validation.ProjectValidator;
 public class ProjectModule implements Module {
 
     /**
-     * @since 4.1
+     * @since 5.0
      */
+    public static ProjectModuleExtender extend(Binder binder) {
+        return new ProjectModuleExtender(binder);
+    }
+
+    /**
+     * @since 4.1
+     * @deprecated in favor of {@link #extend(Binder)}
+     */
+    @Deprecated(since = "5.0")
     public static ListBuilder<ProjectExtension> contributeExtensions(Binder binder) {
         return binder.bindList(ProjectExtension.class);
     }
 
     /**
      * @since 4.1
+     * @deprecated in favor of {@link #extend(Binder)}
      */
+    @Deprecated(since = "5.0")
     public static ListBuilder<UpgradeHandler> contributeUpgradeHandler(Binder binder) {
         return binder.bindList(UpgradeHandler.class);
     }
@@ -65,14 +76,15 @@ public class ProjectModule implements Module {
         binder.bind(ConfigurationNameMapper.class).to(DefaultConfigurationNameMapper.class);
 
         binder.bind(UpgradeService.class).to(DefaultUpgradeService.class);
-        // Note: order is important
-        contributeUpgradeHandler(binder)
-                .add(UpgradeHandler_V7.class)
-                .add(UpgradeHandler_V8.class)
-                .add(UpgradeHandler_V9.class)
-                .add(UpgradeHandler_V10.class)
-                .add(UpgradeHandler_V11.class);
 
-        contributeExtensions(binder);
+        extend(binder)
+                .initAllExtensions()
+
+                // Note: order is important
+                .addUpgradeHandler(UpgradeHandler_V7.class)
+                .addUpgradeHandler(UpgradeHandler_V8.class)
+                .addUpgradeHandler(UpgradeHandler_V9.class)
+                .addUpgradeHandler(UpgradeHandler_V10.class)
+                .addUpgradeHandler(UpgradeHandler_V11.class);
     }
 }

--- a/cayenne-project/src/main/java/org/apache/cayenne/project/ProjectModuleExtender.java
+++ b/cayenne-project/src/main/java/org/apache/cayenne/project/ProjectModuleExtender.java
@@ -1,0 +1,55 @@
+package org.apache.cayenne.project;
+
+import org.apache.cayenne.di.Binder;
+import org.apache.cayenne.di.ListBuilder;
+import org.apache.cayenne.project.extension.ProjectExtension;
+import org.apache.cayenne.project.upgrade.handlers.UpgradeHandler;
+
+/**
+ * @since 5.0
+ */
+public class ProjectModuleExtender {
+
+    private final Binder binder;
+
+    private ListBuilder<UpgradeHandler> upgradeHandlers;
+    private ListBuilder<ProjectExtension> extensions;
+
+    public ProjectModuleExtender(Binder binder) {
+        this.binder = binder;
+    }
+
+    protected ProjectModuleExtender initAllExtensions() {
+        contributeExtensions();
+        contributeUpgradeHandler();
+        return this;
+    }
+
+    public ProjectModuleExtender addUpgradeHandler(UpgradeHandler handler) {
+        contributeUpgradeHandler().add(handler);
+        return this;
+    }
+
+    public ProjectModuleExtender addUpgradeHandler(Class<? extends UpgradeHandler> handler) {
+        contributeUpgradeHandler().add(handler);
+        return this;
+    }
+
+    public ProjectModuleExtender addExtension(ProjectExtension extension) {
+        contributeExtensions().add(extension);
+        return this;
+    }
+
+    public ProjectModuleExtender addExtension(Class<? extends ProjectExtension> extension) {
+        contributeExtensions().add(extension);
+        return this;
+    }
+
+    private ListBuilder<ProjectExtension> contributeExtensions() {
+        return extensions != null ? extensions : (extensions = binder.bindList(ProjectExtension.class));
+    }
+
+    private ListBuilder<UpgradeHandler> contributeUpgradeHandler() {
+        return upgradeHandlers != null ? upgradeHandlers : (upgradeHandlers = binder.bindList(UpgradeHandler.class));
+    }
+}

--- a/cayenne-project/src/main/java/org/apache/cayenne/project/extension/ProjectExtension.java
+++ b/cayenne-project/src/main/java/org/apache/cayenne/project/extension/ProjectExtension.java
@@ -29,7 +29,7 @@ import org.apache.cayenne.configuration.ConfigurationNodeVisitor;
  *     so they can safely store big chunks of data.
  * </p>
  * <p>
- *     Extensions can be contributed by {@link org.apache.cayenne.project.ProjectModule#contributeExtensions(org.apache.cayenne.di.Binder)}.
+ *     Extensions can be contributed by {@link org.apache.cayenne.project.ProjectModuleExtender#addExtension(ProjectExtension)}
  *     {@link org.apache.cayenne.project.ProjectModule} currently used by Modeler and cli tools, e.g. cdbimport and cgen.
  * </p>
  *

--- a/cayenne-server/src/main/java/org/apache/cayenne/DataChannelQueryFilter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/DataChannelQueryFilter.java
@@ -38,7 +38,7 @@ import org.apache.cayenne.query.Query;
  * }}</pre>
  *
  * @see DataChannelSyncFilter
- * @see org.apache.cayenne.configuration.server.ServerModule#contributeDomainQueryFilters(org.apache.cayenne.di.Binder)
+ * @see org.apache.cayenne.configuration.server.ServerModuleExtender#addQueryFilter(DataChannelQueryFilter) 
  *
  * @since 4.1
  */

--- a/cayenne-server/src/main/java/org/apache/cayenne/DataChannelSyncFilter.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/DataChannelSyncFilter.java
@@ -40,7 +40,7 @@ import org.apache.cayenne.graph.GraphDiff;
  * }}</pre>
  *
  * @see DataChannelQueryFilter
- * @see org.apache.cayenne.configuration.server.ServerModule#contributeDomainSyncFilters(org.apache.cayenne.di.Binder)
+ * @see org.apache.cayenne.configuration.server.ServerModuleExtender#addSyncFilter(Class, boolean)
  *
  * @since 4.1
  */

--- a/cayenne-server/src/main/java/org/apache/cayenne/configuration/Constants.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/configuration/Constants.java
@@ -18,7 +18,7 @@
  ****************************************************************/
 package org.apache.cayenne.configuration;
 
-import org.apache.cayenne.di.Binder;
+import org.apache.cayenne.access.types.ExtendedType;
 
 /**
  * Defines the names of runtime properties and named collections used in DI modules.
@@ -33,7 +33,7 @@ public interface Constants {
      * A DI container key for the Map&lt;String, String&gt; storing properties
      * used by built-in Cayenne service.
      *
-     * @see org.apache.cayenne.configuration.server.ServerModule#contributeProperties(Binder).
+     * @see org.apache.cayenne.configuration.server.ServerModuleExtender#setProperty(String, Object)
      */
     String PROPERTIES_MAP = "cayenne.properties";
 
@@ -47,7 +47,7 @@ public interface Constants {
     /**
      * A DI container key for the List&lt;Object&gt; storing lifecycle events listeners.
      *
-     * @see org.apache.cayenne.configuration.server.ServerModule#contributeDomainListeners(Binder).
+     * @see org.apache.cayenne.configuration.server.ServerModuleExtender#addListener(Object) 
      */
     String SERVER_DOMAIN_LISTENERS_LIST = "cayenne.server.domain_listeners";
 
@@ -61,7 +61,7 @@ public interface Constants {
      * A DI container key for the List&lt;ExtendedType&gt; storing default
      * adapter-agnostic ExtendedTypes.
      *
-     * @see org.apache.cayenne.configuration.server.ServerModule#contributeDefaultTypes(Binder).
+     * @see org.apache.cayenne.configuration.server.ServerModuleExtender#addDefaultExtendedType(ExtendedType) 
      */
     String SERVER_DEFAULT_TYPES_LIST = "cayenne.server.default_types";
 
@@ -69,7 +69,7 @@ public interface Constants {
      * A DI container key for the List&lt;ExtendedType&gt; storing a
      * user-provided ExtendedTypes.
      *
-     * @see org.apache.cayenne.configuration.server.ServerModule#contributeUserTypes(Binder).
+     * @see org.apache.cayenne.configuration.server.ServerModuleExtender#addUserExtendedType(ExtendedType) 
      */
     String SERVER_USER_TYPES_LIST = "cayenne.server.user_types";
 
@@ -77,7 +77,7 @@ public interface Constants {
      * A DI container key for the List&lt;ExtendedTypeFactory&gt; storing
      * default and user-provided ExtendedTypeFactories.
      *
-     * @see org.apache.cayenne.configuration.server.ServerModule#contributeTypeFactories(Binder).
+     * @see org.apache.cayenne.configuration.server.ServerModuleExtender#addExtendedTypeFactory(Class) 
      */
     String SERVER_TYPE_FACTORIES_LIST = "cayenne.server.type_factories";
 
@@ -177,7 +177,7 @@ public interface Constants {
     /**
      * Snapshot cache max size
      *
-     * @see org.apache.cayenne.configuration.server.ServerModule#setSnapshotCacheSize(Binder, int)
+     * @see org.apache.cayenne.configuration.server.ServerModuleExtender#snapshotCacheSize(int) 
      * @since 4.0
      */
     String SNAPSHOT_CACHE_SIZE_PROPERTY = "cayenne.DataRowStore.snapshot.size";

--- a/cayenne-server/src/main/java/org/apache/cayenne/configuration/server/ServerModuleExtender.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/configuration/server/ServerModuleExtender.java
@@ -1,0 +1,337 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.configuration.server;
+
+import org.apache.cayenne.DataChannelQueryFilter;
+import org.apache.cayenne.DataChannelSyncFilter;
+import org.apache.cayenne.access.types.ExtendedType;
+import org.apache.cayenne.access.types.ExtendedTypeFactory;
+import org.apache.cayenne.access.types.ValueObjectType;
+import org.apache.cayenne.configuration.Constants;
+import org.apache.cayenne.dba.DbAdapter;
+import org.apache.cayenne.dba.PkGenerator;
+import org.apache.cayenne.di.Binder;
+import org.apache.cayenne.di.ListBuilder;
+import org.apache.cayenne.di.MapBuilder;
+import org.apache.cayenne.tx.TransactionFilter;
+
+/**
+ * A builder of extensions for {@link ServerModule}.
+ *
+ * @see ServerModule#extend(Binder)
+ * @since 5.0
+ */
+public class ServerModuleExtender {
+
+    private final Binder binder;
+
+    private MapBuilder<String> properties;
+    private ListBuilder<String> projectLocations;
+    private ListBuilder<DbAdapterDetector> adapterDetectors;
+    private MapBuilder<PkGenerator> pkGenerators;
+    private ListBuilder<DataChannelQueryFilter> queryFilters;
+    private ListBuilder<DataChannelSyncFilter> syncFilters;
+    private ListBuilder<Object> listeners;
+    private ListBuilder<ExtendedType> defaultExtendedTypes;
+    private ListBuilder<ExtendedType> userExtendedTypes;
+    private ListBuilder<ExtendedTypeFactory> extendedTypeFactories;
+    private ListBuilder<ValueObjectType> valueObjectTypes;
+
+    protected ServerModuleExtender(Binder binder) {
+        this.binder = binder;
+    }
+
+    protected ServerModuleExtender initAllExtensions() {
+        contributeProperties();
+        contributeProjectLocations();
+        contributeAdapterDetectors();
+        contributePkGenerators();
+        contributeQueryFilters();
+        contributeSyncFilters();
+        contributeListeners();
+        contributeDefaultExtendedTypes();
+        contributeUserExtendedTypes();
+        contributeExtendedTypeFactories();
+        contributeValueObjectTypes();
+        return this;
+    }
+
+    /**
+     * Sets Cayenne runtime property. Property names known to Cayenne are defined in the {@link Constants} interface.
+     */
+    public ServerModuleExtender setProperty(String key, Object value) {
+        contributeProperties().put(key, value != null ? value.toString() : null);
+        return this;
+    }
+
+    /**
+     * Configures the stack to synchronize data between ObjectContexts. This is false by default.
+     */
+    public ServerModuleExtender syncContexts() {
+        contributeProperties().put(Constants.SERVER_CONTEXTS_SYNC_PROPERTY, "true");
+        return this;
+    }
+
+    /**
+     * Sets transaction management to either external. By default, transactions are internally managed by Cayenne.
+     */
+    public ServerModuleExtender externalTransactions() {
+        contributeProperties().put(Constants.SERVER_EXTERNAL_TX_PROPERTY, "true");
+        return this;
+    }
+
+    /**
+     * Sets max size of snapshot cache.
+     *
+     * @param size max size of snapshot cache
+     */
+    public ServerModuleExtender snapshotCacheSize(int size) {
+        contributeProperties().put(Constants.SNAPSHOT_CACHE_SIZE_PROPERTY, Integer.toString(size));
+        return this;
+    }
+
+    /**
+     * Adds a custom project location.
+     */
+    public ServerModuleExtender addProjectLocation(String location) {
+        contributeProjectLocations().add(location);
+        return this;
+    }
+
+    /**
+     * Adds a custom PK generator per DbAdapter
+     */
+    public ServerModuleExtender addPkGenerator(Class<? extends DbAdapter> adapter, PkGenerator pkGenerator) {
+        contributePkGenerators().put(adapter.getName(), pkGenerator);
+        return this;
+    }
+
+    /**
+     * Adds a custom PK generator per DbAdapter
+     */
+    public ServerModuleExtender addPkGenerator(Class<? extends DbAdapter> adapter, Class<? extends PkGenerator> pkGeneratorType) {
+        contributePkGenerators().put(adapter.getName(), pkGeneratorType);
+        return this;
+    }
+
+    /**
+     * Adds a custom query filter to the end of the existing filter list
+     */
+    public ServerModuleExtender addQueryFilter(DataChannelQueryFilter queryFilter) {
+        contributeQueryFilters().add(queryFilter);
+        return this;
+    }
+
+    /**
+     * Adds a custom query filter to the end of the existing filter list
+     */
+    public ServerModuleExtender addQueryFilter(Class<? extends DataChannelQueryFilter> queryFilterType) {
+        contributeQueryFilters().add(queryFilterType);
+        return this;
+    }
+
+    /**
+     * Adds a custom sync filter.
+     */
+    public ServerModuleExtender addSyncFilter(DataChannelSyncFilter syncFilter) {
+        contributeSyncFilters().add(syncFilter);
+        return this;
+    }
+
+    /**
+     * Adds a custom sync filter.
+     */
+    public ServerModuleExtender addSyncFilter(Class<? extends DataChannelSyncFilter> syncFilterType) {
+        contributeSyncFilters().add(syncFilterType);
+        return this;
+    }
+
+    /**
+     * Adds a custom sync filter. Depending on the "includeInTransaction" parameter value it is added either
+     * before or after the {@link TransactionFilter}.
+     */
+    public ServerModuleExtender addSyncFilter(DataChannelSyncFilter syncFilter, boolean includeInTransaction) {
+        if (includeInTransaction) {
+            contributeSyncFilters().insertBefore(syncFilter, TransactionFilter.class);
+        } else {
+            contributeSyncFilters().addAfter(syncFilter, TransactionFilter.class);
+        }
+
+        return this;
+    }
+
+    /**
+     * Adds a custom sync filter. Depending on the "includeInTransaction" parameter value it is added either
+     * before or after the {@link TransactionFilter}.
+     */
+    public ServerModuleExtender addSyncFilter(Class<? extends DataChannelSyncFilter> syncFilterType, boolean includeInTransaction) {
+        if (includeInTransaction) {
+            contributeSyncFilters().insertBefore(syncFilterType, TransactionFilter.class);
+        } else {
+            contributeSyncFilters().addAfter(syncFilterType, TransactionFilter.class);
+        }
+
+        return this;
+    }
+
+    /**
+     * Registers an annotated event listener.
+     */
+    public ServerModuleExtender addListener(Object listener) {
+        contributeListeners().add(listener);
+        return this;
+    }
+
+    /**
+     * Registers an annotated event listener of a given type
+     */
+    public ServerModuleExtender addListenerType(Class<?> listenerType) {
+        contributeListeners().add(listenerType);
+        return this;
+    }
+
+    /**
+     * Adds a custom DbAdapterDetector
+     */
+    public ServerModuleExtender addAdapterDetector(DbAdapterDetector adapterDetector) {
+        contributeAdapterDetectors().add(adapterDetector);
+        return this;
+    }
+
+    /**
+     * Adds a custom DbAdapterDetector
+     */
+    public ServerModuleExtender addAdapterDetector(Class<? extends DbAdapterDetector> adapterDetectorType) {
+        contributeAdapterDetectors().add(adapterDetectorType);
+        return this;
+    }
+
+    /**
+     * Adds a default adapter-agnostic ExtendedType. "Default" types are loaded before adapter-provided or "user"
+     * types, so they may be overridden by those.
+     */
+    public ServerModuleExtender addDefaultExtendedType(ExtendedType<?> type) {
+        contributeDefaultExtendedTypes().add(type);
+        return this;
+    }
+
+    /**
+     * Adds a default adapter-agnostic ExtendedType. "Default" types are loaded before adapter-provided or "user"
+     * types, so they may be overridden by those.
+     */
+    public ServerModuleExtender addDefaultExtendedType(Class<? extends ExtendedType<?>> type) {
+        contributeDefaultExtendedTypes().add(type);
+        return this;
+    }
+
+    /**
+     * Adds an adapter-agnostic ExtendedType. "User" types are loaded after default and adapter-provided types and
+     * can override those.
+     */
+    public ServerModuleExtender addUserExtendedType(ExtendedType<?> type) {
+        contributeUserExtendedTypes().add(type);
+        return this;
+    }
+
+    /**
+     * Adds an adapter-agnostic ExtendedType. "User" types are loaded after default and adapter-provided types and
+     * can override those.
+     */
+    public ServerModuleExtender addUserExtendedType(Class<? extends ExtendedType<?>> type) {
+        contributeUserExtendedTypes().add(type);
+        return this;
+    }
+
+    /**
+     * Adds an ExtendedTypeFactory used for dynamic extended type creation.
+     */
+    public ServerModuleExtender addExtendedTypeFactory(ExtendedTypeFactory factory) {
+        contributeExtendedTypeFactories().add(factory);
+        return this;
+    }
+
+    /**
+     * Adds an ExtendedTypeFactory used for dynamic extended type creation.
+     */
+    public ServerModuleExtender addExtendedTypeFactory(Class<? extends ExtendedTypeFactory> factoryType) {
+        contributeExtendedTypeFactories().add(factoryType);
+        return this;
+    }
+
+    /**
+     * Adds a custom {@link ValueObjectType}.
+     */
+    public ServerModuleExtender addValueObjectType(ValueObjectType<?, ?> type) {
+        contributeValueObjectTypes().add(type);
+        return this;
+    }
+
+    /**
+     * Adds a custom {@link ValueObjectType}.
+     */
+    public ServerModuleExtender addValueObjectType(Class<? extends ValueObjectType<?, ?>> type) {
+        contributeValueObjectTypes().add(type);
+        return this;
+    }
+
+    private ListBuilder<String> contributeProjectLocations() {
+        return projectLocations != null ? projectLocations : (projectLocations = binder.bindList(String.class, Constants.SERVER_PROJECT_LOCATIONS_LIST));
+    }
+
+    private MapBuilder<String> contributeProperties() {
+        return properties != null ? properties : (properties = binder.bindMap(String.class, Constants.PROPERTIES_MAP));
+    }
+
+    private ListBuilder<DataChannelQueryFilter> contributeQueryFilters() {
+        return queryFilters != null ? queryFilters : (queryFilters = binder.bindList(DataChannelQueryFilter.class));
+    }
+
+    private ListBuilder<DataChannelSyncFilter> contributeSyncFilters() {
+        return syncFilters != null ? syncFilters : (syncFilters = binder.bindList(DataChannelSyncFilter.class));
+    }
+
+    private ListBuilder<Object> contributeListeners() {
+        return listeners != null ? listeners : (listeners = binder.bindList(Object.class, Constants.SERVER_DOMAIN_LISTENERS_LIST));
+    }
+
+    private ListBuilder<DbAdapterDetector> contributeAdapterDetectors() {
+        return adapterDetectors != null ? adapterDetectors : (adapterDetectors = binder.bindList(DbAdapterDetector.class, Constants.SERVER_ADAPTER_DETECTORS_LIST));
+    }
+
+    private ListBuilder<ExtendedType> contributeDefaultExtendedTypes() {
+        return defaultExtendedTypes != null ? defaultExtendedTypes : (defaultExtendedTypes = binder.bindList(ExtendedType.class, Constants.SERVER_DEFAULT_TYPES_LIST));
+    }
+
+    private ListBuilder<ExtendedType> contributeUserExtendedTypes() {
+        return userExtendedTypes != null ? userExtendedTypes : (userExtendedTypes = binder.bindList(ExtendedType.class, Constants.SERVER_USER_TYPES_LIST));
+    }
+
+    private ListBuilder<ExtendedTypeFactory> contributeExtendedTypeFactories() {
+        return extendedTypeFactories != null ? extendedTypeFactories : (extendedTypeFactories = binder.bindList(ExtendedTypeFactory.class, Constants.SERVER_TYPE_FACTORIES_LIST));
+    }
+
+    private ListBuilder<ValueObjectType> contributeValueObjectTypes() {
+        return valueObjectTypes != null ? valueObjectTypes : (valueObjectTypes = binder.bindList(ValueObjectType.class));
+    }
+
+    private MapBuilder<PkGenerator> contributePkGenerators() {
+        return pkGenerators != null ? pkGenerators : (pkGenerators = binder.bindMap(PkGenerator.class));
+    }
+}

--- a/cayenne-server/src/test/java/org/apache/cayenne/access/DefaultDataRowStoreFactoryIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/access/DefaultDataRowStoreFactoryIT.java
@@ -26,8 +26,10 @@ import org.apache.cayenne.access.flush.operation.DefaultDbRowOpSorter;
 import org.apache.cayenne.configuration.DefaultRuntimeProperties;
 import org.apache.cayenne.configuration.RuntimeProperties;
 import org.apache.cayenne.configuration.server.ServerModule;
+import org.apache.cayenne.configuration.server.ServerModuleExtender;
 import org.apache.cayenne.configuration.server.ServerRuntime;
 import org.apache.cayenne.di.AdhocObjectFactory;
+import org.apache.cayenne.di.Binder;
 import org.apache.cayenne.di.ClassLoaderManager;
 import org.apache.cayenne.di.DIBootstrap;
 import org.apache.cayenne.di.Injector;
@@ -82,7 +84,7 @@ public class DefaultDataRowStoreFactoryIT extends ServerCase {
             binder.bind(RuntimeProperties.class).to(DefaultRuntimeProperties.class);
             binder.bind(EventBridge.class).toProvider(NoopEventBridgeProvider.class);
             binder.bind(DataRowStoreFactory.class).to(DefaultDataRowStoreFactory.class);
-            ServerModule.setSnapshotCacheSize(binder, CACHE_SIZE);
+            ServerModule.extend(binder).snapshotCacheSize(CACHE_SIZE);
         };
 
         Injector injector = DIBootstrap.createInjector(testModule);
@@ -112,7 +114,7 @@ public class DefaultDataRowStoreFactoryIT extends ServerCase {
             binder.bind(DbRowOpSorter.class).to(DefaultDbRowOpSorter.class);
             binder.bind(AdhocObjectFactory.class).to(DefaultAdhocObjectFactory.class);
             binder.bind(ClassLoaderManager.class).to(DefaultClassLoaderManager.class);
-            ServerModule.contributeProperties(binder);
+            new TestExtender(binder).initAllExtensions();
         };
 
         Injector injector = DIBootstrap.createInjector(testModule);
@@ -120,6 +122,17 @@ public class DefaultDataRowStoreFactoryIT extends ServerCase {
                 .createDataRowStore("test");
 
         assertEquals(dataStore.getEventBridge().getClass(), MockEventBridge.class);
+    }
+
+    static class TestExtender extends ServerModuleExtender {
+        public TestExtender(Binder binder) {
+            super(binder);
+        }
+
+        @Override
+        protected ServerModuleExtender initAllExtensions() {
+            return super.initAllExtensions();
+        }
     }
 
 }

--- a/cayenne-server/src/test/java/org/apache/cayenne/configuration/server/DataDomainProviderTest.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/configuration/server/DataDomainProviderTest.java
@@ -18,10 +18,6 @@
  ****************************************************************/
 package org.apache.cayenne.configuration.server;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.apache.cayenne.ConfigurationException;
 import org.apache.cayenne.DataChannel;
 import org.apache.cayenne.ObjectId;
@@ -110,13 +106,17 @@ import org.apache.cayenne.log.Slf4jJdbcEventLogger;
 import org.apache.cayenne.map.DataMap;
 import org.apache.cayenne.map.EntitySorter;
 import org.apache.cayenne.map.LifecycleEvent;
-import org.apache.cayenne.reflect.generic.ValueComparisonStrategyFactory;
 import org.apache.cayenne.reflect.generic.DefaultValueComparisonStrategyFactory;
+import org.apache.cayenne.reflect.generic.ValueComparisonStrategyFactory;
 import org.apache.cayenne.resource.ClassLoaderResourceLocator;
 import org.apache.cayenne.resource.Resource;
 import org.apache.cayenne.resource.ResourceLocator;
 import org.apache.cayenne.resource.mock.MockResource;
 import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
@@ -164,47 +164,44 @@ public class DataDomainProviderTest {
         final EventManager eventManager = new MockEventManager();
         final TestListener mockListener = new TestListener();
 
-        Module testModule = binder -> {
-            final ClassLoaderManager classLoaderManager = new DefaultClassLoaderManager();
-            binder.bind(ClassLoaderManager.class).toInstance(classLoaderManager);
-            binder.bind(AdhocObjectFactory.class).to(DefaultAdhocObjectFactory.class);
+        Module testModule = b -> {
 
-            ServerModule.contributeProperties(binder);
+            ClassLoaderManager classLoaderManager = new DefaultClassLoaderManager();
+            b.bind(ClassLoaderManager.class).toInstance(classLoaderManager);
+            b.bind(AdhocObjectFactory.class).to(DefaultAdhocObjectFactory.class);
+            b.bind(PkGenerator.class).to(JdbcPkGenerator.class);
+            b.bind(PkGeneratorFactoryProvider.class).to(PkGeneratorFactoryProvider.class);
 
-            ServerModule.contributeAdapterDetectors(binder).add(FirebirdSniffer.class)
-                    .add(FrontBaseSniffer.class).add(IngresSniffer.class)
-                    .add(SQLiteSniffer.class).add(DB2Sniffer.class).add(H2Sniffer.class).add(HSQLDBSniffer.class)
-                    .add(SybaseSniffer.class).add(DerbySniffer.class).add(SQLServerSniffer.class)
-                    .add(OracleSniffer.class).add(PostgresSniffer.class).add(MySQLSniffer.class)
-                    .add(MariaDBSniffer.class);
-            ServerModule.contributeDomainQueryFilters(binder);
-            ServerModule.contributeDomainSyncFilters(binder);
-            ServerModule.contributeDomainListeners(binder).add(mockListener);
-            ServerModule.contributeProjectLocations(binder).add(testConfigName);
+            ServerModule.extend(b)
+                    .initAllExtensions()
 
-            binder.bind(PkGenerator.class).to(JdbcPkGenerator.class);
-            binder.bind(PkGeneratorFactoryProvider.class).to(PkGeneratorFactoryProvider.class);
-            ServerModule.contributePkGenerators(binder)
-                    .put(DB2Adapter.class.getName(), DB2PkGenerator.class)
-                    .put(DerbyAdapter.class.getName(), DerbyPkGenerator.class)
-                    .put(FrontBaseAdapter.class.getName(), FrontBasePkGenerator.class)
-                    .put(H2Adapter.class.getName(), H2PkGenerator.class)
-                    .put(IngresAdapter.class.getName(), IngresPkGenerator.class)
-                    .put(MySQLAdapter.class.getName(), MySQLPkGenerator.class)
-                    .put(OracleAdapter.class.getName(), OraclePkGenerator.class)
-                    .put(Oracle8Adapter.class.getName(), OraclePkGenerator.class)
-                    .put(PostgresAdapter.class.getName(), PostgresPkGenerator.class)
-                    .put(SQLServerAdapter.class.getName(), SybasePkGenerator.class)
-                    .put(SybaseAdapter.class.getName(), SybasePkGenerator.class);
+                    .addAdapterDetector(FirebirdSniffer.class)
+                    .addAdapterDetector(FrontBaseSniffer.class).addAdapterDetector(IngresSniffer.class)
+                    .addAdapterDetector(SQLiteSniffer.class).addAdapterDetector(DB2Sniffer.class)
+                    .addAdapterDetector(H2Sniffer.class).addAdapterDetector(HSQLDBSniffer.class)
+                    .addAdapterDetector(SybaseSniffer.class).addAdapterDetector(DerbySniffer.class)
+                    .addAdapterDetector(SQLServerSniffer.class).addAdapterDetector(OracleSniffer.class)
+                    .addAdapterDetector(PostgresSniffer.class).addAdapterDetector(MySQLSniffer.class)
+                    .addAdapterDetector(MariaDBSniffer.class)
 
-            // configure extended types
-            ServerModule.contributeDefaultTypes(binder);
-            ServerModule.contributeUserTypes(binder);
-            ServerModule.contributeTypeFactories(binder);
+                    .addListener(mockListener)
+                    .addProjectLocation(testConfigName)
 
-            binder.bind(EventManager.class).toInstance(eventManager);
-            binder.bind(EntitySorter.class).toInstance(new AshwoodEntitySorter());
-            binder.bind(SchemaUpdateStrategyFactory.class).to(DefaultSchemaUpdateStrategyFactory.class);
+                    .addPkGenerator(DB2Adapter.class, DB2PkGenerator.class)
+                    .addPkGenerator(DerbyAdapter.class, DerbyPkGenerator.class)
+                    .addPkGenerator(FrontBaseAdapter.class, FrontBasePkGenerator.class)
+                    .addPkGenerator(H2Adapter.class, H2PkGenerator.class)
+                    .addPkGenerator(IngresAdapter.class, IngresPkGenerator.class)
+                    .addPkGenerator(MySQLAdapter.class, MySQLPkGenerator.class)
+                    .addPkGenerator(OracleAdapter.class, OraclePkGenerator.class)
+                    .addPkGenerator(Oracle8Adapter.class, OraclePkGenerator.class)
+                    .addPkGenerator(PostgresAdapter.class, PostgresPkGenerator.class)
+                    .addPkGenerator(SQLServerAdapter.class, SybasePkGenerator.class)
+                    .addPkGenerator(SybaseAdapter.class, SybasePkGenerator.class);
+
+            b.bind(EventManager.class).toInstance(eventManager);
+            b.bind(EntitySorter.class).toInstance(new AshwoodEntitySorter());
+            b.bind(SchemaUpdateStrategyFactory.class).to(DefaultSchemaUpdateStrategyFactory.class);
 
             final ResourceLocator locator = new ClassLoaderResourceLocator(classLoaderManager) {
 
@@ -220,29 +217,28 @@ public class DataDomainProviderTest {
                 }
             };
 
-            binder.bind(ResourceLocator.class).toInstance(locator);
-            binder.bind(Key.get(ResourceLocator.class, Constants.SERVER_RESOURCE_LOCATOR)).toInstance(locator);
-            binder.bind(ConfigurationNameMapper.class).to(DefaultConfigurationNameMapper.class);
-            binder.bind(DataChannelDescriptorMerger.class).to(DefaultDataChannelDescriptorMerger.class);
-            binder.bind(DataChannelDescriptorLoader.class).toInstance(testLoader);
-            binder.bind(DbAdapterFactory.class).to(DefaultDbAdapterFactory.class);
-            binder.bind(RuntimeProperties.class).to(DefaultRuntimeProperties.class);
-            binder.bind(BatchTranslatorFactory.class).to(DefaultBatchTranslatorFactory.class);
-            binder.bind(SelectTranslatorFactory.class).to(DefaultSelectTranslatorFactory.class);
+            b.bind(ResourceLocator.class).toInstance(locator);
+            b.bind(Key.get(ResourceLocator.class, Constants.SERVER_RESOURCE_LOCATOR)).toInstance(locator);
+            b.bind(ConfigurationNameMapper.class).to(DefaultConfigurationNameMapper.class);
+            b.bind(DataChannelDescriptorMerger.class).to(DefaultDataChannelDescriptorMerger.class);
+            b.bind(DataChannelDescriptorLoader.class).toInstance(testLoader);
+            b.bind(DbAdapterFactory.class).to(DefaultDbAdapterFactory.class);
+            b.bind(RuntimeProperties.class).to(DefaultRuntimeProperties.class);
+            b.bind(BatchTranslatorFactory.class).to(DefaultBatchTranslatorFactory.class);
+            b.bind(SelectTranslatorFactory.class).to(DefaultSelectTranslatorFactory.class);
 
-            binder.bind(DataSourceFactory.class).toInstance(new MockDataSourceFactory());
-            binder.bind(JdbcEventLogger.class).to(Slf4jJdbcEventLogger.class);
-            binder.bind(QueryCache.class).toInstance(mock(QueryCache.class));
-            binder.bind(RowReaderFactory.class).toInstance(mock(RowReaderFactory.class));
-            binder.bind(DataNodeFactory.class).to(DefaultDataNodeFactory.class);
-            binder.bind(SQLTemplateProcessor.class).toInstance(mock(SQLTemplateProcessor.class));
+            b.bind(DataSourceFactory.class).toInstance(new MockDataSourceFactory());
+            b.bind(JdbcEventLogger.class).to(Slf4jJdbcEventLogger.class);
+            b.bind(QueryCache.class).toInstance(mock(QueryCache.class));
+            b.bind(RowReaderFactory.class).toInstance(mock(RowReaderFactory.class));
+            b.bind(DataNodeFactory.class).to(DefaultDataNodeFactory.class);
+            b.bind(SQLTemplateProcessor.class).toInstance(mock(SQLTemplateProcessor.class));
 
-            binder.bind(EventBridge.class).toProvider(NoopEventBridgeProvider.class);
-            binder.bind(DataRowStoreFactory.class).to(DefaultDataRowStoreFactory.class);
+            b.bind(EventBridge.class).toProvider(NoopEventBridgeProvider.class);
+            b.bind(DataRowStoreFactory.class).to(DefaultDataRowStoreFactory.class);
 
-            ServerModule.contributeValueObjectTypes(binder);
-            binder.bind(ValueObjectTypeRegistry.class).to(DefaultValueObjectTypeRegistry.class);
-            binder.bind(ValueComparisonStrategyFactory.class).to(DefaultValueComparisonStrategyFactory.class);
+            b.bind(ValueObjectTypeRegistry.class).to(DefaultValueObjectTypeRegistry.class);
+            b.bind(ValueComparisonStrategyFactory.class).to(DefaultValueComparisonStrategyFactory.class);
         };
 
         Injector injector = DIBootstrap.createInjector(testModule);

--- a/cayenne-server/src/test/java/org/apache/cayenne/configuration/server/DefaultDbAdapterFactoryTest.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/configuration/server/DefaultDbAdapterFactoryTest.java
@@ -44,8 +44,8 @@ import org.apache.cayenne.di.spi.DefaultClassLoaderManager;
 import org.apache.cayenne.log.JdbcEventLogger;
 import org.apache.cayenne.log.Slf4jJdbcEventLogger;
 import org.apache.cayenne.map.DbEntity;
-import org.apache.cayenne.reflect.generic.ValueComparisonStrategyFactory;
 import org.apache.cayenne.reflect.generic.DefaultValueComparisonStrategyFactory;
+import org.apache.cayenne.reflect.generic.ValueComparisonStrategyFactory;
 import org.apache.cayenne.resource.ClassLoaderResourceLocator;
 import org.apache.cayenne.resource.ResourceLocator;
 import org.junit.Test;
@@ -76,8 +76,7 @@ public class DefaultDbAdapterFactoryTest {
         dataSource.setupConnection(connection);
 
         Module testModule = binder -> {
-            ServerModule.contributeProperties(binder);
-            ServerModule.contributePkGenerators(binder);
+            ServerModule.extend(binder).initAllExtensions();
 
             binder.bind(PkGenerator.class).to(JdbcPkGenerator.class);
             binder.bind(PkGeneratorFactoryProvider.class).to(PkGeneratorFactoryProvider.class);
@@ -99,29 +98,25 @@ public class DefaultDbAdapterFactoryTest {
     }
 
     @Test
-    public void testCreatedAdapter_Generic() throws Exception {
+    public void testCreatedAdapter_Generic() {
 
-        List<DbAdapterDetector> detectors = new ArrayList<DbAdapterDetector>();
+        List<DbAdapterDetector> detectors = new ArrayList<>();
 
-        Module testModule = binder -> {
-            ServerModule.contributeProperties(binder);
-            ServerModule.contributeDefaultTypes(binder);
-            ServerModule.contributeUserTypes(binder);
-            ServerModule.contributeTypeFactories(binder);
-            ServerModule.contributePkGenerators(binder);
+        Module testModule = b -> {
 
-            binder.bind(PkGenerator.class).to(JdbcPkGenerator.class);
-            binder.bind(PkGeneratorFactoryProvider.class).to(PkGeneratorFactoryProvider.class);
-            binder.bind(JdbcEventLogger.class).to(Slf4jJdbcEventLogger.class);
-            binder.bind(ClassLoaderManager.class).to(DefaultClassLoaderManager.class);
-            binder.bind(AdhocObjectFactory.class).to(DefaultAdhocObjectFactory.class);
-            binder.bind(ResourceLocator.class).to(ClassLoaderResourceLocator.class);
-            binder.bind(Key.get(ResourceLocator.class, Constants.SERVER_RESOURCE_LOCATOR)).to(ClassLoaderResourceLocator.class);
-            binder.bind(RuntimeProperties.class).to(DefaultRuntimeProperties.class);
-            binder.bind(BatchTranslatorFactory.class).toInstance(mock(BatchTranslatorFactory.class));
+            ServerModule.extend(b).initAllExtensions();
 
-            ServerModule.contributeValueObjectTypes(binder);
-            binder.bind(ValueObjectTypeRegistry.class).to(DefaultValueObjectTypeRegistry.class);
+            b.bind(PkGenerator.class).to(JdbcPkGenerator.class);
+            b.bind(PkGeneratorFactoryProvider.class).to(PkGeneratorFactoryProvider.class);
+            b.bind(JdbcEventLogger.class).to(Slf4jJdbcEventLogger.class);
+            b.bind(ClassLoaderManager.class).to(DefaultClassLoaderManager.class);
+            b.bind(AdhocObjectFactory.class).to(DefaultAdhocObjectFactory.class);
+            b.bind(ResourceLocator.class).to(ClassLoaderResourceLocator.class);
+            b.bind(Key.get(ResourceLocator.class, Constants.SERVER_RESOURCE_LOCATOR)).to(ClassLoaderResourceLocator.class);
+            b.bind(RuntimeProperties.class).to(DefaultRuntimeProperties.class);
+            b.bind(BatchTranslatorFactory.class).toInstance(mock(BatchTranslatorFactory.class));
+
+            b.bind(ValueObjectTypeRegistry.class).to(DefaultValueObjectTypeRegistry.class);
         };
 
         Injector injector = DIBootstrap.createInjector(testModule);
@@ -143,26 +138,21 @@ public class DefaultDbAdapterFactoryTest {
 
         List<DbAdapterDetector> detectors = new ArrayList<>();
 
-        Module testModule = binder -> {
-            ServerModule.contributeProperties(binder);
-            ServerModule.contributeDefaultTypes(binder);
-            ServerModule.contributeUserTypes(binder);
-            ServerModule.contributeTypeFactories(binder);
-            ServerModule.contributePkGenerators(binder);
+        Module testModule = b -> {
+            ServerModule.extend(b).initAllExtensions();
 
-            binder.bind(PkGenerator.class).to(JdbcPkGenerator.class);
-            binder.bind(PkGeneratorFactoryProvider.class).to(PkGeneratorFactoryProvider.class);
-            binder.bind(JdbcEventLogger.class).to(Slf4jJdbcEventLogger.class);
-            binder.bind(ClassLoaderManager.class).to(DefaultClassLoaderManager.class);
-            binder.bind(AdhocObjectFactory.class).to(DefaultAdhocObjectFactory.class);
-            binder.bind(ResourceLocator.class).to(ClassLoaderResourceLocator.class);
-            binder.bind(Key.get(ResourceLocator.class, Constants.SERVER_RESOURCE_LOCATOR)).to(ClassLoaderResourceLocator.class);
-            binder.bind(RuntimeProperties.class).to(DefaultRuntimeProperties.class);
-            binder.bind(BatchTranslatorFactory.class).toInstance(mock(BatchTranslatorFactory.class));
+            b.bind(PkGenerator.class).to(JdbcPkGenerator.class);
+            b.bind(PkGeneratorFactoryProvider.class).to(PkGeneratorFactoryProvider.class);
+            b.bind(JdbcEventLogger.class).to(Slf4jJdbcEventLogger.class);
+            b.bind(ClassLoaderManager.class).to(DefaultClassLoaderManager.class);
+            b.bind(AdhocObjectFactory.class).to(DefaultAdhocObjectFactory.class);
+            b.bind(ResourceLocator.class).to(ClassLoaderResourceLocator.class);
+            b.bind(Key.get(ResourceLocator.class, Constants.SERVER_RESOURCE_LOCATOR)).to(ClassLoaderResourceLocator.class);
+            b.bind(RuntimeProperties.class).to(DefaultRuntimeProperties.class);
+            b.bind(BatchTranslatorFactory.class).toInstance(mock(BatchTranslatorFactory.class));
 
-            ServerModule.contributeValueObjectTypes(binder);
-            binder.bind(ValueObjectTypeRegistry.class).to(DefaultValueObjectTypeRegistry.class);
-            binder.bind(ValueComparisonStrategyFactory.class).to(DefaultValueComparisonStrategyFactory.class);
+            b.bind(ValueObjectTypeRegistry.class).to(DefaultValueObjectTypeRegistry.class);
+            b.bind(ValueComparisonStrategyFactory.class).to(DefaultValueComparisonStrategyFactory.class);
         };
 
         Injector injector = DIBootstrap.createInjector(testModule);
@@ -191,8 +181,7 @@ public class DefaultDbAdapterFactoryTest {
         dataSource.setupConnection(connection);
 
         Module testModule = binder -> {
-            ServerModule.contributeProperties(binder);
-            ServerModule.contributePkGenerators(binder);
+            ServerModule.extend(binder).initAllExtensions();
 
             binder.bind(PkGenerator.class).to(JdbcPkGenerator.class);
             binder.bind(PkGeneratorFactoryProvider.class).to(PkGeneratorFactoryProvider.class);

--- a/cayenne-server/src/test/java/org/apache/cayenne/unit/di/server/ServerCaseContextsSync.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/unit/di/server/ServerCaseContextsSync.java
@@ -18,7 +18,6 @@
  ****************************************************************/
 package org.apache.cayenne.unit.di.server;
 
-import org.apache.cayenne.configuration.Constants;
 import org.apache.cayenne.configuration.server.ServerModule;
 import org.apache.cayenne.configuration.server.ServerRuntime;
 import org.apache.cayenne.di.DIBootstrap;
@@ -43,8 +42,7 @@ public class ServerCaseContextsSync extends DICase {
                 new ServerCaseModule(testScope),
                 binder -> {
                     binder.bind(ServerRuntime.class).toProvider(ServerRuntimeProviderContextsSync.class).in(testScope);
-                    ServerModule.contributeProperties(binder)
-                            .put(Constants.SERVER_CONTEXTS_SYNC_PROPERTY, String.valueOf(true));
+                    ServerModule.extend(binder).syncContexts();
                 });
         injector.getInstance(SchemaBuilder.class).rebuildSchema();
     }

--- a/cayenne-server/src/test/java/org/apache/cayenne/unit/di/server/ServerRuntimeProvider.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/unit/di/server/ServerRuntimeProvider.java
@@ -18,10 +18,6 @@
  ****************************************************************/
 package org.apache.cayenne.unit.di.server;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-
 import org.apache.cayenne.ConfigurationException;
 import org.apache.cayenne.access.DataDomain;
 import org.apache.cayenne.configuration.Constants;
@@ -34,6 +30,10 @@ import org.apache.cayenne.di.Inject;
 import org.apache.cayenne.di.Module;
 import org.apache.cayenne.di.Provider;
 import org.apache.cayenne.unit.UnitDbAdapter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 
 public class ServerRuntimeProvider implements Provider<ServerRuntime> {
 
@@ -88,10 +88,10 @@ public class ServerRuntimeProvider implements Provider<ServerRuntime> {
             binder.bind(DataNodeFactory.class).to(ServerCaseDataNodeFactory.class);
             binder.bind(UnitDbAdapter.class).toInstance(unitDbAdapter);
 
-            ServerModule.contributeProperties(binder)
+            ServerModule.extend(binder)
                     // Use soft references instead of default weak.
                     // Should remove problems with random-failing tests (those that are GC-sensitive).
-                    .put(Constants.SERVER_OBJECT_RETAIN_STRATEGY_PROPERTY, "soft");
+                    .setProperty(Constants.SERVER_OBJECT_RETAIN_STRATEGY_PROPERTY, "soft");
 
             // map DataSources for all test DataNode names
             binder.bind(ServerCaseDataSourceFactory.class).toInstance(dataSourceFactory);

--- a/cayenne-server/src/test/java/org/apache/cayenne/unit/di/server/ServerRuntimeProviderContextsSync.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/unit/di/server/ServerRuntimeProviderContextsSync.java
@@ -18,16 +18,15 @@
  ****************************************************************/
 package org.apache.cayenne.unit.di.server;
 
-import java.util.ArrayList;
-import java.util.Collection;
-
-import org.apache.cayenne.configuration.Constants;
 import org.apache.cayenne.configuration.server.ServerModule;
 import org.apache.cayenne.dba.DbAdapter;
 import org.apache.cayenne.di.Inject;
 import org.apache.cayenne.di.Module;
 import org.apache.cayenne.di.Provider;
 import org.apache.cayenne.unit.UnitDbAdapter;
+
+import java.util.ArrayList;
+import java.util.Collection;
 
 /**
  * @since 4.1
@@ -44,8 +43,7 @@ public class ServerRuntimeProviderContextsSync extends ServerRuntimeProvider {
     @Override
     protected Collection<? extends Module> getExtraModules() {
         Collection<Module> modules = new ArrayList<>(super.getExtraModules());
-        modules.add(binder -> ServerModule.contributeProperties(binder)
-                .put(Constants.SERVER_CONTEXTS_SYNC_PROPERTY, String.valueOf(true)));
+        modules.add(binder -> ServerModule.extend(binder).syncContexts());
         return modules;
     }
 }

--- a/cayenne-server/src/test/java/org/apache/cayenne/unit/di/server/WeakReferenceStrategyServerRuntimeProvider.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/unit/di/server/WeakReferenceStrategyServerRuntimeProvider.java
@@ -18,14 +18,16 @@
  ****************************************************************/
 package org.apache.cayenne.unit.di.server;
 
-import java.util.ArrayList;
-import java.util.Collection;
-
+import org.apache.cayenne.configuration.Constants;
+import org.apache.cayenne.configuration.server.ServerModule;
 import org.apache.cayenne.dba.DbAdapter;
 import org.apache.cayenne.di.Inject;
 import org.apache.cayenne.di.Module;
 import org.apache.cayenne.di.Provider;
 import org.apache.cayenne.unit.UnitDbAdapter;
+
+import java.util.ArrayList;
+import java.util.Collection;
 
 public class WeakReferenceStrategyServerRuntimeProvider extends ServerRuntimeProvider {
 
@@ -39,7 +41,7 @@ public class WeakReferenceStrategyServerRuntimeProvider extends ServerRuntimePro
     @Override
     protected Collection<? extends Module> getExtraModules() {
         Collection<Module> modules = new ArrayList<>(super.getExtraModules());
-        modules.add(new WeakReferenceStrategyModule());
+        modules.add(b -> ServerModule.extend(b).setProperty(Constants.SERVER_OBJECT_RETAIN_STRATEGY_PROPERTY, "weak"));
         return modules;
     }
 }

--- a/cayenne-server/src/test/java/org/apache/cayenne/unit/jira/CAY_743Test.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/unit/jira/CAY_743Test.java
@@ -40,7 +40,7 @@ public class CAY_743Test {
             @Override
             public void configure(Binder binder) {
                 super.configure(binder);
-                ServerModule.contributeProjectLocations(binder).add("cay743/cayenne-domain.xml");
+                ServerModule.extend(binder).addProjectLocation("cay743/cayenne-domain.xml");
             }
         });
 

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/init/CayenneModelerModule.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/init/CayenneModelerModule.java
@@ -54,10 +54,10 @@ public class CayenneModelerModule implements Module {
         binder.bind(DataChannelMetaData.class).to(DefaultDataChannelMetaData.class);
         binder.bind(XMLReader.class).toProviderInstance(new XMLReaderProvider(true)).withoutScope();
 
-        ProjectModule.contributeExtensions(binder)
-                .add(InfoExtension.class)
-                .add(GraphExtension.class)
-                .add(DbImportExtension.class)
-                .add(CgenExtension.class);
+        ProjectModule.extend(binder)
+                .addExtension(InfoExtension.class)
+                .addExtension(GraphExtension.class)
+                .addExtension(DbImportExtension.class)
+                .addExtension(CgenExtension.class);
     }
 }


### PR DESCRIPTION
This is the first cut of the https://issues.apache.org/jira/browse/CAY-2772 feature (extender API). I converted `ServerModule`, `JCacheModule` and `ProjectModule`. The PR is internally consistent, and can be merged as is. The new API even improves the internal Cayenne configuration code. Still, there are some TODOs to finalize CAY-2772 scope:

* Remaining modules need to be converted (CommitLogModule, CryptoModule, etc).
* We need to decide whether we want cover methods in `ServerRuntimeBuilder` for `ServerModuleExtender` (I think yes).
