### PR TITLE
CAY-2807 entity property disambiguate method parameters

### DIFF
--- a/cayenne-server/src/main/java/org/apache/cayenne/exp/property/CollectionProperty.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/exp/property/CollectionProperty.java
@@ -114,8 +114,9 @@ public abstract class CollectionProperty<V extends Persistent, E extends Collect
     }
 
     /**
-     * @return An expression for finding objects with given id set
+     ** @deprecated in favor of {@link #idsIn(Object...)}
      */
+    @Deprecated(since = "5.0")
     public Expression containsId(Object firstId, Object... moreId) {
 
         int moreValuesLength = moreId != null ? moreId.length : 0;
@@ -131,9 +132,25 @@ public abstract class CollectionProperty<V extends Persistent, E extends Collect
     }
 
     /**
-     * @return An expression for finding objects with given id set.
+     * @return An expression for finding objects with given id set
+     * @since 5.0
      */
+    public Expression idsIn(Object... ids) {return ExpressionFactory.inExp(getExpression(), ids);
+    }
+
+    /**
+     ** @deprecated in favor of {@link #idsInCollection(Collection)}
+     */
+    @Deprecated(since = "5.0")
     public Expression containsId(Collection<Object> ids) {
+        return ExpressionFactory.inExp(getExpression(), ids);
+    }
+
+    /**
+     * @return An expression for finding objects with given id set.
+     * @since 5.0
+     */
+    public Expression idsInCollection(Collection<?> ids) {
         return ExpressionFactory.inExp(getExpression(), ids);
     }
 
@@ -146,8 +163,9 @@ public abstract class CollectionProperty<V extends Persistent, E extends Collect
     }
 
     /**
-     * @return An expression for finding objects without given id set.
+     ** @deprecated in favor of {@link #idsNotIn(Object...)}
      */
+    @Deprecated(since = "5.0")
     public Expression notContainsId(Object firstId, Object... moreId) {
 
         int moreValuesLength = moreId != null ? moreId.length : 0;
@@ -164,8 +182,24 @@ public abstract class CollectionProperty<V extends Persistent, E extends Collect
 
     /**
      * @return An expression for finding objects without given id set.
+     * @since 5.0
      */
+    public Expression idsNotIn(Object... ids) {return ExpressionFactory.notInExp(getExpression(), ids);
+    }
+
+    /**
+     ** @deprecated in favor of {@link #idsNotInCollection(Collection)}
+     */
+    @Deprecated(since = "5.0")
     public Expression notContainsId(Collection<Object> ids) {
+        return ExpressionFactory.notInExp(getExpression(), ids);
+    }
+
+    /**
+     * @return An expression for finding objects without given id set.
+     * @since 5.0
+     */
+    public Expression idsNotInCollection(Collection<?> ids) {
         return ExpressionFactory.notInExp(getExpression(), ids);
     }
 

--- a/cayenne-server/src/main/java/org/apache/cayenne/exp/property/EntityProperty.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/exp/property/EntityProperty.java
@@ -22,6 +22,7 @@ package org.apache.cayenne.exp.property;
 import java.util.Collection;
 
 import org.apache.cayenne.Persistent;
+import org.apache.cayenne.di.Binder;
 import org.apache.cayenne.exp.Expression;
 import org.apache.cayenne.exp.ExpressionFactory;
 import org.apache.cayenne.exp.parser.ASTPath;
@@ -60,10 +61,18 @@ public class EntityProperty<E extends Persistent> extends BaseProperty<E> implem
         return ExpressionFactory.matchExp(getExpression(), id);
     }
 
+    /**
+     ** @deprecated in favor of {@link #idsInCollection(Collection)}
+     */
+    @Deprecated (since = "5.0")
     public Expression inId(Collection<Object> ids) {
         return ExpressionFactory.inExp(getExpression(), ids);
     }
 
+    /**
+     ** @deprecated in favor of {@link #idsIn(Object...)}
+     */
+    @Deprecated (since = "5.0")
     public Expression inId(Object firstId, Object... moreIds) {
         Object[] ids = new Object[moreIds.length + 1];
         ids[0] = firstId;
@@ -71,20 +80,58 @@ public class EntityProperty<E extends Persistent> extends BaseProperty<E> implem
         return ExpressionFactory.inExp(getExpression(), ids);
     }
 
