### PR TITLE
CAY-2996 Move source and javadoc jar generation to a release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -983,7 +983,7 @@
                 </plugins>
             </build>
         </profile>
-        <!-- Optional profiles used to build and sign artifacts -->
+        <!-- Optional profile for building and signing release artifacts -->
         <profile>
             <id>release</id>
             <build>
@@ -1012,13 +1012,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>gpg</id>
-            <build>
-                <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -862,18 +862,6 @@
 
         <plugins>
             <plugin>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>bundle-source-jar</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>
@@ -995,7 +983,38 @@
                 </plugins>
             </build>
         </profile>
-        <!-- Optional profile used to sign artifacts -->
+        <!-- Optional profiles used to build and sign artifacts -->
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>bundle-source-jar</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>bundle-javadoc-jar</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>gpg</id>
             <build>


### PR DESCRIPTION
## What does this PR do?

Moves source and Javadoc JAR generation into a dedicated `release` Maven profile.

Normal Maven builds now produce only the main and test artifacts. When the `release` profile is enabled, Maven also attaches `-sources.jar` and `-javadoc.jar` for publication.

Previously, source JAR generation was enabled for every Maven build, while Javadoc JAR generation was not configured as part of the Maven release artifact lifecycle.

After the change, the release guide at https://cayenne.apache.org/dev/release-guide.html should use the `release` profile:

```diff
 cd cayenne
 mvn release:clean
 mvn release:prepare -DpreparationGoals="clean install" -DautoVersionSubmodules=true
-mvn release:perform -P gpg [-Dgpg.keyname=B8AF90BF]
+mvn release:perform -P release [-Dgpg.keyname=B8AF90BF]
```

## Testing

Verified that:

```bash
mvn clean install -DskipTests
```

does not generate or install source or Javadoc JARs.

Verified that:

```bash
mvn clean install -Prelease -DskipTests
```

generates and installs:

```text
*-sources.jar
*-javadoc.jar
```