### PR TITLE
CAY-2847 Improve duplicate select column detection when using order by

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -102,5 +102,6 @@ CAY-2840 Vertical Inheritance: Missing subclass attributes with joint prefetch
 CAY-2841 Multi column ColumnSelect with SHARED_CACHE fails after 1st select
 CAY-2844 Joint prefetch doesn't use ObjEntity qualifier
 CAY-2842 Prevent duplicate select columns when using distinct with order by
+CAY-2847 Improve duplicate select column detection when using order by
 CAY-2850 Query using Clob comparison with empty String fails
 CAY-2851 Replace Existing OneToOne From New Object

--- a/cayenne/src/test/java/org/apache/cayenne/access/translator/select/OrderingStageTest.java
+++ b/cayenne/src/test/java/org/apache/cayenne/access/translator/select/OrderingStageTest.java
@@ -115,7 +115,7 @@ public class OrderingStageTest {
         ColumnExtractorStage columnStage = new ColumnExtractorStage();
         columnStage.perform(context);
 
-        OrderingStage orderingStage = new OrderingStage();
+        OrderingDistictStage orderingStage = new OrderingDistictStage();
         orderingStage.perform(context);
 
         assertTrue(context.getQuery().isDistinct());


### PR DESCRIPTION
The current implementation has three problems:

1. It fails when a column has an alias
2. It builds the whole SQL column string before comparing
3. It doesn't seem very robust in preventing false results

This PR replaces the current implementation with a visitor pattern that fails fast.
The visitor extracts each node's parts into a List which is progressively compared to the parts extracted from the order node.
Each item must match in position and content in both lists for them to match and will abort comparing as soon as possible.