+    /**
+     * @since 5.0
+     */
+    public Expression idsInCollection(Collection<?> ids){
+        return ExpressionFactory.inExp(getExpression(), ids);
+    }
+
+    /**
+     * @since 5.0
+     */
+    public Expression idsIn(Object... ids){
+        return ExpressionFactory.inExp(getExpression(), ids);
+    }
+
     public Expression neqId(Object id) {
         return ExpressionFactory.noMatchExp(getExpression(), id);
     }
 
+    /**
+     ** @deprecated in favor of {@link #idsNotInCollection(Collection)}
+     */
+    @Deprecated (since = "5.0")
     public Expression ninId(Collection<Object> ids) {
         return ExpressionFactory.notInExp(getExpression(), ids);
     }
 
+    /**
+     ** @deprecated in favor of {@link #idsNotIn(Object...)}
+     */
+    @Deprecated (since = "5.0")
     public Expression ninId(Object firstId, Object... moreIds) {
         Object[] ids = new Object[moreIds.length + 1];
         ids[0] = firstId;
         System.arraycopy(moreIds, 0, ids, 1, moreIds.length);
         return ExpressionFactory.notInExp(getExpression(), ids);
     }
+
+    /**
+     * @since 5.0
+     */
+    public Expression idsNotInCollection(Collection<?> ids){
+        return ExpressionFactory.notInExp(getExpression(), ids);
+    }
+
+    /**
+     * @since 5.0
+     */
+    public Expression idsNotIn(Object... ids){
+        return ExpressionFactory.notInExp(getExpression(), ids);
+    }
+
+
 
 
     /**

--- a/cayenne-server/src/main/java/org/apache/cayenne/exp/property/MapProperty.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/exp/property/MapProperty.java
@@ -145,8 +145,9 @@ public class MapProperty<K, V extends Persistent> extends BaseProperty<Map<K, V>
     }
 
     /**
-     * @return An expression for finding objects with given id set
+     ** @deprecated in favor of {@link #idsIn(Object...)}
      */
+    @Deprecated(since = "5.0")
     public Expression containsId(Object firstId, Object... moreId) {
 
         int moreValuesLength = moreId != null ? moreId.length : 0;
@@ -162,9 +163,25 @@ public class MapProperty<K, V extends Persistent> extends BaseProperty<Map<K, V>
     }
 
     /**
-     * @return An expression for finding objects with given id set.
+     * @return An expression for finding objects with given id set
+     * @since 5.0
      */
+    public Expression idsIn(Object... ids) {return ExpressionFactory.inExp(getExpression(), ids);
+    }
+
+    /**
+     ** @deprecated in favor of {@link #idsInCollection(Collection)}
+     */
+    @Deprecated(since = "5.0")
     public Expression containsId(Collection<Object> ids) {
+        return ExpressionFactory.inExp(getExpression(), ids);
+    }
+
+    /**
+     * @return An expression for finding objects with given id set.
+     * @since 5.0
+     */
+    public Expression idsInCollection(Collection<?> ids) {
         return ExpressionFactory.inExp(getExpression(), ids);
     }
 
@@ -177,8 +194,9 @@ public class MapProperty<K, V extends Persistent> extends BaseProperty<Map<K, V>
     }
 
     /**
-     * @return An expression for finding objects without given id set.
+     ** @deprecated in favor of {@link #idsNotIn(Object...)}
      */
