### PR TITLE
CAY-2794 Fix Incorrect JavaType for Vertical-Inheritance Attributes

### DIFF
--- a/cayenne-server/src/test/java/org/apache/cayenne/access/VerticalInheritanceIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/access/VerticalInheritanceIT.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -641,6 +642,7 @@ public class VerticalInheritanceIT extends ServerCase {
 
 		IvImpl impl = context.newObject(IvImpl.class);
 		impl.setName("Impl 1");
+		impl.setAttr0(new Date());
 		impl.setAttr1("attr1");
 		impl.setAttr2("attr2");
 		impl.setOther1(other1);

--- a/cayenne-server/src/test/java/org/apache/cayenne/testdo/inheritance_vertical/auto/_IvImpl.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/testdo/inheritance_vertical/auto/_IvImpl.java
@@ -3,7 +3,9 @@ package org.apache.cayenne.testdo.inheritance_vertical.auto;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.Date;
 
+import org.apache.cayenne.exp.property.DateProperty;
 import org.apache.cayenne.exp.property.EntityProperty;
 import org.apache.cayenne.exp.property.PropertyFactory;
 import org.apache.cayenne.exp.property.StringProperty;
@@ -22,16 +24,28 @@ public abstract class _IvImpl extends IvBase {
 
     public static final String ID_PK_COLUMN = "ID";
 
+    public static final DateProperty<Date> ATTR0 = PropertyFactory.createDate("attr0", Date.class);
     public static final StringProperty<String> ATTR1 = PropertyFactory.createString("attr1", String.class);
     public static final StringProperty<String> ATTR2 = PropertyFactory.createString("attr2", String.class);
     public static final EntityProperty<IvOther> OTHER1 = PropertyFactory.createEntity("other1", IvOther.class);
     public static final EntityProperty<IvOther> OTHER2 = PropertyFactory.createEntity("other2", IvOther.class);
 
+    protected Date attr0;
     protected String attr1;
     protected String attr2;
 
     protected Object other1;
     protected Object other2;
+
+    public void setAttr0(Date attr0) {
+        beforePropertyWrite("attr0", this.attr0, attr0);
+        this.attr0 = attr0;
+    }
+
+    public Date getAttr0() {
+        beforePropertyRead("attr0");
+        return this.attr0;
+    }
 
     public void setAttr1(String attr1) {
         beforePropertyWrite("attr1", this.attr1, attr1);
@@ -76,6 +90,8 @@ public abstract class _IvImpl extends IvBase {
         }
 
         switch(propName) {
+            case "attr0":
+                return this.attr0;
             case "attr1":
                 return this.attr1;
             case "attr2":
@@ -96,6 +112,9 @@ public abstract class _IvImpl extends IvBase {
         }
 
         switch (propName) {
+            case "attr0":
+                this.attr0 = (Date)val;
+                break;
             case "attr1":
                 this.attr1 = (String)val;
                 break;
@@ -124,6 +143,7 @@ public abstract class _IvImpl extends IvBase {
     @Override
     protected void writeState(ObjectOutputStream out) throws IOException {
         super.writeState(out);
+        out.writeObject(this.attr0);
         out.writeObject(this.attr1);
         out.writeObject(this.attr2);
         out.writeObject(this.other1);
@@ -133,6 +153,7 @@ public abstract class _IvImpl extends IvBase {
     @Override
     protected void readState(ObjectInputStream in) throws IOException, ClassNotFoundException {
         super.readState(in);
+        this.attr0 = (Date)in.readObject();
         this.attr1 = (String)in.readObject();
         this.attr2 = (String)in.readObject();
         this.other1 = in.readObject();

--- a/cayenne-server/src/test/resources/inheritance-vertical.map.xml
+++ b/cayenne-server/src/test/resources/inheritance-vertical.map.xml
@@ -53,6 +53,7 @@
 		<db-attribute name="SUB1_NAME" type="VARCHAR" length="100"/>
 	</db-entity>
 	<db-entity name="IV_IMPL">
+		<db-attribute name="ATTR0" type="DATE"/>
 		<db-attribute name="ATTR1" type="VARCHAR" length="100"/>
 		<db-attribute name="ATTR2" type="VARCHAR" length="100"/>
 		<db-attribute name="ID" type="INTEGER" isPrimaryKey="true" isMandatory="true"/>
@@ -133,6 +134,7 @@
 	</obj-entity>
 	<obj-entity name="IvImpl" superEntityName="IvBase" className="org.apache.cayenne.testdo.inheritance_vertical.IvImpl">
 		<qualifier><![CDATA[type = "I"]]></qualifier>
+		<obj-attribute name="attr0" type="java.util.Date" db-attribute-path="impl.ATTR0"/>
 		<obj-attribute name="attr1" type="java.lang.String" db-attribute-path="impl.ATTR1"/>
 		<obj-attribute name="attr2" type="java.lang.String" db-attribute-path="impl.ATTR2"/>
 	</obj-entity>


### PR DESCRIPTION
Breaking test for [CAY-2794](https://issues.apache.org/jira/browse/CAY-2794)

All I had to do was add a Date attribute to `IvImpl`, and one of the existing tests failed. But I did go ahead and set that attribute to a Date value, just so someone doesn't decide to remove that attribute in the future.

Still looking for a solution.