### PR TITLE
CAY-2597 `case-when` implementation

### DIFF
--- a/cayenne/src/main/java/org/apache/cayenne/access/translator/select/QualifierTranslator.java
+++ b/cayenne/src/main/java/org/apache/cayenne/access/translator/select/QualifierTranslator.java
@@ -247,6 +247,15 @@ class QualifierTranslator implements TraversalHandler {
                     objectNode(scalarVal, null);
                 }
                 return null;
+
+            case CASE_WHEN:
+                return new CaseNode();
+            case WHEN:
+                return new WhenNode();
+            case THEN:
+                return new ThenNode();
+            case ELSE:
+                return new ElseNode();
         }
         return null;
     }
@@ -388,7 +397,7 @@ class QualifierTranslator implements TraversalHandler {
             case BITWISE_AND: case BITWISE_LEFT_SHIFT: case BITWISE_OR: case BITWISE_RIGHT_SHIFT: case BITWISE_XOR:
             case OR: case AND: case LESS_THAN: case LESS_THAN_EQUAL_TO: case GREATER_THAN: case GREATER_THAN_EQUAL_TO:
             case TRUE: case FALSE: case ASTERISK: case EXISTS: case NOT_EXISTS: case SUBQUERY: case ENCLOSING_OBJECT: case FULL_OBJECT:
-            case SCALAR:
+            case SCALAR: case CASE_WHEN: case WHEN: case THEN: case ELSE:
                 return true;
         }
         return false;

--- a/cayenne/src/main/java/org/apache/cayenne/dba/hsqldb/HSQLTreeProcessor.java
+++ b/cayenne/src/main/java/org/apache/cayenne/dba/hsqldb/HSQLTreeProcessor.java
@@ -20,9 +20,12 @@
 package org.apache.cayenne.dba.hsqldb;
 
 import org.apache.cayenne.access.sqlbuilder.sqltree.ColumnNode;
+import org.apache.cayenne.access.sqlbuilder.sqltree.ElseNode;
 import org.apache.cayenne.access.sqlbuilder.sqltree.FunctionNode;
 import org.apache.cayenne.access.sqlbuilder.sqltree.Node;
 import org.apache.cayenne.access.sqlbuilder.sqltree.OpExpressionNode;
+import org.apache.cayenne.access.sqlbuilder.sqltree.ThenNode;
+import org.apache.cayenne.access.sqlbuilder.sqltree.ValueNode;
 import org.apache.cayenne.access.translator.select.BaseSQLTreeProcessor;
 import org.apache.cayenne.access.sqlbuilder.sqltree.TrimmingColumnNode;
 