+    @Deprecated(since = "5.0")
     public Expression notContainsId(Object firstId, Object... moreId) {
 
         int moreValuesLength = moreId != null ? moreId.length : 0;
@@ -195,8 +213,24 @@ public class MapProperty<K, V extends Persistent> extends BaseProperty<Map<K, V>
 
     /**
      * @return An expression for finding objects without given id set.
+     * @since 5.0
      */
+    public Expression idsNotIn(Object... ids) {return ExpressionFactory.notInExp(getExpression(), ids);
+    }
+
+    /**
+     ** @deprecated in favor of {@link #idsNotInCollection(Collection)}
+     */
+    @Deprecated(since = "5.0")
     public Expression notContainsId(Collection<Object> ids) {
+        return ExpressionFactory.notInExp(getExpression(), ids);
+    }
+
+    /**
+     * @return An expression for finding objects without given id set.
+     * @since 5.0
+     */
+    public Expression idsNotInCollection(Collection<?> ids) {
         return ExpressionFactory.notInExp(getExpression(), ids);
     }
 

--- a/cayenne-server/src/test/java/org/apache/cayenne/exp/property/EntityPropertyTest.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/exp/property/EntityPropertyTest.java
@@ -99,6 +99,18 @@ public class EntityPropertyTest {
     }
 
     @Test
+    public void idsInCollection() {
+        Expression exp = property.idsInCollection(Arrays.asList(1, 2, 3));
+        assertEquals(ExpressionFactory.exp("path in (1, 2, 3)"), exp);
+    }
+
+    @Test
+    public void idsInVararg() {
+        Expression exp = property.idsIn(1, 2, 3);
+        assertEquals(ExpressionFactory.exp("path in (1, 2, 3)"), exp);
+    }
+
+    @Test
     public void neqId() {
         Expression exp = property.neqId(1);
         assertEquals(ExpressionFactory.exp("path <> 1"), exp);
@@ -113,6 +125,18 @@ public class EntityPropertyTest {
     @Test
     public void ninIdVararg() {
         Expression exp = property.ninId(1, 2, 3);
+        assertEquals(ExpressionFactory.exp("path not in (1, 2, 3)"), exp);
+    }
+
+    @Test
+    public void idsNotInCollection() {
+        Expression exp = property.idsNotInCollection(Arrays.asList(1, 2, 3));
+        assertEquals(ExpressionFactory.exp("path not in (1, 2, 3)"), exp);
+    }
+
+    @Test
+    public void idsNotInVararg() {
+        Expression exp = property.idsNotIn(1, 2, 3);
         assertEquals(ExpressionFactory.exp("path not in (1, 2, 3)"), exp);
     }
 }

--- a/cayenne-server/src/test/java/org/apache/cayenne/exp/property/ListPropertyTest.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/exp/property/ListPropertyTest.java
@@ -90,6 +90,30 @@ public class ListPropertyTest {
     }
 
     @Test
+    public void idsInVararg() {
+        Expression exp = property.idsIn(1, 2, 3);
+        assertEquals(ExpressionFactory.exp("path in (1, 2, 3)"), exp);
+    }
+
+    @Test
+    public void idsInCollection() {
+        Expression exp = property.idsInCollection(Arrays.asList(1, 2, 3));
+        assertEquals(ExpressionFactory.exp("path in (1, 2, 3)"), exp);
+    }
+
+    @Test
+    public void idsNotInVararg() {
+        Expression exp = property.idsNotIn(1, 2, 3);
+        assertEquals(ExpressionFactory.exp("path not in (1, 2, 3)"), exp);
+    }
+
+    @Test
+    public void idsNotInCollection() {
+        Expression exp = property.idsNotInCollection(Arrays.asList(1, 2, 3));
+        assertEquals(ExpressionFactory.exp("path not in (1, 2, 3)"), exp);
+    }
+
+    @Test
     public void notContainsOne() {
         Artist artist = new Artist();
         Expression exp = property.notContains(artist);

--- a/cayenne-server/src/test/java/org/apache/cayenne/exp/property/MapPropertyTest.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/exp/property/MapPropertyTest.java
@@ -108,6 +108,30 @@ public class MapPropertyTest {
     }
 
     @Test
+    public void idsInVararg() {
+        Expression exp = property.idsIn(1, 2, 3);
+        assertEquals(ExpressionFactory.exp("path in (1,2,3)"), exp);
+    }
+
+    @Test
+    public void idsInCollection() {
+        Expression exp = property.idsInCollection(Arrays.asList(1, 2, 3));
+        assertEquals(ExpressionFactory.exp("path in (1,2,3)"), exp);
+    }
+
+    @Test
+    public void idsNotInVararg() {
+        Expression exp = property.idsNotIn(1, 2, 3);
+        assertEquals(ExpressionFactory.exp("path not in (1,2,3)"), exp);
+    }
+
+    @Test
+    public void idsNotInCollection() {
+        Expression exp = property.idsNotInCollection(Arrays.asList(1, 2, 3));
+        assertEquals(ExpressionFactory.exp("path not in (1,2,3)"), exp);
+    }
+
+    @Test
     public void containsManyIdCollection() {
         Expression exp = property.containsId(Arrays.asList(1, 2, 3));
         assertEquals(ExpressionFactory.exp("path in (1,2,3)"), exp);


### PR DESCRIPTION
API redesign in EntityProperty, CollectionProperty, MapProperty

**Deprecated this methods:** 

Expression inId(Collection<Object> ids)
Expression inId(Object firstId, Object... moreIds)

Expression ninId(Collection<Object> ids)
Expression ninId(Object firstId, Object... moreIds)

**in favor of this:**

Expression idsInCollection(Collection<?> ids)
Expression idsIn(Object... ids)

Expression idsNotInCollection(Collection<?> ids)
Expression idsNotIn(Object... ids)
