### PR TITLE
CAY-2876 Memory leak in the ObjectStore

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -22,6 +22,7 @@ Bug Fixes:
 CAY-2866 DefaultDataDomainFlushAction breaks on circular relationship update
 CAY-2868 Regression: DefaultDbRowOpSorter shouldn't sort update operations
 CAY-2871 QualifierTranslator breaks on a relationship with a compound FK
+CAY-2876 Memory leak in the ObjectStore
 CAY-2879 Negative number for non parameterized ObjectSelect query not processed correctly
 
 ----------------------------------

--- a/cayenne-server/src/main/java/org/apache/cayenne/access/ObjectStore.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/access/ObjectStore.java
@@ -427,6 +427,9 @@ public class ObjectStore implements Serializable, SnapshotEventListener, GraphMa
             switch (object.getPersistenceState()) {
                 case PersistenceState.DELETED:
                     objectMap.remove(id);
+                    if(trackedFlattenedPaths != null) {
+                        trackedFlattenedPaths.remove(id);
+                    }
                     object.setObjectContext(null);
                     object.setPersistenceState(PersistenceState.TRANSIENT);
                     break;
@@ -651,9 +654,11 @@ public class ObjectStore implements Serializable, SnapshotEventListener, GraphMa
                     if (dataObject == null || delegate.shouldProcessDelete(dataObject)) {
                         objectMap.remove(nodeId);
                         changes.remove(nodeId);
+                        if(trackedFlattenedPaths != null) {
+                            trackedFlattenedPaths.remove(nodeId);
+                        }
 
-                        // setting DataContext to null will also set
-                        // state to transient
+                        // setting DataContext to null will also set state to transient
                         object.setObjectContext(null);
 
                         if (dataObject != null) {


### PR DESCRIPTION
Another approach to the CAY-2876

This PR introduces cleanup callback in the `ReferenceMap` keeping flattened paths as is in the `ObjectStore` and dropping them in sync with the main object map. This is a less reliable fix then before, but it guarantees that there will be no problems with the object store data consistency.

In 5.0 we could experiment a bit more and try something more robust.