### PR TITLE
CAY-2851 Replace Existing OneToOne From New Object

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -26,6 +26,7 @@ CAY-2838 Vertical Inheritance: Problem setting db attribute to null via flattene
 CAY-2840 Vertical Inheritance: Missing subclass attributes with joint prefetch
 CAY-2841 Multi column ColumnSelect with SHARED_CACHE fails after 1st select
 CAY-2844 Joint prefetch doesn't use ObjEntity qualifier
+CAY-2851 Replace Existing OneToOne From New Object
 
 ----------------------------------
 Release: 4.2

--- a/cayenne-commitlog/src/test/java/org/apache/cayenne/commitlog/CommitLogFilterIT.java
+++ b/cayenne-commitlog/src/test/java/org/apache/cayenne/commitlog/CommitLogFilterIT.java
@@ -243,7 +243,23 @@ public class CommitLogFilterIT extends AuditableServerCase {
         verify(mockListener).onPostCommit(any(ObjectContext.class), changeMap.capture());
 
         assertNotNull(changeMap.getValue());
-        assertEquals(4, changeMap.getValue().getUniqueChanges().size());
+        assertEquals(5, changeMap.getValue().getUniqueChanges().size());
+
+        ObjectChange a1c = changeMap.getValue().getChanges().get(
+            ObjectId.of("Auditable1", Auditable1.ID_PK_COLUMN, 1));
+        assertNotNull(a1c);
+        assertEquals(ObjectChangeType.UPDATE, a1c.getType());
+        ToManyRelationshipChange a1c1 = a1c.getToManyRelationshipChanges().get(Auditable1.CHILDREN1.getName());
+        assertEquals(2, a1c1.getAdded().size());
+        assertEquals(1, a1c1.getRemoved().size());
+
+        ObjectChange a2c = changeMap.getValue().getChanges().get(
+            ObjectId.of("Auditable1", Auditable1.ID_PK_COLUMN, 2));
+        assertNotNull(a2c);
+        assertEquals(ObjectChangeType.UPDATE, a2c.getType());
+        ToManyRelationshipChange a2c1 = a2c.getToManyRelationshipChanges().get(Auditable1.CHILDREN1.getName());
+        assertEquals(0, a2c1.getAdded().size());
+        assertEquals(1, a2c1.getRemoved().size());
 
         ObjectChange ac1c = changeMap.getValue().getChanges().get(
                 ObjectId.of("AuditableChild1", AuditableChild1.ID_PK_COLUMN, 1));

--- a/cayenne-server/src/main/java/org/apache/cayenne/BaseDataObject.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/BaseDataObject.java
@@ -428,6 +428,10 @@ public abstract class BaseDataObject extends PersistentObject implements DataObj
                 .getRelationship(relName);
         ObjRelationship revRel = rel.getReverseRelationship();
         if (revRel != null) {
+            Object oldTarget = val.readProperty(revRel.getName());
+            if (oldTarget != val && oldTarget instanceof DataObject && val instanceof BaseDataObject) {
+                ((BaseDataObject)val).unsetReverseRelationship(revRel.getName(), (DataObject) oldTarget);
+            }
             if (revRel.isToMany()) {
                 val.addToManyTarget(revRel.getName(), this, false);
             } else {

--- a/cayenne-server/src/test/java/org/apache/cayenne/CDOOne2ManyIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/CDOOne2ManyIT.java
@@ -41,6 +41,7 @@ import java.util.Date;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
@@ -292,5 +293,49 @@ public class CDOOne2ManyIT extends ServerCase {
         // save
         // test "assertion" is that commit succeeds (PK of ae1 was set properly)
         context.commitChanges();
+    }
+
+    @Test
+    public void testReplace() {
+
+        Painting p1 = context.newObject(Painting.class);
+        p1.setPaintingTitle("xa");
+
+        Gallery g1 = context.newObject(Gallery.class);
+        g1.setGalleryName("yTW");
+
+        p1.setToGallery(g1);
+
+        context.commitChanges();
+        ObjectContext context2 = runtime.newContext();
+
+        // test database data
+        Painting p2 = ObjectSelect.query(Painting.class).selectOne(context2);
+        Gallery g21 = p2.getToGallery();
+        assertNotNull(g21);
+        assertEquals("yTW", g21.getGalleryName());
+        assertEquals(1, g21.getPaintingArray().size());
+        assertSame(p2, g21.getPaintingArray().get(0));
+
+        Gallery g22 = context2.newObject(Gallery.class);
+        g22.setGalleryName("rE");
+        g22.addToPaintingArray(p2);
+
+        // test before save
+        assertEquals(0, g21.getPaintingArray().size());
+        assertEquals(1, g22.getPaintingArray().size());
+        assertSame(p2, g22.getPaintingArray().get(0));
+
+        // do save II
+        context2.commitChanges();
+
+        ObjectContext context3 = runtime.newContext();
+
+        Painting p3 = ObjectSelect.query(Painting.class).selectOne(context3);
+        Gallery g3 = p3.getToGallery();
+        assertNotNull(g3);
+        assertEquals("rE", g3.getGalleryName());
+        assertEquals(1, g3.getPaintingArray().size());
+        assertSame(p3, g3.getPaintingArray().get(0));
     }
 }

--- a/cayenne-server/src/test/java/org/apache/cayenne/CDOOneDep2OneIT.java
+++ b/cayenne-server/src/test/java/org/apache/cayenne/CDOOneDep2OneIT.java
@@ -144,4 +144,57 @@ public class CDOOneDep2OneIT extends CayenneDOTestBase {
         assertEquals(pi2oid, pi3.getObjectId());
 
     }
+
+    @Test
+    public void testReplaceOtherSide() throws Exception {
+        String altPaintingName = "alt painting";
+
+        PaintingInfo pi1 = newPaintingInfo();
+        Painting p1 = newPainting();
+        p1.setPaintingTitle(altPaintingName);
+
+        pi1.setPainting(p1);
+
+        assertTrue(context.hasChanges());
+
+        // do save
+        context.commitChanges();
+        context = context1;
+
+        // test database data
+        PaintingInfo pi2 = fetchPaintingInfo();
+        Painting p21 = pi2.getPainting();
+        assertNotNull(p21);
+        assertEquals(altPaintingName, p21.getPaintingTitle());
+        assertSame(pi2, p21.getToPaintingInfo());
+        ByteArrayTypeTest.assertByteArraysEqual(paintingImage, p21
+                .getToPaintingInfo()
+                .getImageBlob());
+
+        Painting p22 = newPainting();
+
+        // *** TESTING THIS ***
+        p22.setToPaintingInfo(pi2);
+
+        // test before save
+        assertNull(p21.getToPaintingInfo());
+        assertSame(pi2, p22.getToPaintingInfo());
+        assertSame(p22, pi2.getPainting());
+        assertEquals(PersistenceState.MODIFIED, pi2.getPersistenceState());
+
+        // do save II
+        context.commitChanges();
+        ObjectId pi2oid = pi2.getObjectId();
+        context = context1;
+
+        PaintingInfo pi3 = fetchPaintingInfo();
+        Painting p3 = pi3.getPainting();
+        assertNotNull(p3);
+        assertEquals(paintingName, p3.getPaintingTitle());
+        assertSame(pi3, p3.getToPaintingInfo());
+
+        // test that object id was updated.
+        assertEquals(pi2oid, pi3.getObjectId());
+
+    }
 }


### PR DESCRIPTION
breaking tests and fix for [CAY-2851](https://issues.apache.org/jira/browse/CAY-2851)

also updated the test in `CommitLogFilterIT.testPostCommit_UpdateToOne` to account for the actual changes