@@ -30,6 +33,12 @@ import org.apache.cayenne.access.sqlbuilder.sqltree.TrimmingColumnNode;
  * @since 4.2
  */
 public class HSQLTreeProcessor extends BaseSQLTreeProcessor {
+
+    @Override
+    protected void onValueNode(Node parent, ValueNode child, int index) {
+        boolean needBinding = !(parent instanceof ThenNode || parent instanceof ElseNode);
+        replaceChild(parent, index, new ValueNode(child.getValue(), child.isArray(), child.getAttribute(), needBinding));
+    }
 
     @Override
     protected void onColumnNode(Node parent, ColumnNode child, int index) {

--- a/cayenne/src/main/java/org/apache/cayenne/exp/Expression.java
+++ b/cayenne/src/main/java/org/apache/cayenne/exp/Expression.java
@@ -209,6 +209,26 @@ public abstract class Expression implements Serializable, XMLSerializable {
 	 */
 	public static final int SCALAR = 56;
 
+	/**
+	 * @since 5.0
+	 */
+	public static final int CASE_WHEN = 57;
+
+	/**
+	 * @since 5.0
+	 */
+	public static final int WHEN = 58;
+
+	/**
+	 * @since 5.0
+	 */
+	public static final int THEN = 59;
+
+	/**
+	 * @since 5.0
+	 */
+	public static final int ELSE = 60;
+
 	protected int type = -1;
 
 	/**

--- a/cayenne/src/main/java/org/apache/cayenne/exp/ExpressionFactory.java
+++ b/cayenne/src/main/java/org/apache/cayenne/exp/ExpressionFactory.java
@@ -31,9 +31,11 @@ import org.apache.cayenne.exp.parser.ASTBitwiseNot;
 import org.apache.cayenne.exp.parser.ASTBitwiseOr;
 import org.apache.cayenne.exp.parser.ASTBitwiseRightShift;
 import org.apache.cayenne.exp.parser.ASTBitwiseXor;
+import org.apache.cayenne.exp.parser.ASTCaseWhen;
 import org.apache.cayenne.exp.parser.ASTDbIdPath;
 import org.apache.cayenne.exp.parser.ASTDbPath;
 import org.apache.cayenne.exp.parser.ASTDivide;
+import org.apache.cayenne.exp.parser.ASTElse;
 import org.apache.cayenne.exp.parser.ASTEnclosingObject;
 import org.apache.cayenne.exp.parser.ASTEqual;
 import org.apache.cayenne.exp.parser.ASTExists;
@@ -62,7 +64,9 @@ import org.apache.cayenne.exp.parser.ASTPath;
 import org.apache.cayenne.exp.parser.ASTScalar;
 import org.apache.cayenne.exp.parser.ASTSubquery;
 import org.apache.cayenne.exp.parser.ASTSubtract;
+import org.apache.cayenne.exp.parser.ASTThen;
 import org.apache.cayenne.exp.parser.ASTTrue;
+import org.apache.cayenne.exp.parser.ASTWhen;
 import org.apache.cayenne.exp.parser.ExpressionParser;
 import org.apache.cayenne.exp.parser.ExpressionParserTokenManager;
 import org.apache.cayenne.exp.parser.JavaCharStream;
@@ -1524,5 +1528,32 @@ public class ExpressionFactory {
 	 */
 	public static Expression any(ColumnSelect<?> subquery) {
 		return new ASTAny(new ASTSubquery(subquery));
+	}
+
+	/**
+	 * @since 5.0
+	 */
+	public static Expression caseWhen(List<Expression> whenExp, List<Expression> thenExp) {
+		return caseWhen(whenExp, thenExp, null);
+	}
+
+	/**
+	 * @since 5.0
+	 */
+	public static Expression caseWhen(List<Expression> whenExp, List<Expression> thenExp, Expression caseDefault) {
+		if (whenExp.size() != thenExp.size()) {
+			throw new ExpressionException("Each member in the \"When\"-\"Then\" pairs must be defined");
+		}
+		List<Expression> expressions = new ArrayList<>();
+		for (int i = 0; i < whenExp.size(); i++) {
+			expressions.add(new ASTWhen(whenExp.get(i)));
+			expressions.add(new ASTThen(thenExp.get(i)));
+		}
+		boolean hasDefault = false;
+		if (caseDefault != null) {
+			expressions.add(new ASTElse(caseDefault));
+			hasDefault = true;
+		}
+		return new ASTCaseWhen(hasDefault, expressions.toArray(new Expression[0]));
 	}
 }

--- a/cayenne/src/main/java/org/apache/cayenne/exp/parser/ASTCaseWhen.java
+++ b/cayenne/src/main/java/org/apache/cayenne/exp/parser/ASTCaseWhen.java
@@ -1,0 +1,91 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.exp.parser;
+
+import org.apache.cayenne.exp.Expression;
+import org.apache.cayenne.util.ConversionUtil;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * "CASE-WHEN" expression root node.
+ *
+ * @see org.apache.cayenne.exp.ExpressionFactory#caseWhen(List, List, Expression)
+ * @since 5.0
+ */
+public class ASTCaseWhen extends SimpleNode {
+
+    private boolean hasDefault;
+
+    public ASTCaseWhen(boolean hasDefault, Expression... nodes) {
+        super(0);
+        for (int i = 0; i < nodes.length; i++) {
+            jjtAddChild((Node) nodes[i], i);
+        }
+        connectChildren();
+        this.hasDefault = hasDefault;
+    }
+
+    public ASTCaseWhen(int id) {
+        super(id);
+    }
+
+    /**
+     * Creates a copy of this expression node, without copying children.
+     */
+    @Override
+    public Expression shallowCopy() {
+        return new ASTCaseWhen(id);
+    }
+
+    @Override
+    protected String getExpressionOperator(int index) {
+        return "case";
+    }
+
+    @Override
+    protected Object evaluateNode(Object o) throws Exception {
+        int numChildren = jjtGetNumChildren();
+        if (numChildren == 0) {
+            return null;
+        }
+        for (int i = 0; i < numChildren - 1; i = i + 2) {
+            Object evaluatedWhen = evaluateChild(i, o);
+            if (ConversionUtil.toBoolean(evaluatedWhen)) {
+                return evaluateChild(i + 1, o);
+            }
+        }
+        if (hasDefault) {
+            return evaluateChild(numChildren - 1, o);
+        }
+        return null;
+    }
+
+    @Override
+    public int getType() {
+        return Expression.CASE_WHEN;
+    }
+
+    @Override
+    public void appendAsEJBQL(List<Object> parameterAccumulator, Appendable out, String rootId) throws IOException {
+        throw new UnsupportedOperationException("EJBQL 'case when' is not supported");
+    }
+}

--- a/cayenne/src/main/java/org/apache/cayenne/exp/parser/ASTElse.java
+++ b/cayenne/src/main/java/org/apache/cayenne/exp/parser/ASTElse.java
@@ -17,27 +17,55 @@
  *  under the License.
  ****************************************************************/
 
-package org.apache.cayenne.access.sqlbuilder.sqltree;
+package org.apache.cayenne.exp.parser;
 
-import org.apache.cayenne.access.sqlbuilder.QuotingAppendable;
+import org.apache.cayenne.exp.Expression;
+
+import java.io.IOException;
+import java.util.List;
 
 /**
+ * "ELSE" part of the case-when expression.
+ *
  * @since 5.0
  */
-public class CaseNode extends Node {
+public class ASTElse extends SimpleNode {
 
-    @Override
-    public QuotingAppendable append(QuotingAppendable buffer) {
-        return buffer.append(" CASE");
+    public ASTElse(Object node) {
+        super(0);
+        jjtAddChild((Node) node, 0);
+        connectChildren();
+    }
+
+
+    public ASTElse(int id) {
+        super(id);
     }
 
     @Override
-    public Node copy() {
-        return new CaseNode();
+    public Expression shallowCopy() {
+        return new ASTElse(id);
     }
 
     @Override
-    public void appendChildrenEnd(QuotingAppendable buffer) {
-            buffer.append(" END");
+    protected String getExpressionOperator(int index) {
+        return "else";
     }
+
+    @Override
+    protected Object evaluateNode(Object o) throws Exception {
+        return evaluateChild(0, o);
+    }
+
+    @Override
+    public int getType() {
+        return Expression.ELSE;
+    }
+
+    @Override
+    public void appendAsEJBQL(List<Object> parameterAccumulator, Appendable out, String rootId) throws IOException {
+        throw new UnsupportedOperationException("EJBQL 'else' is not supported");
+    }
+
+
 }

--- a/cayenne/src/main/java/org/apache/cayenne/exp/parser/ASTThen.java
+++ b/cayenne/src/main/java/org/apache/cayenne/exp/parser/ASTThen.java
@@ -17,27 +17,57 @@
  *  under the License.
  ****************************************************************/
 
-package org.apache.cayenne.access.sqlbuilder.sqltree;
+package org.apache.cayenne.exp.parser;
 
-import org.apache.cayenne.access.sqlbuilder.QuotingAppendable;
+import org.apache.cayenne.exp.Expression;
+
+import java.io.IOException;
+import java.util.List;
 
 /**
+ * "THEN" part of the case-when expression.
+ *
  * @since 5.0
  */
-public class CaseNode extends Node {
+public class ASTThen extends SimpleNode {
 
+    public ASTThen(Object node) {
+        super(0);
+        jjtAddChild((Node) node, 0);
+        connectChildren();
+    }
+
+    public ASTThen(int id) {
+        super(id);
+    }
+
+    /**
+     * Creates a copy of this expression node, without copying children.
+     */
     @Override
-    public QuotingAppendable append(QuotingAppendable buffer) {
-        return buffer.append(" CASE");
+    public Expression shallowCopy() {
+        return new ASTThen(id);
     }
 
     @Override
-    public Node copy() {
-        return new CaseNode();
+    protected String getExpressionOperator(int index) {
+        return "then";
     }
 
     @Override
-    public void appendChildrenEnd(QuotingAppendable buffer) {
-            buffer.append(" END");
+    protected Object evaluateNode(Object o) throws Exception {
+        return evaluateChild(0, o);
     }
+
+    @Override
+    public int getType() {
+        return Expression.THEN;
+    }
+
+    @Override
+    public void appendAsEJBQL(List<Object> parameterAccumulator, Appendable out, String rootId) throws IOException {
+        throw new UnsupportedOperationException("EJBQL 'then' is not supported");
+    }
+
+
 }

--- a/cayenne/src/main/java/org/apache/cayenne/exp/parser/ASTWhen.java
+++ b/cayenne/src/main/java/org/apache/cayenne/exp/parser/ASTWhen.java
@@ -1,0 +1,85 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.exp.parser;
+
+import org.apache.cayenne.exp.Expression;
+import org.apache.cayenne.exp.ExpressionException;
+import org.apache.cayenne.util.ConversionUtil;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * "WHEN" part of the case-when expression.
+ *
+ * @since 5.0
+ */
+public class ASTWhen extends AggregateConditionNode {
+
+    public ASTWhen(Expression condition) {
+        super(0);
+        jjtAddChild((Node) condition, 0);
+        connectChildren();
+    }
+
+    public ASTWhen(int id) {
+        super(id);
+    }
+
+    @Override
+    public Expression shallowCopy() {
+        return new ASTWhen(id);
+    }
+
+    @Override
+    protected String getExpressionOperator(int index) {
+        return "when";
+    }
+
+    @Override
+    protected Object evaluateNode(Object o) throws Exception {
+        if (jjtGetNumChildren() == 0) {
+            return Boolean.FALSE;
+        }
+        Object value = evaluateChild(0, o);
+        if (ConversionUtil.toBoolean(value)) {
+            return Boolean.TRUE;
+        }
+        return Boolean.FALSE;
+    }
+
+    @Override
+    public int getType() {
+        return Expression.WHEN;
+    }
+
+    @Override
+    public void jjtSetParent(Node n) {
+        if (!(n instanceof ASTCaseWhen)) {
+            throw new ExpressionException(expName() + ": invalid parent");
+        }
+        parent = n;
+    }
+
+    @Override
+    public void appendAsEJBQL(List<Object> parameterAccumulator, Appendable out, String rootId) throws IOException {
+        throw new UnsupportedOperationException("EJBQL 'when' is not supported");
+    }
+}

--- a/cayenne/src/main/java/org/apache/cayenne/exp/parser/AggregateConditionNode.java
+++ b/cayenne/src/main/java/org/apache/cayenne/exp/parser/AggregateConditionNode.java
@@ -57,7 +57,7 @@ public abstract class AggregateConditionNode extends SimpleNode {
 		// no children or a single child
 		switch (condition.getOperandCount()) {
 		case 1:
-			if (condition instanceof ASTNot) {
+			if (condition instanceof ASTNot || condition instanceof ASTWhen) {
 				return condition;
 			} else {
 				return condition.getOperand(0);

--- a/cayenne/src/test/java/org/apache/cayenne/exp/CaseWhenIT.java
+++ b/cayenne/src/test/java/org/apache/cayenne/exp/CaseWhenIT.java
@@ -1,0 +1,85 @@
+/*****************************************************************
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ ****************************************************************/
+
+package org.apache.cayenne.exp;
+
+import org.apache.cayenne.ObjectContext;
+import org.apache.cayenne.di.Inject;
+import org.apache.cayenne.exp.property.PropertyFactory;
+import org.apache.cayenne.exp.property.StringProperty;
+import org.apache.cayenne.query.ObjectSelect;
+import org.apache.cayenne.test.jdbc.DBHelper;
+import org.apache.cayenne.test.jdbc.TableHelper;
+import org.apache.cayenne.testdo.testmap.Painting;
+import org.apache.cayenne.unit.di.runtime.CayenneProjects;
+import org.apache.cayenne.unit.di.runtime.RuntimeCase;
+import org.apache.cayenne.unit.di.runtime.UseCayenneRuntime;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.apache.cayenne.exp.ExpressionFactory.betweenExp;
+import static org.apache.cayenne.exp.ExpressionFactory.caseWhen;
+import static org.apache.cayenne.exp.ExpressionFactory.wrapScalarValue;
+
+@UseCayenneRuntime(CayenneProjects.TESTMAP_PROJECT)
+public class CaseWhenIT extends RuntimeCase {
+
+    @Inject
+    private ObjectContext context;
+
+    @Inject
+    protected DBHelper dbHelper;
+
+    @Before
+    public void setUp() throws Exception {
+        new TableHelper(dbHelper, "PAINTING")
+                .setColumns("PAINTING_ID", "PAINTING_TITLE", "PAINTING_DESCRIPTION", "ESTIMATED_PRICE")
+                .insert(1, "Black square", "Oil on linen, 79.5 x 79.5 cm", 15);
+    }
+
+    @Test
+    public void caseWhenExpressionFactoryTest() {
+        Expression caseWhenNoDefault = caseWhen(
+                List.of((betweenExp("estimatedPrice", 0, 9)),
+                        (betweenExp("estimatedPrice", 10, 20))),
+                List.of((wrapScalarValue("firstThenResult")),
+                        (wrapScalarValue("secondThenResult"))));
+
+        StringProperty<String> propertyNoDefault = PropertyFactory.createString(caseWhenNoDefault, String.class);
+        String result = ObjectSelect.columnQuery(Painting.class, propertyNoDefault).selectFirst(context);
+        Assert.assertEquals("secondThenResult", result);
+    }
+
+    @Test
+    public void caseWhenDefaultExpressionFactoryTest() {
+        Expression caseWhenNoDefault = caseWhen(
+                List.of(betweenExp("estimatedPrice", 0, 14)),
+                List.of((wrapScalarValue("firstThenResult"))),
+                wrapScalarValue("defaultResult"));
+
+        StringProperty<String> propertyNoDefault = PropertyFactory.createString(caseWhenNoDefault, String.class);
+        String result = ObjectSelect.columnQuery(Painting.class, propertyNoDefault).selectFirst(context);
+        Assert.assertEquals("defaultResult", result.trim());
+
+    }
+
+}

--- a/cayenne/src/test/java/org/apache/cayenne/exp/ExpressionTest.java
+++ b/cayenne/src/test/java/org/apache/cayenne/exp/ExpressionTest.java
@@ -18,6 +18,9 @@
  ****************************************************************/
 package org.apache.cayenne.exp;
 
+import static org.apache.cayenne.exp.ExpressionFactory.betweenExp;
+import static org.apache.cayenne.exp.ExpressionFactory.caseWhen;
+import static org.apache.cayenne.exp.ExpressionFactory.pathExp;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -463,5 +466,21 @@ public class ExpressionTest {
 		StringBuilder buffer = new StringBuilder();
 		exp.appendAsString(buffer);
 		assertEquals("db:year.month.day.avg", buffer.toString());
+	}
+
+	@Test(expected = ExpressionException.class)
+	public void invalidQueryCaseWhenExpressionFactoryTest() {
+		caseWhen(
+				List.of((betweenExp("estimatedPrice", 0, 9)),
+						(betweenExp("estimatedPrice", 10, 20))),
+				List.of((pathExp("paintingDescription"))));
+	}
+
+	@Test (expected = UnsupportedOperationException.class)
+	public void testAppendAsEJBQLCaseWhen() throws IOException {
+		Expression caseWhen = ExpressionFactory.caseWhen(
+				List.of(ExpressionFactory.betweenExp("x",1,2)),
+				List.of(ExpressionFactory.pathExp("x")));
+		caseWhen.appendAsEJBQL(null, null, "x");
 	}
 }


### PR DESCRIPTION
PR brings support for the `CASE-WHEN` SQL operator to the Cayenne expression API.

Usage example (from the test):
```java
Expression caseWhen = ExpressionFactory.caseWhen(
                List.of(Artist.PAINTING_ARRAY.dot(Painting.ESTIMATED_PRICE).between(BigDecimal.ZERO, BigDecimal.valueOf(50)),
                        Artist.PAINTING_ARRAY.dot(Painting.ESTIMATED_PRICE).between(BigDecimal.valueOf(51), BigDecimal.valueOf(100))),
                List.of(Artist.ARTIST_NAME.getExpression(),
                        Artist.DATE_OF_BIRTH.getExpression()));
```

This PR supersedes  #593