### PR TITLE
DB2 cannot build relationships-flattened test project

### DIFF
--- a/cayenne-server/src/test/resources/relationships-flattened.map.xml
+++ b/cayenne-server/src/test/resources/relationships-flattened.map.xml
@@ -19,11 +19,11 @@
 		<db-attribute name="ID" type="INTEGER" isPrimaryKey="true" isMandatory="true"/>
 	</db-entity>
 	<db-entity name="ENTITY2">
-		<db-attribute name="ENTITY1_ID" type="INTEGER"/>
+		<db-attribute name="ENTITY1_ID" type="INTEGER" isMandatory="true"/>
 		<db-attribute name="ID" type="INTEGER" isPrimaryKey="true" isMandatory="true"/>
 	</db-entity>
 	<db-entity name="ENTITY3">
-		<db-attribute name="ENTITY2_ID" type="INTEGER"/>
+		<db-attribute name="ENTITY2_ID" type="INTEGER" isMandatory="true"/>
 		<db-attribute name="ID" type="INTEGER" isPrimaryKey="true" isMandatory="true"/>
 	</db-entity>
 	<db-entity name="FLATTENED_CIRCULAR">


### PR DESCRIPTION
Running tests for DB2 fails with [DB2 -542 error](https://www.sqlerror.de/db2_sql_error_-542_sqlstate_42831.html). The reason is nullable db-attributes which are included in unique index because of 1-to-1 relationship. Making them not null is the simplest solution.