### PR TITLE
CAY-2789 MalformedJsonException thrown when reading manually edited JSON data in Postgres

### DIFF
--- a/cayenne-server/src/main/java/org/apache/cayenne/value/json/JsonTokenizer.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/value/json/JsonTokenizer.java
@@ -52,6 +52,9 @@ final class JsonTokenizer {
         while (position < data.length) {
             // skip whitespace
             skipWhitespace();
+            if (position == data.length) {
+                break;
+            }
             JsonToken token = nextValue();
             // only string could be used as an object member name
             if (states[currentState] == State.OBJECT_MEMBER_NAME) {

--- a/cayenne-server/src/test/java/org/apache/cayenne/value/json/JsonTokenizerTest.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/value/json/JsonTokenizerTest.java
@@ -284,6 +284,24 @@ public class JsonTokenizerTest {
     }
 
     @Test
+    public void testTrailingSpaces() {
+        JsonTokenizer tokenizer;
+        JsonTokenizer.JsonToken token;
+
+        tokenizer = new JsonTokenizer("{\"test\": \"some value\"} \n");
+        token = tokenizer.nextToken();
+        assertEquals(JsonTokenizer.TokenType.OBJECT_START, token.type);
+        token = tokenizer.nextToken();
+        assertEquals(JsonTokenizer.TokenType.STRING, token.type);
+        token = tokenizer.nextToken();
+        assertEquals(JsonTokenizer.TokenType.STRING, token.type);
+        token = tokenizer.nextToken();
+        assertEquals(JsonTokenizer.TokenType.OBJECT_END, token.type);
+        token = tokenizer.nextToken();
+        assertEquals(JsonTokenizer.TokenType.NONE, token.type);
+    }
+
+    @Test
     public void testEmptyArray() {
         JsonTokenizer tokenizer = new JsonTokenizer("[]");
         JsonTokenizer.JsonToken token1 = tokenizer.nextToken();

--- a/cayenne-server/src/test/java/org/apache/cayenne/value/json/JsonTokenizerTest.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/value/json/JsonTokenizerTest.java
@@ -29,6 +29,16 @@ import static org.junit.Assert.assertEquals;
 public class JsonTokenizerTest {
 
     @Test
+    public void testEmpty() {
+        JsonTokenizer tokenizer;
+        JsonTokenizer.JsonToken token;
+
+        tokenizer = new JsonTokenizer("");
+        token = tokenizer.nextToken();
+        assertEquals(JsonTokenizer.TokenType.NONE, token.type);
+    }
+
+    @Test
     public void testNull() {
         JsonTokenizer tokenizer;
         JsonTokenizer.JsonToken token;


### PR DESCRIPTION
Fixed JsonTokenizer throwing MalformedJsonException because of trailing whitespace characters.