### PR TITLE
CAY-2854 Improve delete prevention detection of flattened attribute row

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -105,3 +105,4 @@ CAY-2842 Prevent duplicate select columns when using distinct with order by
 CAY-2850 Query using Clob comparison with empty String fails
 CAY-2851 Replace Existing OneToOne From New Object
 CAY-2853 Incorrect deletion of entities from flattened attributes
+CAY-2854 Improve delete prevention detection of flattened attribute row

--- a/cayenne/src/main/java/org/apache/cayenne/access/ObjectResolver.java
+++ b/cayenne/src/main/java/org/apache/cayenne/access/ObjectResolver.java
@@ -30,6 +30,7 @@ import org.apache.cayenne.map.DbAttribute;
 import org.apache.cayenne.map.DbEntity;
 import org.apache.cayenne.map.EntityResolver;
 import org.apache.cayenne.map.ObjEntity;
+import org.apache.cayenne.reflect.AdditionalDbEntityDescriptor;
 import org.apache.cayenne.reflect.ClassDescriptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -182,8 +183,8 @@ class ObjectResolver {
 	        return;
         }
 
-	    for(Map.Entry<CayennePath, DbEntity> entry : classDescriptor.getAdditionalDbEntities().entrySet()) {
-            DbEntity dbEntity = entry.getValue();
+	    for(Map.Entry<CayennePath, AdditionalDbEntityDescriptor> entry : classDescriptor.getAdditionalDbEntities().entrySet()) {
+            DbEntity dbEntity = entry.getValue().getDbEntity();
             CayennePath path = entry.getKey();
             CayennePath prefix = path.length() == 1 ? path : path.tail(path.length() - 1);
             ObjectId objectId = createObjectId(row, "db:" + dbEntity.getName(), dbEntity.getPrimaryKeys(), prefix, false);

--- a/cayenne/src/main/java/org/apache/cayenne/access/ObjectStore.java
+++ b/cayenne/src/main/java/org/apache/cayenne/access/ObjectStore.java
@@ -979,7 +979,7 @@ public class ObjectStore implements Serializable, SnapshotEventListener, GraphMa
      * Check that flattened path for given object ID has data row in DB.
      * @since 4.1
      */
-    boolean hasFlattenedPath(ObjectId objectId, String path) {
+    boolean hasFlattenedPath(ObjectId objectId, CayennePath path) {
         if(trackedFlattenedPaths == null) {
             return false;
         }

--- a/cayenne/src/main/java/org/apache/cayenne/reflect/AdditionalDbEntityDescriptor.java
+++ b/cayenne/src/main/java/org/apache/cayenne/reflect/AdditionalDbEntityDescriptor.java
@@ -1,0 +1,29 @@
+package org.apache.cayenne.reflect;
+
+import org.apache.cayenne.exp.path.CayennePath;
+import org.apache.cayenne.map.DbEntity;
+
+public class AdditionalDbEntityDescriptor
+{
+    private CayennePath path;
+    private DbEntity entity;
+    private boolean noDelete;
+
+    AdditionalDbEntityDescriptor(CayennePath path, DbEntity entity, boolean noDelete) {
+        this.noDelete = noDelete;
+        this.entity = entity;
+        this.path = path;
+    }
+
+    public DbEntity getDbEntity() {
+        return entity;
+    }
+
+    public CayennePath getPath() {
+        return path;
+    }
+
+    public boolean noDelete() {
+        return noDelete;
+    }
+}

--- a/cayenne/src/main/java/org/apache/cayenne/reflect/ClassDescriptor.java
+++ b/cayenne/src/main/java/org/apache/cayenne/reflect/ClassDescriptor.java
@@ -58,11 +58,11 @@ public interface ClassDescriptor {
      * <p>
      * Keys are full paths for corresponding flattened attributes.
      * <p>
-     *
-     * @since 4.1
+     * 
+     * @since 5.0
      * @return information about additional db entities
      */
-    Map<CayennePath, DbEntity> getAdditionalDbEntities();
+    Map<CayennePath, AdditionalDbEntityDescriptor> getAdditionalDbEntities();
 
     /**
      * @since 3.0

--- a/cayenne/src/main/java/org/apache/cayenne/reflect/LazyClassDescriptorDecorator.java
+++ b/cayenne/src/main/java/org/apache/cayenne/reflect/LazyClassDescriptorDecorator.java
@@ -91,7 +91,7 @@ public class LazyClassDescriptorDecorator implements ClassDescriptor {
     }
 
     @Override
-    public Map<CayennePath, DbEntity> getAdditionalDbEntities() {
+    public Map<CayennePath, AdditionalDbEntityDescriptor> getAdditionalDbEntities() {
         checkDescriptorInitialized();
         return descriptor.getAdditionalDbEntities();
     }

--- a/cayenne/src/main/java/org/apache/cayenne/reflect/PersistentDescriptor.java
+++ b/cayenne/src/main/java/org/apache/cayenne/reflect/PersistentDescriptor.java
@@ -62,7 +62,7 @@ public class PersistentDescriptor implements ClassDescriptor {
 
 	protected ObjEntity entity;
 	protected Collection<DbEntity> rootDbEntities;
-	protected Map<CayennePath, DbEntity> additionalDbEntities;
+	protected Map<CayennePath, AdditionalDbEntityDescriptor> additionalDbEntities;
 
 	protected EntityInheritanceTree entityInheritanceTree;
 
@@ -128,12 +128,12 @@ public class PersistentDescriptor implements ClassDescriptor {
 	 * @param path path for entity
 	 * @param targetEntity additional entity
 	 */
-	void addAdditionalDbEntity(CayennePath path, DbEntity targetEntity) {
+	void addAdditionalDbEntity(CayennePath path, DbEntity targetEntity, boolean noDelete) {
 		if(additionalDbEntities == null) {
 			additionalDbEntities = new HashMap<>();
 		}
 
-		additionalDbEntities.put(path, targetEntity);
+		additionalDbEntities.put(path, new AdditionalDbEntityDescriptor(path, targetEntity, noDelete));
 	}
 
 	void sortProperties() {
@@ -232,7 +232,7 @@ public class PersistentDescriptor implements ClassDescriptor {
 	}
 
 	@Override
-	public Map<CayennePath, DbEntity> getAdditionalDbEntities() {
+	public Map<CayennePath, AdditionalDbEntityDescriptor> getAdditionalDbEntities() {
 		if(additionalDbEntities == null) {
 			return Collections.emptyMap();
 		}


### PR DESCRIPTION
Weather a flattened attribute row should/should not be deleted is currently detected each time during each delete query construction (see [PR 614](https://github.com/apache/cayenne/pull/614)).

In order to optimize the above repetitive process this PR moves the detection code into `PersistentDescriptorFactory` and sets a marker in `CayennePath` if needed to prevent the deletion of flattened attribute rows.