### PR TITLE
CAY-2780 Multiple configurations for classes generation

### DIFF
--- a/cayenne-ant/src/main/java/org/apache/cayenne/tools/CayenneGeneratorTask.java
+++ b/cayenne-ant/src/main/java/org/apache/cayenne/tools/CayenneGeneratorTask.java
@@ -19,6 +19,8 @@
 package org.apache.cayenne.tools;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.cayenne.configuration.xml.DataChannelMetaData;
 import org.apache.cayenne.dbsync.filter.NamePatternMatcher;
@@ -26,6 +28,7 @@ import org.apache.cayenne.dbsync.reverse.configuration.ToolsModule;
 import org.apache.cayenne.di.Injector;
 import org.apache.cayenne.gen.ArtifactsGenerationMode;
 import org.apache.cayenne.gen.CgenConfiguration;
+import org.apache.cayenne.gen.CgenConfigList;
 import org.apache.cayenne.gen.ClassGenerationAction;
 import org.apache.cayenne.gen.ClassGenerationActionFactory;
 import org.apache.cayenne.gen.CgenTemplate;
@@ -37,7 +40,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * An Ant task to perform class generation based on CayenneDataMap.
- * 
+ *
  * @since 3.0
  */
 public class CayenneGeneratorTask extends CayenneTask {
@@ -87,7 +90,7 @@ public class CayenneGeneratorTask extends CayenneTask {
 
     /**
      * Optional path (classpath or filesystem) to external velocity tool configuration file
-     * @since 4.2 
+     * @since 4.2
      */
     protected String externaltoolconfig;
 
@@ -116,38 +119,40 @@ public class CayenneGeneratorTask extends CayenneTask {
             Thread.currentThread().setContextClassLoader(CayenneGeneratorTask.class.getClassLoader());
 
             DataMap dataMap = loadAction.getMainDataMap();
+            for (ClassGenerationAction generatorAction : createGenerators(dataMap)) {
+                CayenneGeneratorEntityFilterAction filterEntityAction = new CayenneGeneratorEntityFilterAction();
+                filterEntityAction.setNameFilter(NamePatternMatcher.build(logger, includeEntitiesPattern, excludeEntitiesPattern));
 
-            ClassGenerationAction generatorAction = createGenerator(dataMap);
-            CayenneGeneratorEntityFilterAction filterEntityAction = new CayenneGeneratorEntityFilterAction();
-            filterEntityAction.setNameFilter(NamePatternMatcher.build(logger, includeEntitiesPattern, excludeEntitiesPattern));
-
-            CayenneGeneratorEmbeddableFilterAction filterEmbeddableAction = new CayenneGeneratorEmbeddableFilterAction();
-            filterEmbeddableAction.setNameFilter(NamePatternMatcher.build(logger, null, excludeEmbeddablesPattern));
-            generatorAction.setLogger(logger);
-            if(force) {
-                // will (re-)generate all files
-                generatorAction.getCgenConfiguration().setForce(true);
+                CayenneGeneratorEmbeddableFilterAction filterEmbeddableAction = new CayenneGeneratorEmbeddableFilterAction();
+                filterEmbeddableAction.setNameFilter(NamePatternMatcher.build(logger, null, excludeEmbeddablesPattern));
+                generatorAction.setLogger(logger);
+                if (force) {
+                    // will (re-)generate all files
+                    generatorAction.getCgenConfiguration().setForce(true);
+                }
+                generatorAction.getCgenConfiguration().setTimestamp(map.lastModified());
+                if (!hasConfig() && useConfigFromDataMap) {
+                    generatorAction.prepareArtifacts();
+                } else {
+                    generatorAction.addEntities(filterEntityAction.getFilteredEntities(dataMap));
+                    generatorAction.addEmbeddables(filterEmbeddableAction.getFilteredEmbeddables(dataMap));
+                    generatorAction.addQueries(dataMap.getQueryDescriptors());
+                }
+                generatorAction.execute();
             }
-            generatorAction.getCgenConfiguration().setTimestamp(map.lastModified());
-            if(!hasConfig() && useConfigFromDataMap) {
-                generatorAction.prepareArtifacts();
-            } else {
-                generatorAction.addEntities(filterEntityAction.getFilteredEntities(dataMap));
-                generatorAction.addEmbeddables(filterEmbeddableAction.getFilteredEmbeddables(dataMap));
-                generatorAction.addQueries(dataMap.getQueryDescriptors());
-            }
-            generatorAction.execute();
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             throw new BuildException(e);
         } finally {
             Thread.currentThread().setContextClassLoader(loader);
         }
     }
 
-    private ClassGenerationAction createGenerator(DataMap dataMap) {
-        CgenConfiguration cgenConfiguration = buildConfiguration(dataMap);
-        return injector.getInstance(ClassGenerationActionFactory.class).createAction(cgenConfiguration);
+    private List<ClassGenerationAction> createGenerators(DataMap dataMap) {
+        List<ClassGenerationAction> actions = new ArrayList<>();
+        for (CgenConfiguration configuration : buildConfigurations(dataMap)) {
+            actions.add(injector.getInstance(ClassGenerationActionFactory.class).createAction(configuration));
+        }
+        return actions;
     }
 
     private boolean hasConfig() {
@@ -158,20 +163,26 @@ public class CayenneGeneratorTask extends CayenneTask {
                 datamapsupertemplate != null || createpkproperties != null || force || externaltoolconfig != null;
     }
 
-     CgenConfiguration buildConfiguration(DataMap dataMap) {
-        CgenConfiguration cgenConfiguration = injector.getInstance(DataChannelMetaData.class).get(dataMap, CgenConfiguration.class);
-        if(hasConfig()) {
+    List<CgenConfiguration> buildConfigurations(DataMap dataMap) {
+        List<CgenConfiguration> configurations = new ArrayList<>();
+        CgenConfigList cgenConfigList = injector.getInstance(DataChannelMetaData.class).get(dataMap, CgenConfigList.class);
+        if (hasConfig()) {
             logger.info("Using cgen config from pom.xml");
-            return cgenConfigFromPom(dataMap);
-        } else if(cgenConfiguration != null) {
-            logger.info("Using cgen config from " + cgenConfiguration.getDataMap().getName());
+            configurations.add(cgenConfigFromPom(dataMap));
+            return configurations;
+        } else if (cgenConfigList != null) {
+            for (CgenConfiguration cgenConfiguration : cgenConfigList.getAll()) {
+                configurations.add(cgenConfiguration);
+                logger.info("Using cgen config from " + cgenConfiguration.getDataMap().getName());
+            }
             useConfigFromDataMap = true;
-            return cgenConfiguration;
+            return configurations;
         } else {
             logger.info("Using default cgen config.");
-            cgenConfiguration = new CgenConfiguration();
+            CgenConfiguration cgenConfiguration = new CgenConfiguration();
             cgenConfiguration.setDataMap(dataMap);
-            return cgenConfiguration;
+            configurations.add(cgenConfiguration);
+            return configurations;
         }
     }
 
@@ -231,7 +242,7 @@ public class CayenneGeneratorTask extends CayenneTask {
 
     /**
      * Sets the map.
-     * 
+     *
      * @param map The map to set
      */
     public void setMap(File map) {
@@ -240,7 +251,7 @@ public class CayenneGeneratorTask extends CayenneTask {
 
     /**
      * Sets the additional DataMaps.
-     * 
+     *
      * @param additionalMapsPath The additional DataMaps to set
      */
     public void setAdditionalMaps(Path additionalMapsPath) {

--- a/cayenne-ant/src/main/java/org/apache/cayenne/tools/CayenneGeneratorTask.java
+++ b/cayenne-ant/src/main/java/org/apache/cayenne/tools/CayenneGeneratorTask.java
@@ -20,6 +20,7 @@ package org.apache.cayenne.tools;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.cayenne.configuration.xml.DataChannelMetaData;
@@ -164,25 +165,19 @@ public class CayenneGeneratorTask extends CayenneTask {
     }
 
     List<CgenConfiguration> buildConfigurations(DataMap dataMap) {
-        List<CgenConfiguration> configurations = new ArrayList<>();
         CgenConfigList cgenConfigList = injector.getInstance(DataChannelMetaData.class).get(dataMap, CgenConfigList.class);
         if (hasConfig()) {
             logger.info("Using cgen config from pom.xml");
-            configurations.add(cgenConfigFromPom(dataMap));
-            return configurations;
+            return Collections.singletonList(cgenConfigFromPom(dataMap));
         } else if (cgenConfigList != null) {
-            for (CgenConfiguration cgenConfiguration : cgenConfigList.getAll()) {
-                configurations.add(cgenConfiguration);
-                logger.info("Using cgen config from " + cgenConfiguration.getDataMap().getName());
-            }
+            logger.info("Using cgen config from dataMap");
             useConfigFromDataMap = true;
-            return configurations;
+            return cgenConfigList.getAll();
         } else {
             logger.info("Using default cgen config.");
             CgenConfiguration cgenConfiguration = new CgenConfiguration();
             cgenConfiguration.setDataMap(dataMap);
-            configurations.add(cgenConfiguration);
-            return configurations;
+            return Collections.singletonList(cgenConfiguration);
         }
     }
 

--- a/cayenne-ant/src/test/java/org/apache/cayenne/tools/CayenneGeneratorTaskTest.java
+++ b/cayenne-ant/src/test/java/org/apache/cayenne/tools/CayenneGeneratorTaskTest.java
@@ -33,6 +33,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
+import java.util.List;
 import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
@@ -103,61 +104,63 @@ public class CayenneGeneratorTaskTest {
 
     @Test
     public void testTransferPluginDataToCgenConfiguration() throws Exception {
-        // prepare destination directory
-        File mapDir = new File(baseDir.toURI());
+		// prepare destination directory
+		File mapDir = new File(baseDir.toURI());
 
-        // setup task
-        task.setDestDir(mapDir);
-        task.setMap(map);
-        task.setEncoding("UTF-8");
-        task.setMode("all");
-        task.setOutputPattern("pattern");
-        task.setSuperpkg("superPkg");
-        task.setMakepairs(true);
-        task.setCreatepropertynames(true);
-        task.setOverwrite(true);
-        task.setUsepkgpath(true);
-        task.setTemplate(template.getPath());
+		// setup task
+		task.setDestDir(mapDir);
+		task.setMap(map);
+		task.setEncoding("UTF-8");
+		task.setMode("all");
+		task.setOutputPattern("pattern");
+		task.setSuperpkg("superPkg");
+		task.setMakepairs(true);
+		task.setCreatepropertynames(true);
+		task.setOverwrite(true);
+		task.setUsepkgpath(true);
+		task.setTemplate(template.getPath());
 
-        // run task
-        task.execute();
+		// run task
+		task.execute();
 
-        CgenConfiguration cgenConfiguration = task.buildConfiguration(new DataMap());
-        // check results
+		List<CgenConfiguration> configurations = task.buildConfigurations(new DataMap());
+		for (CgenConfiguration cgenConfiguration : configurations) {
 
-        assertEquals("UTF-8", cgenConfiguration.getEncoding());
-        assertEquals("all", cgenConfiguration.getArtifactsGenerationMode());
-        assertEquals("pattern", cgenConfiguration.getOutputPattern());
-        assertEquals("superPkg", cgenConfiguration.getSuperPkg());
-        assertTrue(cgenConfiguration.isMakePairs());
-        assertTrue(cgenConfiguration.isCreatePropertyNames());
-        assertTrue(cgenConfiguration.isOverwrite());
-        assertTrue(cgenConfiguration.isUsePkgPath());
+			// check results
+			assertEquals("UTF-8", cgenConfiguration.getEncoding());
+			assertEquals("all", cgenConfiguration.getArtifactsGenerationMode());
+			assertEquals("pattern", cgenConfiguration.getOutputPattern());
+			assertEquals("superPkg", cgenConfiguration.getSuperPkg());
+			assertTrue(cgenConfiguration.isMakePairs());
+			assertTrue(cgenConfiguration.isCreatePropertyNames());
+			assertTrue(cgenConfiguration.isOverwrite());
+			assertTrue(cgenConfiguration.isUsePkgPath());
 
-        assertTrue(cgenConfiguration.getTemplate().isFile());
-        assertEquals(convertPath("target/testrun/velotemplate.vm"), convertPath(cgenConfiguration.getTemplate().getData()));
-        assertEquals(TemplateType.ENTITY_SUBCLASS, cgenConfiguration.getTemplate().getType());
+			assertTrue(cgenConfiguration.getTemplate().isFile());
+			assertEquals(convertPath("target/testrun/velotemplate.vm"), convertPath(cgenConfiguration.getTemplate().getData()));
+			assertEquals(TemplateType.ENTITY_SUBCLASS, cgenConfiguration.getTemplate().getType());
 
-        assertTrue(cgenConfiguration.getSuperTemplate().isFile());
-        assertEquals(TemplateType.ENTITY_SUPERCLASS.defaultTemplate().getData(), cgenConfiguration.getSuperTemplate().getData());
-        assertEquals(TemplateType.ENTITY_SUPERCLASS, cgenConfiguration.getSuperTemplate().getType());
+			assertTrue(cgenConfiguration.getSuperTemplate().isFile());
+			assertEquals(TemplateType.ENTITY_SUPERCLASS.defaultTemplate().getData(), cgenConfiguration.getSuperTemplate().getData());
+			assertEquals(TemplateType.ENTITY_SUPERCLASS, cgenConfiguration.getSuperTemplate().getType());
 
-        assertTrue(cgenConfiguration.getEmbeddableTemplate().isFile());
-        assertEquals(TemplateType.EMBEDDABLE_SUBCLASS.defaultTemplate().getData(), cgenConfiguration.getEmbeddableTemplate().getData());
-        assertEquals(TemplateType.EMBEDDABLE_SUBCLASS, cgenConfiguration.getEmbeddableTemplate().getType());
+			assertTrue(cgenConfiguration.getEmbeddableTemplate().isFile());
+			assertEquals(TemplateType.EMBEDDABLE_SUBCLASS.defaultTemplate().getData(), cgenConfiguration.getEmbeddableTemplate().getData());
+			assertEquals(TemplateType.EMBEDDABLE_SUBCLASS, cgenConfiguration.getEmbeddableTemplate().getType());
 
-        assertTrue(cgenConfiguration.getEmbeddableSuperTemplate().isFile());
-        assertEquals(TemplateType.EMBEDDABLE_SUPERCLASS.defaultTemplate().getData(), cgenConfiguration.getEmbeddableSuperTemplate().getData());
-        assertEquals(TemplateType.EMBEDDABLE_SUPERCLASS, cgenConfiguration.getEmbeddableSuperTemplate().getType());
+			assertTrue(cgenConfiguration.getEmbeddableSuperTemplate().isFile());
+			assertEquals(TemplateType.EMBEDDABLE_SUPERCLASS.defaultTemplate().getData(), cgenConfiguration.getEmbeddableSuperTemplate().getData());
+			assertEquals(TemplateType.EMBEDDABLE_SUPERCLASS, cgenConfiguration.getEmbeddableSuperTemplate().getType());
 
-        assertTrue(cgenConfiguration.getDataMapTemplate().isFile());
-        assertEquals(TemplateType.DATAMAP_SUBCLASS.defaultTemplate().getData(), cgenConfiguration.getDataMapTemplate().getData());
-        assertEquals(TemplateType.DATAMAP_SUBCLASS, cgenConfiguration.getDataMapTemplate().getType());
+			assertTrue(cgenConfiguration.getDataMapTemplate().isFile());
+			assertEquals(TemplateType.DATAMAP_SUBCLASS.defaultTemplate().getData(), cgenConfiguration.getDataMapTemplate().getData());
+			assertEquals(TemplateType.DATAMAP_SUBCLASS, cgenConfiguration.getDataMapTemplate().getType());
 
-        assertTrue(cgenConfiguration.getDataMapSuperTemplate().isFile());
-        assertEquals(TemplateType.DATAMAP_SUPERCLASS.defaultTemplate().getData(), cgenConfiguration.getDataMapSuperTemplate().getData());
-        assertEquals(TemplateType.DATAMAP_SUPERCLASS, cgenConfiguration.getDataMapSuperTemplate().getType());
-    }
+			assertTrue(cgenConfiguration.getDataMapSuperTemplate().isFile());
+			assertEquals(TemplateType.DATAMAP_SUPERCLASS.defaultTemplate().getData(), cgenConfiguration.getDataMapSuperTemplate().getData());
+			assertEquals(TemplateType.DATAMAP_SUPERCLASS, cgenConfiguration.getDataMapSuperTemplate().getType());
+		}
+	}
 
     /**
      * Test single classes generation including full package path.

--- a/cayenne-cgen/src/main/java/org/apache/cayenne/gen/CgenConfigList.java
+++ b/cayenne-cgen/src/main/java/org/apache/cayenne/gen/CgenConfigList.java
@@ -1,0 +1,40 @@
+package org.apache.cayenne.gen;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CgenConfigList {
+
+    public static final String DEFAULT_CONFIG_NAME = "Default";
+    private final List<CgenConfiguration> configurations;
+
+    public CgenConfigList() {
+        this.configurations = new ArrayList<>();
+    }
+
+    public CgenConfiguration getByName(String name) {
+        return configurations.stream().filter(config -> config.getName().equals(name)).findFirst().orElse(null);
+    }
+
+    public void removeByName(String name) {
+        configurations.removeIf(configuration -> configuration.getName().equals(name));
+    }
+
+    public void add(CgenConfiguration configuration) {
+        configurations.add(configuration);
+    }
+
+    public List<String> getNames() {
+        List<String> names = new ArrayList<>();
+        configurations.forEach(configuration -> names.add(configuration.getName()));
+        return names;
+    }
+
+    public List<CgenConfiguration> getAll() {
+        return configurations;
+    }
+
+    public boolean isExist(String name) {
+        return getNames().contains(name);
+    }
+}

--- a/cayenne-cgen/src/main/java/org/apache/cayenne/gen/CgenConfigList.java
+++ b/cayenne-cgen/src/main/java/org/apache/cayenne/gen/CgenConfigList.java
@@ -1,8 +1,34 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+
 package org.apache.cayenne.gen;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
+/**
+ * Class stores set of CgenConfigurations using for classes generation
+ *
+ * @since 4.2
+ */
 public class CgenConfigList {
 
     public static final String DEFAULT_CONFIG_NAME = "Default";
@@ -25,9 +51,9 @@ public class CgenConfigList {
     }
 
     public List<String> getNames() {
-        List<String> names = new ArrayList<>();
-        configurations.forEach(configuration -> names.add(configuration.getName()));
-        return names;
+        return configurations.stream()
+                .map(CgenConfiguration::getName)
+                .collect(Collectors.toList());
     }
 
     public List<CgenConfiguration> getAll() {
@@ -35,6 +61,6 @@ public class CgenConfigList {
     }
 
     public boolean isExist(String name) {
-        return getNames().contains(name);
+        return configurations.stream().anyMatch(c -> name.equals(c.getName()));
     }
 }

--- a/cayenne-cgen/src/main/java/org/apache/cayenne/gen/CgenConfiguration.java
+++ b/cayenne-cgen/src/main/java/org/apache/cayenne/gen/CgenConfiguration.java
@@ -52,6 +52,7 @@ public class CgenConfiguration implements Serializable, XMLSerializable {
     private Set<String> embeddableArtifacts;
     private Collection<String> excludeEmbeddableArtifacts;
 
+    private String name;
     private String superPkg;
     private DataMap dataMap;
 
@@ -128,6 +129,14 @@ public class CgenConfiguration implements Serializable, XMLSerializable {
 
     public void setSuperPkg(String superPkg) {
         this.superPkg = superPkg;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     public DataMap getDataMap() {
@@ -409,6 +418,7 @@ public class CgenConfiguration implements Serializable, XMLSerializable {
     public void encodeAsXML(XMLEncoder encoder, ConfigurationNodeVisitor delegate) {
         encoder.start("cgen")
                 .attribute("xmlns", CgenExtension.NAMESPACE)
+                .simpleTag("name", this.name)
                 .simpleTag("excludeEntities", getExcludeEntites())
                 .simpleTag("excludeEmbeddables", getExcludeEmbeddables())
                 .simpleTag("destDir", separatorsToUnix(buildRelPath()))

--- a/cayenne-cgen/src/main/java/org/apache/cayenne/gen/TemplateType.java
+++ b/cayenne-cgen/src/main/java/org/apache/cayenne/gen/TemplateType.java
@@ -32,6 +32,7 @@ public enum TemplateType {
     ENTITY_SUPERCLASS(true,"Entity Superclass","templates/v4_1/superclass.vm"),
 
     ENTITY_SUBCLASS(false,"Entity Subclass","templates/v4_1/subclass.vm"),
+
     EMBEDDABLE_SINGLE_CLASS(false,"Single Embeddable Class","templates/v4_1/embeddable-singleclass.vm"),
 
     EMBEDDABLE_SUPERCLASS(true,"Embeddable Superclass","templates/v4_1/embeddable-superclass.vm"),
@@ -66,15 +67,6 @@ public enum TemplateType {
 
     public CgenTemplate defaultTemplate() {
         return defaultTemplate;
-    }
-
-    public static TemplateType byName(String name){
-        for (TemplateType templateType : TemplateType.values()) {
-            if (templateType.readableName.equals(name)){
-                return templateType;
-            }
-        }
-      return null;
     }
 
     public static boolean isDefault(String templateText) {

--- a/cayenne-cgen/src/main/java/org/apache/cayenne/gen/xml/CgenSaverDelegate.java
+++ b/cayenne-cgen/src/main/java/org/apache/cayenne/gen/xml/CgenSaverDelegate.java
@@ -21,6 +21,7 @@ package org.apache.cayenne.gen.xml;
 import org.apache.cayenne.CayenneRuntimeException;
 import org.apache.cayenne.configuration.xml.DataChannelMetaData;
 import org.apache.cayenne.gen.CgenConfiguration;
+import org.apache.cayenne.gen.CgenConfigList;
 import org.apache.cayenne.map.DataMap;
 import org.apache.cayenne.project.extension.BaseSaverDelegate;
 
@@ -37,16 +38,20 @@ public class CgenSaverDelegate extends BaseSaverDelegate {
 
     private DataChannelMetaData metaData;
 
-    CgenSaverDelegate(DataChannelMetaData metaData){
+    CgenSaverDelegate(DataChannelMetaData metaData) {
         this.metaData = metaData;
     }
 
     @Override
     public Void visitDataMap(DataMap dataMap) {
-        CgenConfiguration cgen = metaData.get(dataMap, CgenConfiguration.class);
-        if(cgen != null){
-            resolveOutputDir(getBaseDirectory().getURL(), cgen);
-            encoder.nested(cgen, getParentDelegate());
+        CgenConfigList cgenConfigList = metaData.get(dataMap, CgenConfigList.class);
+        if (cgenConfigList != null) {
+            for (CgenConfiguration cgen : cgenConfigList.getAll()) {
+                if (cgen != null) {
+                    resolveOutputDir(getBaseDirectory().getURL(), cgen);
+                    encoder.nested(cgen, getParentDelegate());
+                }
+            }
         }
         return null;
     }

--- a/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/CgenTask.java
+++ b/cayenne-gradle-plugin/src/main/java/org/apache/cayenne/tools/CgenTask.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -328,27 +329,21 @@ public class CgenTask extends BaseCayenneTask {
     }
 
     List<CgenConfiguration> buildConfigurations(DataMap dataMap) {
-        List<CgenConfiguration> configurations = new ArrayList<>();
         CgenConfiguration cgenConfiguration;
         if (hasConfig()) {
             getLogger().info("Using cgen config from pom.xml");
-            configurations.add(cgenConfigFromPom(dataMap));
-            return configurations;
+            return Collections.singletonList(cgenConfigFromPom(dataMap));
         } else if (metaData != null && metaData.get(dataMap, CgenConfigList.class) != null) {
+            getLogger().info("Using cgen config from " + dataMap.getName());
             CgenConfigList cgenConfigList = metaData.get(dataMap, CgenConfigList.class);
-            for (CgenConfiguration configuration : cgenConfigList.getAll()) {
-                getLogger().info("Using cgen config from " + dataMap.getName());
-                configurations.add(configuration);
-            }
             useConfigFromDataMap = true;
-            return configurations;
+            return cgenConfigList.getAll();
         } else {
             getLogger().info("Using default cgen config.");
             cgenConfiguration = new CgenConfiguration();
             cgenConfiguration.setRelPath(getDestDirFile().getPath());
             cgenConfiguration.setDataMap(dataMap);
-            configurations.add(cgenConfiguration);
-            return configurations;
+            return Collections.singletonList(cgenConfiguration);
         }
     }
 

--- a/cayenne-gradle-plugin/src/test/java/org/apache/cayenne/tools/CgenTaskTest.java
+++ b/cayenne-gradle-plugin/src/test/java/org/apache/cayenne/tools/CgenTaskTest.java
@@ -63,8 +63,8 @@ public class CgenTaskTest {
         doCallRealMethod().when(mock).setOverwrite(anyBoolean());
         doCallRealMethod().when(mock).setUsePkgPath(anyBoolean());
         doCallRealMethod().when(mock).setTemplate(anyString());
-        when(mock.buildConfiguration(dataMap)).thenCallRealMethod();
-        when(mock.createGenerator(dataMap)).thenCallRealMethod();
+        when(mock.buildConfigurations(dataMap)).thenCallRealMethod();
+        when(mock.createGenerators(dataMap)).thenCallRealMethod();
         when(mock.getLogger()).thenReturn(Logging.getLogger(CgenTaskTest.class));
 
         return mock;
@@ -88,25 +88,26 @@ public class CgenTaskTest {
         task.setOverwrite(true);
         task.setUsePkgPath(true);
 
-        CgenConfiguration configuration = task.buildConfiguration(dataMap);
-        ClassGenerationAction createdAction = new ClassGenerationAction(configuration);
+        for (CgenConfiguration configuration : task.buildConfigurations(dataMap)) {
 
-        CgenConfiguration cgenConfiguration = createdAction.getCgenConfiguration();
-        CgenTemplate cgenTemplate = cgenConfiguration.getTemplate();
-        assertNotNull(cgenConfiguration.getEmbeddableSuperTemplate());
-        assertNotNull(cgenConfiguration.getEmbeddableTemplate());
+            ClassGenerationAction createdAction = new ClassGenerationAction(configuration);
 
-        assertEquals(cgenConfiguration.getEncoding(), "UTF-8");
-        assertEquals(cgenConfiguration.getArtifactsGenerationMode(), "entity");
-        assertEquals(cgenConfiguration.getOutputPattern(), "pattern");
-        assertEquals(cgenConfiguration.getSuperPkg(), "org.example.model.auto");
-        assertTrue(cgenTemplate.isFile());
-        assertEquals("org/apache/cayenne/tools/velotemplate.vm", cgenTemplate.getData());
-        assertTrue(cgenConfiguration.isMakePairs());
-        assertTrue(cgenConfiguration.isCreatePropertyNames());
-        assertTrue(cgenConfiguration.isOverwrite());
-        assertTrue(cgenConfiguration.isUsePkgPath());
+            CgenConfiguration cgenConfiguration = createdAction.getCgenConfiguration();
+            CgenTemplate cgenTemplate = cgenConfiguration.getTemplate();
+            assertNotNull(cgenConfiguration.getEmbeddableSuperTemplate());
+            assertNotNull(cgenConfiguration.getEmbeddableTemplate());
 
+            assertEquals(cgenConfiguration.getEncoding(), "UTF-8");
+            assertEquals(cgenConfiguration.getArtifactsGenerationMode(), "entity");
+            assertEquals(cgenConfiguration.getOutputPattern(), "pattern");
+            assertEquals(cgenConfiguration.getSuperPkg(), "org.example.model.auto");
+            assertTrue(cgenTemplate.isFile());
+            assertEquals("org/apache/cayenne/tools/velotemplate.vm", cgenTemplate.getData());
+            assertTrue(cgenConfiguration.isMakePairs());
+            assertTrue(cgenConfiguration.isCreatePropertyNames());
+            assertTrue(cgenConfiguration.isOverwrite());
+            assertTrue(cgenConfiguration.isUsePkgPath());
+        }
     }
 
 }

--- a/cayenne-server/src/main/resources/org/apache/cayenne/schema/11/cgen.xsd
+++ b/cayenne-server/src/main/resources/org/apache/cayenne/schema/11/cgen.xsd
@@ -26,6 +26,7 @@
     <xs:element name="cgen">
         <xs:complexType>
                 <xs:sequence>
+                    <xs:element name="name" minOccurs="0" type="xs:string"/>
                     <xs:element name="excludeEntities" minOccurs="0" type="xs:string"/>
                     <xs:element name="excludeEmbeddables" minOccurs="0" type="xs:string"/>
                     <xs:element name="destDir" minOccurs="0" type="xs:string"/>

--- a/maven-plugins/cayenne-maven-plugin/src/main/java/org/apache/cayenne/tools/CayenneGeneratorMojo.java
+++ b/maven-plugins/cayenne-maven-plugin/src/main/java/org/apache/cayenne/tools/CayenneGeneratorMojo.java
@@ -20,6 +20,8 @@
 package org.apache.cayenne.tools;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.cayenne.configuration.xml.DataChannelMetaData;
 import org.apache.cayenne.dbsync.filter.NamePatternMatcher;
@@ -27,6 +29,7 @@ import org.apache.cayenne.dbsync.reverse.configuration.ToolsModule;
 import org.apache.cayenne.di.Injector;
 import org.apache.cayenne.gen.ArtifactsGenerationMode;
 import org.apache.cayenne.gen.CgenConfiguration;
+import org.apache.cayenne.gen.CgenConfigList;
 import org.apache.cayenne.gen.ClassGenerationAction;
 import org.apache.cayenne.gen.ClassGenerationActionFactory;
 import org.apache.cayenne.gen.CgenTemplate;
@@ -265,29 +268,29 @@ public class CayenneGeneratorMojo extends AbstractMojo {
 
         try {
             loaderAction.setAdditionalDataMapFiles(convertAdditionalDataMaps());
-
             DataMap dataMap = loaderAction.getMainDataMap();
-            ClassGenerationAction generator = createGenerator(dataMap);
-            CayenneGeneratorEntityFilterAction filterEntityAction = new CayenneGeneratorEntityFilterAction();
-            filterEntityAction.setNameFilter(NamePatternMatcher.build(logger, includeEntities, excludeEntities));
+            for (ClassGenerationAction generator : createGenerators(dataMap)) {
+                CayenneGeneratorEntityFilterAction filterEntityAction = new CayenneGeneratorEntityFilterAction();
+                filterEntityAction.setNameFilter(NamePatternMatcher.build(logger, includeEntities, excludeEntities));
 
-            CayenneGeneratorEmbeddableFilterAction filterEmbeddableAction = new CayenneGeneratorEmbeddableFilterAction();
-            filterEmbeddableAction.setNameFilter(NamePatternMatcher.build(logger, null, excludeEmbeddables));
-            generator.setLogger(logger);
+                CayenneGeneratorEmbeddableFilterAction filterEmbeddableAction = new CayenneGeneratorEmbeddableFilterAction();
+                filterEmbeddableAction.setNameFilter(NamePatternMatcher.build(logger, null, excludeEmbeddables));
+                generator.setLogger(logger);
 
-            if (force) {
-                // will (re-)generate all files
-                generator.getCgenConfiguration().setForce(true);
+                if (force) {
+                    // will (re-)generate all files
+                    generator.getCgenConfiguration().setForce(true);
+                }
+                generator.getCgenConfiguration().setTimestamp(map.lastModified());
+                if (!hasConfig() && useConfigFromDataMap) {
+                    generator.prepareArtifacts();
+                } else {
+                    generator.addEntities(filterEntityAction.getFilteredEntities(dataMap));
+                    generator.addEmbeddables(filterEmbeddableAction.getFilteredEmbeddables(dataMap));
+                    generator.addQueries(dataMap.getQueryDescriptors());
+                }
+                generator.execute();
             }
-            generator.getCgenConfiguration().setTimestamp(map.lastModified());
-            if (!hasConfig() && useConfigFromDataMap) {
-                generator.prepareArtifacts();
-            } else {
-                generator.addEntities(filterEntityAction.getFilteredEntities(dataMap));
-                generator.addEmbeddables(filterEmbeddableAction.getFilteredEmbeddables(dataMap));
-                generator.addQueries(dataMap.getQueryDescriptors());
-            }
-            generator.execute();
         } catch (Exception e) {
             throw new MojoExecutionException("Error generating classes: ", e);
         }
@@ -323,26 +326,35 @@ public class CayenneGeneratorMojo extends AbstractMojo {
      * Factory method to create internal class generator. Called from
      * constructor.
      */
-    private ClassGenerationAction createGenerator(DataMap dataMap) {
-        CgenConfiguration cgenConfiguration = buildConfiguration(dataMap);
-        return injector.getInstance(ClassGenerationActionFactory.class).createAction(cgenConfiguration);
+    private List<ClassGenerationAction> createGenerators(DataMap dataMap) {
+        List<ClassGenerationAction> actions = new ArrayList<>();
+        for (CgenConfiguration configuration : buildConfigurations(dataMap)) {
+            actions.add(injector.getInstance(ClassGenerationActionFactory.class).createAction(configuration));
+        }
+        return actions;
     }
 
-     CgenConfiguration buildConfiguration(DataMap dataMap) {
-        CgenConfiguration cgenConfiguration = injector.getInstance(DataChannelMetaData.class).get(dataMap, CgenConfiguration.class);
+    List<CgenConfiguration> buildConfigurations(DataMap dataMap) {
+        List<CgenConfiguration> configurations = new ArrayList<>();
+        CgenConfigList cgenConfigList = injector.getInstance(DataChannelMetaData.class).get(dataMap, CgenConfigList.class);
         if (hasConfig()) {
             logger.info("Using cgen config from pom.xml");
-            return cgenConfigFromPom(dataMap);
-        } else if (cgenConfiguration != null) {
-            logger.info("Using cgen config from " + cgenConfiguration.getDataMap().getName());
+            configurations.add(cgenConfigFromPom(dataMap));
+            return configurations;
+        } else if (cgenConfigList != null) {
+            for (CgenConfiguration cgenConfiguration : cgenConfigList.getAll()) {
+                configurations.add(cgenConfiguration);
+                logger.info("Using cgen config from " + cgenConfiguration.getDataMap().getName());
+            }
             useConfigFromDataMap = true;
-            return cgenConfiguration;
+            return configurations;
         } else {
             logger.info("Using default cgen config.");
-            cgenConfiguration = new CgenConfiguration();
+            CgenConfiguration cgenConfiguration = new CgenConfiguration();
             cgenConfiguration.setDataMap(dataMap);
             cgenConfiguration.setRelPath(defaultDir.getPath());
-            return cgenConfiguration;
+            configurations.add(cgenConfiguration);
+            return configurations;
         }
     }
 
@@ -359,14 +371,14 @@ public class CayenneGeneratorMojo extends AbstractMojo {
         cgenConfiguration.setOutputPattern(outputPattern != null ? outputPattern : cgenConfiguration.getOutputPattern());
         cgenConfiguration.setOverwrite(overwrite != null ? overwrite : cgenConfiguration.isOverwrite());
         cgenConfiguration.setSuperPkg(superPkg != null ? superPkg : cgenConfiguration.getSuperPkg());
-        cgenConfiguration.setSuperTemplate(superTemplate != null ? new CgenTemplate(superTemplate, true,TemplateType.ENTITY_SUPERCLASS) : cgenConfiguration.getSuperTemplate());
-        cgenConfiguration.setTemplate(template != null ? new CgenTemplate(template, true,TemplateType.ENTITY_SUBCLASS) : cgenConfiguration.getTemplate());
-        cgenConfiguration.setEmbeddableSuperTemplate(embeddableSuperTemplate != null ? new CgenTemplate(embeddableSuperTemplate,true,TemplateType.EMBEDDABLE_SUPERCLASS) : cgenConfiguration.getEmbeddableSuperTemplate());
-        cgenConfiguration.setEmbeddableTemplate(embeddableTemplate != null ? new CgenTemplate(embeddableTemplate,true,TemplateType.EMBEDDABLE_SUBCLASS) : cgenConfiguration.getEmbeddableTemplate());
+        cgenConfiguration.setSuperTemplate(superTemplate != null ? new CgenTemplate(superTemplate, true, TemplateType.ENTITY_SUPERCLASS) : cgenConfiguration.getSuperTemplate());
+        cgenConfiguration.setTemplate(template != null ? new CgenTemplate(template, true, TemplateType.ENTITY_SUBCLASS) : cgenConfiguration.getTemplate());
+        cgenConfiguration.setEmbeddableSuperTemplate(embeddableSuperTemplate != null ? new CgenTemplate(embeddableSuperTemplate, true, TemplateType.EMBEDDABLE_SUPERCLASS) : cgenConfiguration.getEmbeddableSuperTemplate());
+        cgenConfiguration.setEmbeddableTemplate(embeddableTemplate != null ? new CgenTemplate(embeddableTemplate, true, TemplateType.EMBEDDABLE_SUBCLASS) : cgenConfiguration.getEmbeddableTemplate());
         cgenConfiguration.setUsePkgPath(usePkgPath != null ? usePkgPath : cgenConfiguration.isUsePkgPath());
         cgenConfiguration.setCreatePropertyNames(createPropertyNames != null ? createPropertyNames : cgenConfiguration.isCreatePropertyNames());
-        cgenConfiguration.setDataMapTemplate(dataMapTemplate != null ? new CgenTemplate(dataMapTemplate,true,TemplateType.DATAMAP_SUBCLASS) : cgenConfiguration.getDataMapTemplate());
-        cgenConfiguration.setDataMapSuperTemplate(dataMapSuperTemplate != null ? new CgenTemplate(dataMapSuperTemplate,true,TemplateType.DATAMAP_SUPERCLASS) : cgenConfiguration.getDataMapSuperTemplate());
+        cgenConfiguration.setDataMapTemplate(dataMapTemplate != null ? new CgenTemplate(dataMapTemplate, true, TemplateType.DATAMAP_SUBCLASS) : cgenConfiguration.getDataMapTemplate());
+        cgenConfiguration.setDataMapSuperTemplate(dataMapSuperTemplate != null ? new CgenTemplate(dataMapSuperTemplate, true, TemplateType.DATAMAP_SUPERCLASS) : cgenConfiguration.getDataMapSuperTemplate());
         cgenConfiguration.setCreatePKProperties(createPKProperties != null ? createPKProperties : cgenConfiguration.isCreatePKProperties());
         cgenConfiguration.setExternalToolConfig(externalToolConfig != null ? externalToolConfig : cgenConfiguration.getExternalToolConfig());
         if (!cgenConfiguration.isMakePairs()) {

--- a/maven-plugins/cayenne-maven-plugin/src/main/java/org/apache/cayenne/tools/CayenneGeneratorMojo.java
+++ b/maven-plugins/cayenne-maven-plugin/src/main/java/org/apache/cayenne/tools/CayenneGeneratorMojo.java
@@ -21,6 +21,7 @@ package org.apache.cayenne.tools;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.cayenne.configuration.xml.DataChannelMetaData;
@@ -335,26 +336,20 @@ public class CayenneGeneratorMojo extends AbstractMojo {
     }
 
     List<CgenConfiguration> buildConfigurations(DataMap dataMap) {
-        List<CgenConfiguration> configurations = new ArrayList<>();
         CgenConfigList cgenConfigList = injector.getInstance(DataChannelMetaData.class).get(dataMap, CgenConfigList.class);
         if (hasConfig()) {
             logger.info("Using cgen config from pom.xml");
-            configurations.add(cgenConfigFromPom(dataMap));
-            return configurations;
+            return Collections.singletonList(cgenConfigFromPom(dataMap));
         } else if (cgenConfigList != null) {
-            for (CgenConfiguration cgenConfiguration : cgenConfigList.getAll()) {
-                configurations.add(cgenConfiguration);
-                logger.info("Using cgen config from " + cgenConfiguration.getDataMap().getName());
-            }
+            logger.info("Using cgen config from dataMap");
             useConfigFromDataMap = true;
-            return configurations;
+            return cgenConfigList.getAll();
         } else {
             logger.info("Using default cgen config.");
             CgenConfiguration cgenConfiguration = new CgenConfiguration();
             cgenConfiguration.setDataMap(dataMap);
             cgenConfiguration.setRelPath(defaultDir.getPath());
-            configurations.add(cgenConfiguration);
-            return configurations;
+            return Collections.singletonList(cgenConfiguration);
         }
     }
 

--- a/maven-plugins/cayenne-maven-plugin/src/test/java/org/apache/cayenne/tools/CayenneGeneratorMojoTest.java
+++ b/maven-plugins/cayenne-maven-plugin/src/test/java/org/apache/cayenne/tools/CayenneGeneratorMojoTest.java
@@ -25,6 +25,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 
 import java.io.File;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -82,40 +83,41 @@ public class CayenneGeneratorMojoTest extends AbstractMojoTestCase {
         assertNotNull(myMojo);
 
         myMojo.execute();
-        CgenConfiguration cgenConfiguration = myMojo.buildConfiguration(new DataMap());
+        List<CgenConfiguration> cgenConfigurations = myMojo.buildConfigurations(new DataMap());
+        for (CgenConfiguration cgenConfiguration : cgenConfigurations) {
+            assertEquals("UTF-8", cgenConfiguration.getEncoding());
+            assertEquals("all", cgenConfiguration.getArtifactsGenerationMode());
+            assertEquals("pattern", cgenConfiguration.getOutputPattern());
+            assertEquals("superPkg", cgenConfiguration.getSuperPkg());
+            assertTrue(cgenConfiguration.isMakePairs());
+            assertTrue(cgenConfiguration.isCreatePropertyNames());
+            assertTrue(cgenConfiguration.isOverwrite());
+            assertTrue(cgenConfiguration.isUsePkgPath());
 
-        assertEquals("UTF-8", cgenConfiguration.getEncoding());
-        assertEquals("all", cgenConfiguration.getArtifactsGenerationMode());
-        assertEquals("pattern", cgenConfiguration.getOutputPattern());
-        assertEquals("superPkg", cgenConfiguration.getSuperPkg());
-        assertTrue(cgenConfiguration.isMakePairs());
-        assertTrue(cgenConfiguration.isCreatePropertyNames());
-        assertTrue(cgenConfiguration.isOverwrite());
-        assertTrue(cgenConfiguration.isUsePkgPath());
+            assertTrue(cgenConfiguration.getTemplate().isFile());
+            assertEquals(TEST_TEMPLATE_PATH, cgenConfiguration.getTemplate().getData());
+            assertEquals(TemplateType.ENTITY_SUBCLASS, cgenConfiguration.getTemplate().getType());
 
-        assertTrue(cgenConfiguration.getTemplate().isFile());
-        assertEquals(TEST_TEMPLATE_PATH,cgenConfiguration.getTemplate().getData());
-        assertEquals(TemplateType.ENTITY_SUBCLASS,cgenConfiguration.getTemplate().getType());
+            assertTrue(cgenConfiguration.getSuperTemplate().isFile());
+            assertEquals(TEST_TEMPLATE_PATH, cgenConfiguration.getSuperTemplate().getData());
+            assertEquals(TemplateType.ENTITY_SUPERCLASS, cgenConfiguration.getSuperTemplate().getType());
 
-        assertTrue(cgenConfiguration.getSuperTemplate().isFile());
-        assertEquals(TEST_TEMPLATE_PATH,cgenConfiguration.getSuperTemplate().getData());
-        assertEquals(TemplateType.ENTITY_SUPERCLASS,cgenConfiguration.getSuperTemplate().getType());
+            assertTrue(cgenConfiguration.getEmbeddableTemplate().isFile());
+            assertEquals(TEST_TEMPLATE_PATH, cgenConfiguration.getEmbeddableTemplate().getData());
+            assertEquals(TemplateType.EMBEDDABLE_SUBCLASS, cgenConfiguration.getEmbeddableTemplate().getType());
 
-        assertTrue(cgenConfiguration.getEmbeddableTemplate().isFile());
-        assertEquals(TEST_TEMPLATE_PATH,cgenConfiguration.getEmbeddableTemplate().getData());
-        assertEquals(TemplateType.EMBEDDABLE_SUBCLASS,cgenConfiguration.getEmbeddableTemplate().getType());
+            assertTrue(cgenConfiguration.getEmbeddableSuperTemplate().isFile());
+            assertEquals(TEST_TEMPLATE_PATH, cgenConfiguration.getEmbeddableSuperTemplate().getData());
+            assertEquals(TemplateType.EMBEDDABLE_SUPERCLASS, cgenConfiguration.getEmbeddableSuperTemplate().getType());
 
-        assertTrue(cgenConfiguration.getEmbeddableSuperTemplate().isFile());
-        assertEquals(TEST_TEMPLATE_PATH,cgenConfiguration.getEmbeddableSuperTemplate().getData());
-        assertEquals(TemplateType.EMBEDDABLE_SUPERCLASS,cgenConfiguration.getEmbeddableSuperTemplate().getType());
+            assertTrue(cgenConfiguration.getDataMapTemplate().isFile());
+            assertEquals(TEST_TEMPLATE_PATH, cgenConfiguration.getDataMapTemplate().getData());
+            assertEquals(TemplateType.DATAMAP_SUBCLASS, cgenConfiguration.getDataMapTemplate().getType());
 
-        assertTrue(cgenConfiguration.getDataMapTemplate().isFile());
-        assertEquals(TEST_TEMPLATE_PATH,cgenConfiguration.getDataMapTemplate().getData());
-        assertEquals(TemplateType.DATAMAP_SUBCLASS,cgenConfiguration.getDataMapTemplate().getType());
-
-        assertTrue(cgenConfiguration.getDataMapSuperTemplate().isFile());
-        assertEquals(TEST_TEMPLATE_PATH,cgenConfiguration.getDataMapSuperTemplate().getData());
-        assertEquals(TemplateType.DATAMAP_SUPERCLASS,cgenConfiguration.getDataMapSuperTemplate().getType());
+            assertTrue(cgenConfiguration.getDataMapSuperTemplate().isFile());
+            assertEquals(TEST_TEMPLATE_PATH, cgenConfiguration.getDataMapSuperTemplate().getData());
+            assertEquals(TemplateType.DATAMAP_SUPERCLASS, cgenConfiguration.getDataMapSuperTemplate().getType());
+        }
     }
 
     public void testCgenDataMapConfig() throws Exception {

--- a/modeler/cayenne-modeler-generic-ext/src/main/java/org/apache/cayenne/modeler/generic/GenericPlatformInitializer.java
+++ b/modeler/cayenne-modeler-generic-ext/src/main/java/org/apache/cayenne/modeler/generic/GenericPlatformInitializer.java
@@ -81,6 +81,7 @@ public class GenericPlatformInitializer implements PlatformInitializer {
         UIManager.put("Table.scrollPaneBorder",         BorderFactory.createEmptyBorder());
         UIManager.put("SplitPane.border",               BorderFactory.createEmptyBorder());
         UIManager.put("ToolBar.border",                 BorderFactory.createEmptyBorder(1, 1, 1, 1));
+        UIManager.put("CheckBoxHeader.border",          BorderFactory.createEmptyBorder(0, 15, 0, 0));
         UIManager.put("MenuItem.selectionBackground",   greyHighlight);
         UIManager.put("MenuItem.selectionForeground",   Color.BLACK);
         // this one is custom for MainToolBar

--- a/modeler/cayenne-modeler-mac-ext/src/main/java/org/apache/cayenne/modeler/osx/OSXPlatformInitializer.java
+++ b/modeler/cayenne-modeler-mac-ext/src/main/java/org/apache/cayenne/modeler/osx/OSXPlatformInitializer.java
@@ -73,7 +73,7 @@ public class OSXPlatformInitializer implements PlatformInitializer {
 
         UIManager.put("ToolBarSeparatorUI",           OSXToolBarSeparatorUI.class.getName());
         UIManager.put("PanelUI",                      OSXPanelUI.class.getName());
-        // next two is custom made for Cayenne's MainToolBar
+        // next two is custom-made for Cayenne's MainToolBar
         UIManager.put("ToolBar.background",           lightGrey);
         UIManager.put("MainToolBar.background",       lightGrey);
         UIManager.put("MainToolBar.border",           BorderFactory.createEmptyBorder(0, 7, 0, 7));
@@ -92,6 +92,7 @@ public class OSXPlatformInitializer implements PlatformInitializer {
         UIManager.put("Table.selectionForeground",    Color.BLACK);
         UIManager.put("Table.selectionBackground",    lightGrey);
         UIManager.put("Table.focusCellHighlightBorder", BorderFactory.createEmptyBorder());
+        UIManager.put("CheckBoxHeader.border",          BorderFactory.createEmptyBorder(0, 9, 0, 0));
 
         // MacOS BigSur needs additional style tweaking for the tabs active state
         OSXVersion version = OSXVersion.fromSystemProperties();

--- a/modeler/cayenne-modeler-win-ext/src/main/java/org/apache/cayenne/modeler/win/WinPlatformInitializer.java
+++ b/modeler/cayenne-modeler-win-ext/src/main/java/org/apache/cayenne/modeler/win/WinPlatformInitializer.java
@@ -63,6 +63,7 @@ public class WinPlatformInitializer implements PlatformInitializer {
         UIManager.put("ScrollPane.border",      BorderFactory.createEmptyBorder());
         UIManager.put("Table.scrollPaneBorder", BorderFactory.createEmptyBorder());
         UIManager.put("SplitPane.border",       BorderFactory.createEmptyBorder());
+        UIManager.put("CheckBoxHeader.border",  BorderFactory.createEmptyBorder(0, 15, 0, 0));
         UIManager.put("SplitPane.background",   darkGrey);
         UIManager.put("Separator.background",   darkGrey);
         UIManager.put("Separator.foreground",   darkGrey);

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/CheckBoxHeader.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/CheckBoxHeader.java
@@ -1,0 +1,59 @@
+package org.apache.cayenne.modeler.editor.cgen;
+
+import javax.swing.JCheckBox;
+import javax.swing.JTable;
+import javax.swing.UIManager;
+import javax.swing.table.JTableHeader;
+import javax.swing.table.TableCellRenderer;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+
+
+    class CheckBoxHeader extends JCheckBox implements TableCellRenderer, MouseListener  {
+        protected int column;
+        protected boolean mousePressed = false;
+        private final CheckBoxHeader rendererComponent;
+
+        public CheckBoxHeader() {
+            this.rendererComponent = this;
+        }
+
+        public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+            this.column = column;
+            if (table != null) {
+                JTableHeader header = table.getTableHeader();
+                if (header != null) {
+                    header.addMouseListener(rendererComponent);
+                }
+            }
+            rendererComponent.setBackground(UIManager.getColor("Table.selectionBackground"));
+            setBorder(UIManager.getBorder("CheckBoxHeader.border"));
+            return rendererComponent;
+        }
+
+        public void mouseClicked(MouseEvent e) {
+            if (mousePressed) {
+                mousePressed=false;
+                JTableHeader header = (JTableHeader) (e.getSource());
+                int columnAtPoint = header.columnAtPoint(e.getPoint());
+                if (columnAtPoint == column) {
+                    doClick();
+                }
+            }
+        }
+
+        public void mousePressed(MouseEvent e) {
+            mousePressed = true;
+        }
+        public void mouseReleased(MouseEvent e) {
+        }
+        public void mouseEntered(MouseEvent e) {
+        }
+        public void mouseExited(MouseEvent e) {
+        }
+
+    }
+
+

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/CheckBoxHeader.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/CheckBoxHeader.java
@@ -1,3 +1,23 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+
 package org.apache.cayenne.modeler.editor.cgen;
 
 import javax.swing.JCheckBox;
@@ -5,12 +25,15 @@ import javax.swing.JTable;
 import javax.swing.UIManager;
 import javax.swing.table.JTableHeader;
 import javax.swing.table.TableCellRenderer;
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 
 
+/**
+ *
+ * @since 4.2
+ */
     class CheckBoxHeader extends JCheckBox implements TableCellRenderer, MouseListener  {
         protected int column;
         protected boolean mousePressed = false;

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/ClassesTabController.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/ClassesTabController.java
@@ -46,21 +46,20 @@ import java.util.List;
 public class ClassesTabController extends CayenneController {
 
     private static final Icon ERROR_ICON = ModelerUtil.buildIcon("icon-error.png");
-
     protected ClassesTabPanel view;
     protected ObjectBinding tableBinding;
-
     private ValidationResult lastValidationResult;
-    private BindingBuilder builder;
+    private final BindingBuilder builder;
+    private final CheckBoxHeader checkBoxHeader;
 
     public ClassesTabController(CodeGeneratorController parent) {
         super(parent);
-
+        this.checkBoxHeader = new CheckBoxHeader();
         this.view = new ClassesTabPanel();
         this.builder = new BindingBuilder(getApplication().getBindingFactory(), this);
     }
 
-    public void startup(){
+    public void startup() {
         initBindings();
         classSelectedAction();
     }
@@ -74,8 +73,7 @@ public class ClassesTabController extends CayenneController {
     }
 
     protected void initBindings() {
-        builder.bindToAction(getParentController().getView().getCheckAll(), "checkAllAction()");
-
+        builder.bindToAction(checkBoxHeader, "checkAllAction()");
         TableBindingBuilder tableBuilder = new TableBindingBuilder(builder);
 
         tableBuilder.addColumn(
@@ -86,7 +84,7 @@ public class ClassesTabController extends CayenneController {
                 Boolean.TRUE);
 
         tableBuilder.addColumn(
-                "Class",
+                "  Class",
                 "getItemName(#item)",
                 JLabel.class,
                 false,
@@ -101,6 +99,7 @@ public class ClassesTabController extends CayenneController {
 
         this.tableBinding = tableBuilder.bindToTable(view.getTable(), "parent.classes");
         TableColumnModel columnModel = view.getTable().getColumnModel();
+        columnModel.getColumn(0).setHeaderRenderer(checkBoxHeader);
         columnModel.getColumn(1).setCellRenderer(new ImageRendererColumn());
         columnModel.getColumn(2).setCellRenderer(new ImageRendererColumn());
     }
@@ -122,12 +121,11 @@ public class ClassesTabController extends CayenneController {
                 + getParentController().getSelectedEmbeddablesSize()
                 + (getParentController().isDataMapSelected() ? 1 : 0);
         int totalClasses = getParentController().getClasses().size();
-
+        checkBoxHeader.setSelected(selectedCount >= totalClasses);
         getParentController().enableGenerateButton(selectedCount != 0);
-        getParentController().getView().getCheckAll().setSelected(selectedCount >= totalClasses);
         getParentController().updateSelectedEntities();
         getParentController().getStandardModeController().updateTemplateEditorButtons();
-
+        view.repaint();
     }
 
 
@@ -137,14 +135,10 @@ public class ClassesTabController extends CayenneController {
      */
     @SuppressWarnings("unused")
     public void checkAllAction() {
-        if (getParentController().updateSelection(getParentController().getView().getCheckAll().isSelected() ? o -> true : o -> false)) {
+        if (getParentController().updateSelection(checkBoxHeader.isSelected() ? o -> true : o -> false)) {
             tableBinding.updateView();
             getParentController().updateSelectedEntities();
-            if(getParentController().getView().getCheckAll().isSelected()) {
-                getParentController().enableGenerateButton(true);
-            } else {
-                getParentController().enableGenerateButton(false);
-            }
+            getParentController().enableGenerateButton(checkBoxHeader.isSelected());
         }
     }
 
@@ -175,13 +169,14 @@ public class ClassesTabController extends CayenneController {
 
         JLabel labelIcon = new JLabel();
         labelIcon.setVisible(true);
-        if(validationFailure != null) {
+        if (validationFailure != null) {
             labelIcon.setIcon(ERROR_ICON);
             labelIcon.setToolTipText(validationFailure.getDescription());
         }
         return labelIcon;
     }
 
+    @SuppressWarnings("unused")
     public JLabel getItemName(Object obj) {
         String className;
         Icon icon;

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/ClassesTabPanel.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/ClassesTabPanel.java
@@ -23,6 +23,8 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.ScrollPaneConstants;
+import javax.swing.UIManager;
+import javax.swing.table.DefaultTableCellRenderer;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 
@@ -36,6 +38,9 @@ public class ClassesTabPanel extends JPanel {
 
         this.table = new JTable();
         this.table.setRowHeight(22);
+        DefaultTableCellRenderer renderer = new DefaultTableCellRenderer();
+        renderer.setBackground(UIManager.getColor("Table.selectionBackground"));
+        this.table.getTableHeader().setDefaultRenderer(renderer);
 
         JScrollPane tablePanel = new JScrollPane(
                 table,

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/CodeGeneratorPane.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/CodeGeneratorPane.java
@@ -19,13 +19,13 @@
 
 package org.apache.cayenne.modeler.editor.cgen;
 
-import com.jgoodies.forms.builder.DefaultFormBuilder;
+import com.jgoodies.forms.builder.PanelBuilder;
+import com.jgoodies.forms.layout.CellConstraints;
 import com.jgoodies.forms.layout.FormLayout;
 import org.apache.cayenne.modeler.util.ModelerUtil;
 
 import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JLabel;
+import javax.swing.JComboBox;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
@@ -33,7 +33,6 @@ import javax.swing.ScrollPaneConstants;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
-import java.awt.FlowLayout;
 
 /**
  * @since 4.1
@@ -41,42 +40,27 @@ import java.awt.FlowLayout;
 public class CodeGeneratorPane extends JPanel {
 
     private JButton generateButton;
-    private JCheckBox checkAll;
-    private JLabel checkAllLabel;
+    private JComboBox<String> configurationsComboBox;
+    private JButton addConfigBtn;
+    private JButton editConfigBtn;
+    private JButton removeConfigBtn;
+    private JSplitPane splitPane;
 
     public CodeGeneratorPane(Component generatorPanel, Component entitySelectorPanel) {
         super();
         this.setLayout(new BorderLayout());
 
-        JPanel toolBarPanel = new JPanel();
-        toolBarPanel.setLayout(new BorderLayout());
+        initSplitPanel(generatorPanel, entitySelectorPanel);
+        buildView();
+    }
 
-        FormLayout layout = new FormLayout(
-                "fill:110", "");
-        DefaultFormBuilder builder = new DefaultFormBuilder(layout);
-        this.generateButton = new JButton("Generate");
-        generateButton.setIcon(ModelerUtil.buildIcon("icon-gen_java.png"));
-        generateButton.setEnabled(false);
-        builder.append(generateButton);
-        toolBarPanel.add(builder.getPanel(), BorderLayout.EAST);
+    private void buildView() {
+        add(getTopPanel(), BorderLayout.NORTH);
+        add(splitPane, BorderLayout.CENTER);
+    }
 
-        this.checkAll = new JCheckBox();
-        this.checkAllLabel = new JLabel("Check All Classes");
-        checkAll.addItemListener(event -> {
-            if (checkAll.isSelected()) {
-                checkAllLabel.setText("Uncheck All Classess");
-            } else {
-                checkAllLabel.setText("Check All Classes");
-            }
-        });
-        JPanel topPanel = new JPanel(new FlowLayout(FlowLayout.LEADING));
-        topPanel.add(checkAll);
-        topPanel.add(checkAllLabel);
-        toolBarPanel.add(topPanel, BorderLayout.WEST);
-
-        add(toolBarPanel, BorderLayout.NORTH);
-
-        JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
+    private void initSplitPanel(Component generatorPanel, Component entitySelectorPanel) {
+        this.splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
         JScrollPane scrollPane = new JScrollPane(
                 generatorPanel,
                 ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
@@ -86,15 +70,67 @@ public class CodeGeneratorPane extends JPanel {
         // assemble
         splitPane.setRightComponent(scrollPane);
         splitPane.setLeftComponent(entitySelectorPanel);
+    }
 
-        add(splitPane, BorderLayout.CENTER);
+    private JPanel getTopPanel() {
+        JPanel configPanel = new JPanel();
+        configPanel.setLayout(new BorderLayout());
+        configPanel.add(getConfigurationsPanel(), BorderLayout.WEST);
+        configPanel.add(getGeneratePanel(), BorderLayout.EAST);
+        configPanel.setBorder(StandardModePanel.CGEN_PANEL_BORDER);
+        return configPanel;
+    }
+
+    private JPanel getConfigurationsPanel() {
+        FormLayout configCroupLayout = new FormLayout(
+                "109dlu,3dlu,pref,3dlu,pref,3dlu,pref",
+                "p");
+        PanelBuilder configCroupBuilder = new PanelBuilder(configCroupLayout);
+        CellConstraints cc = new CellConstraints();
+        this.configurationsComboBox = new JComboBox<>();
+        this.addConfigBtn = new JButton(ModelerUtil.buildIcon("icon-new.png"));
+        addConfigBtn.setToolTipText("New configuration");
+        this.editConfigBtn = new JButton(ModelerUtil.buildIcon("icon-edit.png"));
+        editConfigBtn.setToolTipText("Rename configuration");
+        this.removeConfigBtn = new JButton(ModelerUtil.buildIcon("icon-trash.png"));
+        removeConfigBtn.setToolTipText("Remove configuration");
+        configCroupBuilder.add(configurationsComboBox, cc.xy(1, 1));
+        configCroupBuilder.add(addConfigBtn, cc.xy(3, 1));
+        configCroupBuilder.add(editConfigBtn, cc.xy(5, 1));
+        configCroupBuilder.add(removeConfigBtn, cc.xy(7, 1));
+        return configCroupBuilder.getPanel();
+    }
+
+    private JPanel getGeneratePanel() {
+        this.generateButton = new JButton("Generate");
+        this.generateButton.setIcon(ModelerUtil.buildIcon("icon-gen_java.png"));
+        this.generateButton.setEnabled(false);
+        FormLayout generateCroupLayout = new FormLayout(
+                "60dlu", "p");
+        PanelBuilder generateCroupBuilder = new PanelBuilder(generateCroupLayout);
+        CellConstraints cc = new CellConstraints();
+
+        generateCroupBuilder.add(generateButton,cc.xy(1,1));
+        return generateCroupBuilder.getPanel();
     }
 
     public JButton getGenerateButton() {
         return generateButton;
     }
 
-    public JCheckBox getCheckAll() {
-        return checkAll;
+    public JComboBox<String> getConfigurationsComboBox() {
+        return configurationsComboBox;
+    }
+
+    public JButton getAddConfigBtn() {
+        return addConfigBtn;
+    }
+
+    public JButton getEditConfigBtn() {
+        return editConfigBtn;
+    }
+
+    public JButton getRemoveConfigBtn() {
+        return removeConfigBtn;
     }
 }

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/SelectionModel.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/SelectionModel.java
@@ -60,6 +60,12 @@ class SelectionModel {
         selectedDataMaps = selectedDataMapsForDataMap.computeIfAbsent(dataMap, dm -> new HashSet<>());
     }
 
+    void clearAll(){
+        selectedEntities.clear();
+        selectedEmbeddables.clear();
+        selectedDataMaps.clear();
+    }
+
     boolean updateSelection(Predicate<ConfigurationNode> predicate, Collection<ConfigurationNode> classes) {
         boolean modified = false;
         for (ConfigurationNode classObj : classes) {

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/StandardModeController.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/StandardModeController.java
@@ -21,7 +21,6 @@ package org.apache.cayenne.modeler.editor.cgen;
 
 import org.apache.cayenne.gen.CgenConfiguration;
 import org.apache.cayenne.gen.TemplateType;
-import org.apache.cayenne.modeler.dialog.pref.PreferenceDialog;
 import org.apache.cayenne.modeler.editor.cgen.templateeditor.TemplateEditorController;
 import org.apache.cayenne.modeler.pref.DataMapDefaults;
 

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/StandardModePanel.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/StandardModePanel.java
@@ -28,10 +28,12 @@ import org.apache.cayenne.modeler.util.TextAdapter;
 import org.apache.cayenne.swing.components.JCayenneCheckBox;
 import org.apache.cayenne.validation.ValidationException;
 
+import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JTextField;
+import javax.swing.border.Border;
 import java.awt.BorderLayout;
 
 /**
@@ -58,7 +60,7 @@ public class StandardModePanel extends GeneratorControllerPanel {
     private JLabel embeddableSuperTemplateLbl;
     private JLabel datamapTemplateLbl;
     private JLabel datamapSuperTemplateLbl;
-
+    static final Border CGEN_PANEL_BORDER = BorderFactory.createEmptyBorder(5, 13, 5, 13);
 
     public StandardModePanel(CodeGeneratorController codeGeneratorController) {
         super(Application.getInstance().getFrameController().getProjectController(), codeGeneratorController);
@@ -99,7 +101,7 @@ public class StandardModePanel extends GeneratorControllerPanel {
         setLayout(new BorderLayout());
         CellConstraints cc = new CellConstraints();
         FormLayout layout = new FormLayout(
-                "left:10dlu, 3dlu, 90dlu, 3dlu, pref, 3dlu, 50dlu, 3dlu, 20dlu",
+                "left:10dlu, 3dlu, 97dlu, 3dlu, 40dlu, 3dlu, 50dlu, 3dlu, 20dlu",
                 "p, 3dlu, p, 10dlu, 11*(p, 3dlu),10dlu,9*(p, 3dlu)");
         PanelBuilder builder = new PanelBuilder(layout);
         builder.setDefaultDialogBorder();
@@ -152,6 +154,7 @@ public class StandardModePanel extends GeneratorControllerPanel {
 
         builder.add(datamapSuperTemplateLbl, cc.xyw(1, 40, 3));
         builder.add(editDataMapSuperTemplateBtn, cc.xy(5, 40));
+        builder.getPanel().setBorder(CGEN_PANEL_BORDER);
 
         add(builder.getPanel(), BorderLayout.CENTER);
     }

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/domain/CgenTabController.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/domain/CgenTabController.java
@@ -29,6 +29,7 @@ import java.util.prefs.Preferences;
 
 import org.apache.cayenne.configuration.xml.DataChannelMetaData;
 import org.apache.cayenne.gen.CgenConfiguration;
+import org.apache.cayenne.gen.CgenConfigList;
 import org.apache.cayenne.gen.ClassGenerationAction;
 import org.apache.cayenne.gen.ClassGenerationActionFactory;
 import org.apache.cayenne.map.DataMap;
@@ -52,35 +53,39 @@ public class CgenTabController extends GeneratorsTabController<CgenConfiguration
 
     public void runGenerators(Set<DataMap> dataMaps) {
         DataChannelMetaData metaData = Application.getInstance().getMetaData();
-        if(dataMaps.isEmpty()) {
+        if (dataMaps.isEmpty()) {
             view.showEmptyMessage();
             return;
         }
         boolean generationFail = false;
-        for(DataMap dataMap : dataMaps) {
+        for (DataMap dataMap : dataMaps) {
             try {
-                CgenConfiguration cgenConfiguration = metaData.get(dataMap, CgenConfiguration.class);
-                if(cgenConfiguration == null) {
-                    cgenConfiguration = createConfiguration(dataMap);
+                CgenConfigList cgenConfigList = metaData.get(dataMap, CgenConfigList.class);
+                if (cgenConfigList != null) {
+                    for (CgenConfiguration cgenConfiguration : cgenConfigList.getAll()) {
+                        if (cgenConfiguration == null) {
+                            cgenConfiguration = createConfiguration(dataMap);
+                        }
+                        // should always run here
+                        cgenConfiguration.setForce(true);
+                        ClassGenerationAction classGenerationAction = new ToolsInjectorBuilder()
+                                .addModule(binder
+                                        -> binder.bind(DataChannelMetaData.class).toInstance(metaData))
+                                .create()
+                                .getInstance(ClassGenerationActionFactory.class)
+                                .createAction(cgenConfiguration);
+                        classGenerationAction.prepareArtifacts();
+                        classGenerationAction.execute();
+                    }
                 }
-                // should always run here
-                cgenConfiguration.setForce(true);
-                ClassGenerationAction classGenerationAction = new ToolsInjectorBuilder()
-                        .addModule(binder
-                                -> binder.bind(DataChannelMetaData.class).toInstance(metaData))
-                        .create()
-                        .getInstance(ClassGenerationActionFactory.class)
-                        .createAction(cgenConfiguration);
-                classGenerationAction.prepareArtifacts();
-                classGenerationAction.execute();
             } catch (Exception e) {
                 LOGGER.error("Error generating classes", e);
                 generationFail = true;
-                ((CgenTab)view).showErrorMessage(e.getMessage());
+                ((CgenTab) view).showErrorMessage(e.getMessage());
             }
         }
-        if(!generationFail) {
-            ((CgenTab)view).showSuccessMessage();
+        if (!generationFail) {
+            ((CgenTab) view).showSuccessMessage();
         }
     }
 

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/templateeditor/EditorTemplateSaver.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/templateeditor/EditorTemplateSaver.java
@@ -54,27 +54,27 @@ public class EditorTemplateSaver {
 
         switch (templateType) {
             case ENTITY_SUPERCLASS: {
-                configuration.setSuperTemplate(new CgenTemplate(template, false, TemplateType.ENTITY_SUPERCLASS));
+                configuration.setSuperTemplate(new CgenTemplate(template, isDefault, TemplateType.ENTITY_SUPERCLASS));
                 break;
             }
             case ENTITY_SUBCLASS: {
-                configuration.setTemplate(new CgenTemplate(template, false, TemplateType.ENTITY_SUBCLASS));
+                configuration.setTemplate(new CgenTemplate(template, isDefault, TemplateType.ENTITY_SUBCLASS));
                 break;
             }
             case EMBEDDABLE_SUPERCLASS: {
-                configuration.setEmbeddableSuperTemplate(new CgenTemplate(template, false, TemplateType.EMBEDDABLE_SUPERCLASS));
+                configuration.setEmbeddableSuperTemplate(new CgenTemplate(template, isDefault, TemplateType.EMBEDDABLE_SUPERCLASS));
                 break;
             }
             case EMBEDDABLE_SUBCLASS: {
-                configuration.setEmbeddableTemplate(new CgenTemplate(template, false, TemplateType.EMBEDDABLE_SUBCLASS));
+                configuration.setEmbeddableTemplate(new CgenTemplate(template, isDefault, TemplateType.EMBEDDABLE_SUBCLASS));
                 break;
             }
             case DATAMAP_SUPERCLASS: {
-                configuration.setDataMapSuperTemplate(new CgenTemplate(template, false, TemplateType.DATAMAP_SUPERCLASS));
+                configuration.setDataMapSuperTemplate(new CgenTemplate(template, isDefault, TemplateType.DATAMAP_SUPERCLASS));
                 break;
             }
             case DATAMAP_SUBCLASS: {
-                configuration.setDataMapTemplate(new CgenTemplate(template, false, TemplateType.DATAMAP_SUBCLASS));
+                configuration.setDataMapTemplate(new CgenTemplate(template, isDefault, TemplateType.DATAMAP_SUBCLASS));
                 break;
             }
             default:

--- a/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/templateeditor/TemplateEditorController.java
+++ b/modeler/cayenne-modeler/src/main/java/org/apache/cayenne/modeler/editor/cgen/templateeditor/TemplateEditorController.java
@@ -99,6 +99,7 @@ public class TemplateEditorController extends CayenneController {
 
     private void configureEditorView(TemplateType templateType) {
         this.editorView.getEditingTemplatePane().setText(templateLoader.load(templateType, isTemplateDefault));
+        this.editorView.getEditingTemplatePane().discardAllEdits();
         this.editorView.editingTemplatePane.setCaretPosition(0);
         this.editorView.getSaveButton().setEnabled(isTemplateModified);
         this.editorView.setTitle(templateType.readableName() + " - cayenne template editor");


### PR DESCRIPTION
We can now store multiple configurations to generate classes.

**How it works:**

1. You can add/rename/delete configurations in the class generation panel for the selected data map (select the data map in the left panel, see fig.1).
2. You can start the class generation with the selected configuration in this panel. Other configurations will not be used.
3. In case you need to generate classes for all your datamaps and configurations, you can do it in the project level class generation panel (select the project in the left panel, see fig.3). All configurations will be used for the selected datamaps.
4. Multiple configurations are also available when using Maven/Ant/Gdradle plugins.
5. If you do not need to use multiple configurations, then no extra steps are required. Default configuration will be used for classes generation.

_Fig. 1_
<img width="1348" alt="Screenshot 2022-11-23 at 09 50 56" src="https://user-images.githubusercontent.com/70625960/203519762-582d4885-9302-4367-a1ff-f3a630d0c357.png">

_Fig. 2_
![1](https://user-images.githubusercontent.com/70625960/203519866-b9285180-59e9-483f-a8b3-0cec75e57fb7.png)

_Fig. 3_
<img width="1348" alt="Screenshot 2022-11-23 at 10 59 09" src="https://user-images.githubusercontent.com/70625960/203519965-8d99957d-123f-4351-8e88-268ee3ff700c.png">







