### PR TITLE
CAY-2853 Incorrect deletion of entities from flattened attributes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -103,3 +103,4 @@ CAY-2841 Multi column ColumnSelect with SHARED_CACHE fails after 1st select
 CAY-2844 Joint prefetch doesn't use ObjEntity qualifier
 CAY-2850 Query using Clob comparison with empty String fails
 CAY-2851 Replace Existing OneToOne From New Object
+CAY-2853 Incorrect deletion of entities from flattened attributes

--- a/cayenne/src/main/java/org/apache/cayenne/access/ObjectStore.java
+++ b/cayenne/src/main/java/org/apache/cayenne/access/ObjectStore.java
@@ -1012,6 +1012,18 @@ public class ObjectStore implements Serializable, SnapshotEventListener, GraphMa
     }
 
     /**
+     * @since 5.0
+     */
+    public Map<CayennePath,ObjectId> getFlattenedPathIdMap(ObjectId objectId) {
+        if(trackedFlattenedPaths == null) {
+            return Collections.emptyMap();
+        }
+
+        return trackedFlattenedPaths
+                .getOrDefault(objectId, Collections.emptyMap());
+    }
+
+    /**
      * Mark that flattened path for object has data row in DB.
      * @since 4.1
      */


### PR DESCRIPTION
When deleting an ObjEntity with flattened attributes Cayenne deletes the related DB attribute's row as well.
 
So if we have for example an ObjEntity "FlatPainting" with flattened attribute "galleryName". If we then delete a "FlatPainting" then the associated gallery will also be deleted, leaving all other paintings at that gallery without a valid Gallery link.
 
Furthermore if we add to our "FlatPainting" a "gallery" relationship attribute with delete rule Deny, the gallery was still being deleted.

The original intention was for something like a "PaintingFull" ObjEntity having all painting attributes and a flattened attribute to "PaintingInfo" as well, where the relationship is 1:1. In this case it makes sense that deleting a "PaintingFull" should also delete its associated PaintingInfo record.

In this PR a check has been added so that reverse toMany relationships are protected from deletion,
and if a relevant ObjRelationship is present then deletions are deferred to it instead.